### PR TITLE
Prevent path conflict on prefix

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -55,8 +55,8 @@ public class QuestionRepository {
     }
 
     static boolean pathConflicts(String path, String otherPath) {
-      path = path.toLowerCase();
-      otherPath = otherPath.toLowerCase();
+      path = path.toLowerCase() + ".";
+      otherPath = otherPath.toLowerCase() + ".";
       return path.startsWith(otherPath) || otherPath.startsWith(path);
     }
   }

--- a/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
@@ -77,6 +77,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
     assertThat(pathConflicts(path, "other.applicant.address")).isFalse();
     assertThat(pathConflicts(path, "other.applicant.address.street")).isFalse();
     assertThat(pathConflicts(path, "other.applicant.address.some.other.field")).isFalse();
+    assertThat(pathConflicts(path, "applicant.addressSome")).isFalse();
   }
 
   private boolean pathConflicts(String path, String otherPath) {


### PR DESCRIPTION
### Description
Appended delimiter to distinguish paths by key names

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #476 
