### PR TITLE
Update PR template so `Fixed` works properly

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ Please explain the changes you made here.
 - [ ] Extended the README / documentation, if necessary
 
 ### Issue(s)
-[Fixes] #<issue_number>
+Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...


### PR DESCRIPTION
I noticed that this template used to put `[Fixed]` in brackets, so if anyone kept the template, their PR wouldn't actually close the issue in question. The `Fixed` has to be freed from brackets for this to work. Thus, updating the template.
