### PR TITLE
Render question errors in TextQuestionRenderer

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -25,7 +25,7 @@ public class ApplicantQuestion {
   private final QuestionDefinition questionDefinition;
   private final ApplicantData applicantData;
 
-  ApplicantQuestion(QuestionDefinition questionDefinition, ApplicantData applicantData) {
+  public ApplicantQuestion(QuestionDefinition questionDefinition, ApplicantData applicantData) {
     this.questionDefinition = checkNotNull(questionDefinition);
     this.applicantData = checkNotNull(applicantData);
   }
@@ -268,6 +268,10 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
+      if (!hasValue()) {
+        return ImmutableSet.of();
+      }
+
       TextQuestionDefinition definition = getQuestionDefinition();
       int textLength = getTextValue().map(s -> s.length()).orElse(0);
       ImmutableSet.Builder<ValidationErrorMessage> errors =

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -26,6 +26,7 @@ public class TextQuestionRenderer extends BaseHtmlView implements ApplicantQuest
         input()
             .withType("text")
             .withCondValue(textQuestion.hasValue(), textQuestion.getTextValue().orElse(""))
-            .withName(textQuestion.getTextPath().path()));
+            .withName(textQuestion.getTextPath().path()),
+        fieldErrors(textQuestion.getQuestionErrors()));
   }
 }

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -14,7 +14,7 @@ import services.applicant.ApplicantQuestion;
 import services.question.TextQuestionDefinition;
 
 public class TextQuestionRendererTest extends WithPostgresContainer {
-  private static final TextQuestionDefinition textQuestionDefinition =
+  private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
       new TextQuestionDefinition(
           1L,
           "question name",
@@ -29,7 +29,7 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
 
   @Before
   public void setUp() {
-    ApplicantQuestion question = new ApplicantQuestion(textQuestionDefinition, applicantData);
+    ApplicantQuestion question = new ApplicantQuestion(TEXT_QUESTION_DEFINITION, applicantData);
     renderer = new TextQuestionRenderer(question);
   }
 
@@ -42,8 +42,8 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
 
   @Test
   public void render_withMinLengthError() {
-    textQuestionDefinition.setMinLength(1);
-    applicantData.putString(textQuestionDefinition.getTextPath(), "");
+    TEXT_QUESTION_DEFINITION.setMinLength(1);
+    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "");
 
     Tag result = renderer.render();
 
@@ -52,8 +52,8 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
 
   @Test
   public void render_withMaxLengthError() {
-    textQuestionDefinition.setMaxLength(3);
-    applicantData.putString(textQuestionDefinition.getTextPath(), "abcd");
+    TEXT_QUESTION_DEFINITION.setMaxLength(3);
+    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "abcd");
 
     Tag result = renderer.render();
 

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -1,0 +1,62 @@
+package views.questiontypes;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import j2html.tags.Tag;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import repository.WithPostgresContainer;
+import services.Path;
+import services.applicant.ApplicantData;
+import services.applicant.ApplicantQuestion;
+import services.question.TextQuestionDefinition;
+
+public class TextQuestionRendererTest extends WithPostgresContainer {
+  private static final TextQuestionDefinition textQuestionDefinition =
+      new TextQuestionDefinition(
+          1L,
+          "question name",
+          Path.create("applicant.my.path"),
+          "description",
+          ImmutableMap.of(Locale.ENGLISH, "question?"),
+          ImmutableMap.of(Locale.ENGLISH, "help text"));
+
+  private final ApplicantData applicantData = new ApplicantData();
+
+  private TextQuestionRenderer renderer;
+
+  @Before
+  public void setUp() {
+    ApplicantQuestion question = new ApplicantQuestion(textQuestionDefinition, applicantData);
+    renderer = new TextQuestionRenderer(question);
+  }
+
+  @Test
+  public void render_withoutQuestionErrors() {
+    Tag result = renderer.render();
+
+    assertThat(result.render()).doesNotContain("This answer must be");
+  }
+
+  @Test
+  public void render_withMinLengthError() {
+    textQuestionDefinition.setMinLength(1);
+    applicantData.putString(textQuestionDefinition.getTextPath(), "");
+
+    Tag result = renderer.render();
+
+    assertThat(result.render()).contains("This answer must be at least 1 characters long.");
+  }
+
+  @Test
+  public void render_withMaxLengthError() {
+    textQuestionDefinition.setMaxLength(3);
+    applicantData.putString(textQuestionDefinition.getTextPath(), "abcd");
+
+    Tag result = renderer.render();
+
+    assertThat(result.render()).contains("This answer must be at most 3 characters long.");
+  }
+}


### PR DESCRIPTION
### Description
Also fix a bug in `TextQuestion#getQuestionErrors`: if the value isn't present, should return empty set of errors.

Add tests.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #390 
