### PR TITLE
Store applications in the database as a snapshot, display the ID of the snapshot

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -160,11 +160,10 @@ public final class ApplicantProgramBlocksController extends Controller {
 
     // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Redirect to
     //  review page when it is available.
-    CompletionStage<Result> reviewPageRedirect = previewPageRedirect(applicantId, programId);
     Optional<Long> nextBlockIdMaybe =
         roApplicantProgramService.getBlockAfter(blockId).map(Block::getId);
     return nextBlockIdMaybe.isEmpty()
-        ? reviewPageRedirect
+        ? previewPageRedirect(applicantId, programId)
         : supplyAsync(
             () ->
                 redirect(

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
@@ -1,6 +1,7 @@
 package controllers.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
@@ -8,6 +9,7 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
+import play.mvc.Call;
 import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
@@ -41,12 +43,14 @@ public class ApplicantProgramsController extends Controller {
   }
 
   public CompletionStage<Result> index(Request request, long applicantId) {
+    Optional<String> banner = request.flash().get("banner");
     return programService
         .listProgramDefinitionsAsync()
         .thenApplyAsync(
             programs -> {
               return ok(
-                  programIndexView.render(messagesApi.preferred(request), applicantId, programs));
+                  programIndexView.render(
+                      messagesApi.preferred(request), applicantId, programs, banner));
             },
             httpContext.current());
   }
@@ -59,16 +63,21 @@ public class ApplicantProgramsController extends Controller {
         .getReadOnlyApplicantProgramService(applicantId, programId)
         .thenApplyAsync(
             roApplicantService -> {
-              Optional<Block> block = roApplicantService.getFirstIncompleteBlock();
-              if (block.isPresent()) {
-                return found(
-                    routes.ApplicantProgramBlocksController.edit(
-                        applicantId, programId, block.get().getId()));
-              } else {
-                // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): All
-                // blocks are filled in, so redirect to end of program submission.
-                return found(routes.ApplicantProgramsController.index(applicantId));
+              Optional<Block> blockMaybe = roApplicantService.getFirstIncompleteBlock();
+              return blockMaybe.flatMap(
+                  block ->
+                      Optional.of(
+                          found(
+                              routes.ApplicantProgramBlocksController.edit(
+                                  applicantId, programId, block.getId()))));
+            },
+            httpContext.current())
+        .thenComposeAsync(
+            resultMaybe -> {
+              if (resultMaybe.isEmpty()) {
+                return previewPageRedirect(applicantId);
               }
+              return supplyAsync(resultMaybe::get);
             },
             httpContext.current())
         .exceptionally(
@@ -82,5 +91,16 @@ public class ApplicantProgramsController extends Controller {
               }
               throw new RuntimeException(ex);
             });
+  }
+
+  private CompletionStage<Result> previewPageRedirect(long applicantId) {
+    // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Replace
+    // with a redirect to the review page.
+    // For now, this just redirects to program index page.
+    Call endOfProgramSubmission = routes.ApplicantProgramsController.index(applicantId);
+    return supplyAsync(
+        () ->
+            found(endOfProgramSubmission)
+                .flashing("banner", String.format("Application was already completed.")));
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -1,9 +1,12 @@
 package models;
 
+import com.google.common.collect.ImmutableList;
 import io.ebean.annotation.DbJson;
+import java.util.List;
 import java.util.Locale;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -21,6 +24,9 @@ public class Applicant extends BaseModel {
 
   @Constraints.Required @DbJson private String object;
   @ManyToOne private Account account;
+
+  @OneToMany(mappedBy = "applicant")
+  private List<Application> applications;
 
   public Applicant() {
     super();
@@ -62,5 +68,9 @@ public class Applicant extends BaseModel {
 
   public void setAccount(Account account) {
     this.account = account;
+  }
+
+  public ImmutableList<Application> getApplications() {
+    return ImmutableList.copyOf(this.applications);
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -1,10 +1,15 @@
 package models;
 
 import io.ebean.annotation.DbJson;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
+import services.Path;
+import services.applicant.ApplicantData;
 
 @Entity
 @Table(name = "applications")
@@ -19,9 +24,11 @@ public class Application extends BaseModel {
   @DbJson
   private String object;
 
-  public Application(Applicant applicant, Program program) {
+  public Application(Applicant applicant, Program program, Instant submitTime) {
     this.applicant = applicant;
-    this.object = applicant.getApplicantData().asJsonString();
+    ApplicantData data = applicant.getApplicantData();
+    data.putString(Path.create("metadata.submitted_time"), submitTime.toString());
+    this.object = data.asJsonString();
     this.program = program;
   }
 
@@ -31,5 +38,9 @@ public class Application extends BaseModel {
 
   public Program getProgram() {
     return this.program;
+  }
+
+  public ApplicantData getApplicantData() {
+    return new ApplicantData(this.object);
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -1,0 +1,35 @@
+package models;
+
+import io.ebean.annotation.DbJson;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import play.data.validation.Constraints;
+
+@Entity
+@Table(name = "applications")
+public class Application extends BaseModel {
+  @ManyToOne private Applicant applicant;
+
+  @ManyToOne private Program program;
+
+  // used by generated code
+  @SuppressWarnings("UnusedVariable")
+  @Constraints.Required
+  @DbJson
+  private String object;
+
+  public Application(Applicant applicant, Program program) {
+    this.applicant = applicant;
+    this.object = applicant.getApplicantData().asJsonString();
+    this.program = program;
+  }
+
+  public Applicant getApplicant() {
+    return this.applicant;
+  }
+
+  public Program getProgram() {
+    return this.program;
+  }
+}

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -1,9 +1,7 @@
 package models;
 
 import io.ebean.annotation.DbJson;
-import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -4,7 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import io.ebean.annotation.DbJson;
+import java.util.List;
 import javax.persistence.Entity;
+import javax.persistence.OneToMany;
 import javax.persistence.PostLoad;
 import javax.persistence.PostPersist;
 import javax.persistence.PostUpdate;
@@ -26,6 +28,9 @@ public class Program extends BaseModel {
   private @Constraints.Required String description;
 
   private @Constraints.Required @DbJson ImmutableList<BlockDefinition> blockDefinitions;
+
+  @OneToMany(mappedBy = "program")
+  private List<Application> applications;
 
   public ProgramDefinition getProgramDefinition() {
     return checkNotNull(this.programDefinition);
@@ -77,5 +82,9 @@ public class Program extends BaseModel {
             .setDescription(this.description)
             .setBlockDefinitions(this.blockDefinitions)
             .build();
+  }
+
+  public ImmutableList<Application> getApplications() {
+    return ImmutableList.copyOf(applications);
   }
 }

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package repository;
 
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
+import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
@@ -12,18 +13,20 @@ import models.Program;
 public class ApplicationRepository {
   private final ProgramRepository programRepository;
   private final ApplicantRepository applicantRepository;
+  private final Clock clock;
 
   @Inject
   public ApplicationRepository(
-      ProgramRepository programRepository, ApplicantRepository applicantRepository) {
+      ProgramRepository programRepository, ApplicantRepository applicantRepository, Clock clock) {
     this.programRepository = programRepository;
     this.applicantRepository = applicantRepository;
+    this.clock = clock;
   }
 
   public CompletionStage<Application> submitApplication(Applicant applicant, Program program) {
     return supplyAsync(
         () -> {
-          Application application = new Application(applicant, program);
+          Application application = new Application(applicant, program, clock.instant());
           application.save();
           return application;
         });
@@ -42,7 +45,7 @@ public class ApplicationRepository {
           }
           Applicant applicant = applicantMaybe.get();
           Program program = programMaybe.get();
-          Application application = new Application(applicant, program);
+          Application application = new Application(applicant, program, clock.instant());
           application.save();
           return Optional.of(application);
         });

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -1,0 +1,50 @@
+package repository;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+import models.Applicant;
+import models.Application;
+import models.Program;
+
+public class ApplicationRepository {
+  private final ProgramRepository programRepository;
+  private final ApplicantRepository applicantRepository;
+
+  @Inject
+  public ApplicationRepository(
+      ProgramRepository programRepository, ApplicantRepository applicantRepository) {
+    this.programRepository = programRepository;
+    this.applicantRepository = applicantRepository;
+  }
+
+  public CompletionStage<Application> submitApplication(Applicant applicant, Program program) {
+    return supplyAsync(
+        () -> {
+          Application application = new Application(applicant, program);
+          application.save();
+          return application;
+        });
+  }
+
+  public CompletionStage<Optional<Application>> submitApplication(
+      long applicantId, long programId) {
+    CompletionStage<Optional<Applicant>> applicantDb =
+        applicantRepository.lookupApplicant(applicantId);
+    CompletionStage<Optional<Program>> programDb = programRepository.lookupProgram(programId);
+    return applicantDb.thenCombineAsync(
+        programDb,
+        (applicantMaybe, programMaybe) -> {
+          if (applicantMaybe.isEmpty() || programMaybe.isEmpty()) {
+            return Optional.empty();
+          }
+          Applicant applicant = applicantMaybe.get();
+          Program program = programMaybe.get();
+          Application application = new Application(applicant, program);
+          application.save();
+          return Optional.of(application);
+        });
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -6,10 +6,13 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.h2;
+import static j2html.TagCreator.p;
 import static j2html.attributes.Attr.HREF;
 
 import com.google.common.collect.ImmutableList;
+import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Optional;
 import javax.inject.Inject;
 import play.i18n.Messages;
 import play.twirl.api.Content;
@@ -37,11 +40,18 @@ public class ProgramIndexView extends BaseHtmlView {
    * @return HTML content for rendering the list of available programs
    */
   public Content render(
-      Messages messages, long applicantId, ImmutableList<ProgramDefinition> programs) {
+      Messages messages,
+      long applicantId,
+      ImmutableList<ProgramDefinition> programs,
+      Optional<String> banner) {
     String applyMessage = messages.at("button.apply");
+    ContainerTag body = body();
+    if (banner.isPresent()) {
+      // TODO: make this a styled toast.
+      body.with(p(banner.get()));
+    }
     return layout.render(
-        body()
-            .with(h1(messages.at("title.programs")))
+        body.with(h1(messages.at("title.programs")))
             .with(each(programs, program -> shortProgram(applicantId, applyMessage, program))));
   }
 

--- a/universal-application-tool-0.0.1/conf/evolutions/default/8.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/8.sql
@@ -1,0 +1,15 @@
+# --- Application table
+
+# --- !Ups
+create table if not exists applications (
+  id bigserial primary key,
+  applicant_id bigint,
+  program_id bigint,
+  object jsonb not null,
+  constraint fk_applicant foreign key(applicant_id) references applicants(id),
+  constraint fk_program foreign key(program_id) references programs(id)
+);
+
+# --- !Downs
+
+drop table if exists applications cascade;

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -88,7 +88,8 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     assertThat(getInputValue("applicant.color")).isEqualTo("baby blue");
 
     long applicantId = getApplicantId();
-    Optional<Applicant> applicantMaybe = applicantRepository.lookupApplicant(applicantId).toCompletableFuture().join();
+    Optional<Applicant> applicantMaybe =
+        applicantRepository.lookupApplicant(applicantId).toCompletableFuture().join();
     assertThat(applicantMaybe).isPresent();
     Applicant applicant = applicantMaybe.get();
     List<Application> applicationList = applicant.getApplications();

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -1,16 +1,25 @@
 package app;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.fluentlenium.core.filter.FilterConstructor.containingText;
 import static org.fluentlenium.core.filter.FilterConstructor.withName;
 import static org.fluentlenium.core.filter.FilterConstructor.withText;
 
+import java.util.List;
+import java.util.Optional;
+import models.Applicant;
+import models.Application;
 import org.junit.Before;
 import org.junit.Test;
+import repository.ApplicantRepository;
 
 public class ApplicantProgramBrowserTest extends BaseBrowserTest {
 
+  private ApplicantRepository applicantRepository;
+
   @Before
   public void setUp() {
+    applicantRepository = app.injector().instanceOf(ApplicantRepository.class);
     // Create a program with two blocks.
 
     loginAsAdmin();
@@ -66,6 +75,7 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Expect review
     //  page when it is implemented.
     // All blocks complete. Back to list of programs.
+    assertThat(browser.$("p", containingText("Successfully saved application")).present()).isTrue();
     assertThat(browser.$("h1", withText("Programs")).present()).isTrue();
     assertThat(browser.$("h2", withText("Mock program")).present()).isTrue();
 
@@ -74,5 +84,12 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     assertThat(getInputValue("applicant.name.first")).isEqualTo("Finn");
     assertThat(getInputValue("applicant.name.last")).isEqualTo("the Human");
     assertThat(getInputValue("applicant.color")).isEqualTo("baby blue");
+
+    long applicantId = getApplicantId();
+    Optional<Applicant> applicantMaybe = applicantRepository.lookupApplicant(applicantId).toCompletableFuture().join();
+    assertThat(applicantMaybe).isPresent();
+    Applicant applicant = applicantMaybe.get();
+    List<Application> applicationList = applicant.getApplications();
+    assertThat(applicationList.size()).isEqualTo(1);
   }
 }

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -12,6 +12,8 @@ import models.Application;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ApplicantRepository;
+import services.Path;
+import services.applicant.ApplicantData;
 
 public class ApplicantProgramBrowserTest extends BaseBrowserTest {
 
@@ -91,5 +93,9 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     Applicant applicant = applicantMaybe.get();
     List<Application> applicationList = applicant.getApplications();
     assertThat(applicationList.size()).isEqualTo(1);
+    ApplicantData resultData = applicationList.get(0).getApplicantData();
+    Optional<String> savedName = resultData.readString(Path.create("applicant.name.first"));
+    assertThat(savedName).isPresent();
+    assertThat(savedName.get()).isEqualTo("Finn");
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -3,6 +3,7 @@ package controllers.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
+import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
@@ -192,7 +193,7 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
     Result result =
         subject.update(request, applicant.id, program.id, 1L).toCompletableFuture().join();
 
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.status()).isEqualTo(FOUND);
 
     // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Change
     //  reviewRoute when review page is available.


### PR DESCRIPTION
### Description
Creates a new table - applications - which contains snapshots of a user's entire applicant object at the time that an application is submitted.  It links to a program and an applicant.

Moved some of the async logic around since now a request to the "next block" button might create this new DB object.  On that note, I'm sorry that this diff is borderline incomprehensible, I have _not_ figured out how to make java async code look good.  Suggestions welcome...


### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #205 
Fixed #209 
