### PR TITLE
Closes #486 TextQuestionDefinition needs a scalar field

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -309,7 +309,7 @@ public class ApplicantQuestion {
         return textValue;
       }
 
-      textValue = applicantData.readString(questionDefinition.getPath());
+      textValue = applicantData.readString(getTextPath());
 
       return textValue;
     }

--- a/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
@@ -117,7 +117,7 @@ public class TextQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getTextPath() {
-    return getPath();
+    return getPath().toBuilder().append("text").build();
   }
 
   public ScalarType getTextType() {

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -60,7 +60,7 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     // Fill in first block correctly.
     fillInput("applicant.name.first", "Finn");
     fillInput("applicant.name.last", "the Human");
-    fillInput("applicant.color", "baby blue");
+    fillInput("applicant.color.text", "baby blue");
 
     browser.$("button", withText("Save and continue")).click();
 
@@ -85,7 +85,7 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     browser.$("a", withText("Apply")).click();
     assertThat(getInputValue("applicant.name.first")).isEqualTo("Finn");
     assertThat(getInputValue("applicant.name.last")).isEqualTo("the Human");
-    assertThat(getInputValue("applicant.color")).isEqualTo("baby blue");
+    assertThat(getInputValue("applicant.color.text")).isEqualTo("baby blue");
 
     long applicantId = getApplicantId();
     Optional<Applicant> applicantMaybe =

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
@@ -64,7 +64,7 @@ public class ApplicantQuestionTest {
 
   @Test
   public void textQuestion_withPresentApplicantData() {
-    applicantData.putString(textQuestionDefinition.getPath(), "hello");
+    applicantData.putString(textQuestionDefinition.getTextPath(), "hello");
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(textQuestionDefinition, applicantData);
     ApplicantQuestion.TextQuestion textQuestion = applicantQuestion.getTextQuestion();
@@ -87,7 +87,7 @@ public class ApplicantQuestionTest {
                 .setQuestionHelpText(ImmutableMap.of(Locale.US, "help text"))
                 .setValidationPredicates(TextValidationPredicates.create(0, 4))
                 .build();
-    applicantData.putString(question.getPath(), "hello");
+    applicantData.putString(question.getTextPath(), "hello");
     ApplicantQuestion applicantQuestion = new ApplicantQuestion(question, applicantData);
     ApplicantQuestion.TextQuestion textQuestion = applicantQuestion.getTextQuestion();
 

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -40,7 +40,7 @@ public class BlockDefinitionTest {
         .hasValue(ScalarType.STRING);
     assertThat(block.getScalarType(Path.create("applicant.address.zip")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.color"))).hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.color.text"))).hasValue(ScalarType.STRING);
     assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
   }
 
@@ -56,7 +56,7 @@ public class BlockDefinitionTest {
             Path.create("applicant.address.city"),
             Path.create("applicant.address.state"),
             Path.create("applicant.address.zip"),
-            Path.create("applicant.color"));
+            Path.create("applicant.color.text"));
 
     assertThat(block.hasPaths(paths)).isTrue();
 

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -213,10 +213,10 @@ public class QuestionDefinitionTest {
             ImmutableMap.of(),
             ImmutableMap.of());
     assertThat(question.getScalars())
-        .containsOnly(entry(Path.create("path.to.question"), ScalarType.STRING));
-    assertThat(question.getScalarType(Path.create("path.to.question")).get())
+        .containsOnly(entry(Path.create("path.to.question.text"), ScalarType.STRING));
+    assertThat(question.getScalarType(Path.create("path.to.question.text")).get())
         .isEqualTo(ScalarType.STRING);
-    assertThat(question.getScalarType(Path.create("path.to.question")).get().getClassFor().get())
+    assertThat(question.getScalarType(Path.create("path.to.question.text")).get().getClassFor().get())
         .isEqualTo(String.class);
   }
 


### PR DESCRIPTION
### Description
- Added scalar path for Text in TextQuestionDefinition
- Fixed bugs and updated related tests
### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #486 
