### PR TITLE
Rename support.Questions to support.TestQuestionBank 

### DIFF
--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -20,7 +20,7 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.WithPostgresContainer;
 import support.ProgramBuilder;
-import support.Questions;
+import support.TestQuestionBank;
 
 public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer {
 
@@ -32,7 +32,10 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
   public void setUp() {
     subject = instanceOf(ApplicantProgramBlocksController.class);
     program =
-        ProgramBuilder.newProgram().withBlock().withQuestion(Questions.applicantName()).build();
+        ProgramBuilder.newProgram()
+            .withBlock()
+            .withQuestion(TestQuestionBank.applicantName())
+            .build();
     applicant = resourceCreator().insertApplicant();
   }
 
@@ -151,9 +154,9 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
     program =
         ProgramBuilder.newProgram()
             .withBlock("block 1")
-            .withQuestion(Questions.applicantName())
+            .withQuestion(TestQuestionBank.applicantName())
             .withBlock("block 2")
-            .withQuestion(Questions.applicantAddress())
+            .withQuestion(TestQuestionBank.applicantAddress())
             .build();
     Request request =
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, 1L))
@@ -176,7 +179,7 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
     program =
         ProgramBuilder.newProgram()
             .withBlock("block 1")
-            .withQuestion(Questions.applicantName())
+            .withQuestion(TestQuestionBank.applicantName())
             .build();
 
     Request request =

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -15,9 +15,9 @@ import org.junit.BeforeClass;
 import play.Application;
 import play.db.ebean.EbeanConfig;
 import play.test.Helpers;
-import support.Questions;
 import support.ResourceCreator;
 import support.TestConstants;
+import support.TestQuestionBank;
 
 public class WithPostgresContainer {
 
@@ -64,6 +64,6 @@ public class WithPostgresContainer {
 
   @Before
   public void resetSupportQuestionsCache() {
-    Questions.reset();
+    TestQuestionBank.reset();
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -14,11 +14,16 @@ import services.question.TextQuestionDefinition;
 /**
  * A cached {@link Question} bank for testing.
  *
+ * <p>The {@link Question}s in this question bank should be treated as constants, but they need to
+ * be persisted in the database for some tests so they are persisted and cached. The properties of
+ * these questions (e.g. question path) are not canonical and may not be representative of the
+ * properties defined by CiviForm administrators.
+ *
  * <p>To add a new {@link Question} to the question bank: create a {@link QuestionEnum} for it,
  * create a private static method to construct the question, and create a public static method to
  * retrieve the cached question.
  */
-public class Questions {
+public class TestQuestionBank {
   private static final long VERSION = 1L;
 
   private enum QuestionEnum {
@@ -34,17 +39,18 @@ public class Questions {
   }
 
   public static Question applicantName() {
-    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_NAME, Questions::applicantName);
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
   }
 
   public static Question applicantAddress() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_ADDRESS, Questions::applicantAddress);
+        QuestionEnum.APPLICANT_ADDRESS, TestQuestionBank::applicantAddress);
   }
 
   public static Question applicantFavoriteColor() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_FAVORITE_COLOR, Questions::applicantFavoriteColor);
+        QuestionEnum.APPLICANT_FAVORITE_COLOR, TestQuestionBank::applicantFavoriteColor);
   }
 
   private static Question applicantName(QuestionEnum ignore) {


### PR DESCRIPTION
Rename and add to docstring describing that the questions here may not be completely representative of questions defined by CiviForm administrators.
