### PR TITLE
Add methods to Path and ApplicantData to support updating metadata

### DIFF
--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -17,6 +17,8 @@ public abstract class Path {
   private static final String JSON_PATH_START = "$" + JSON_PATH_DIVIDER;
   private static final Splitter JSON_SPLITTER = Splitter.on(JSON_PATH_DIVIDER);
   private static final Joiner JSON_JOINER = Joiner.on(JSON_PATH_DIVIDER);
+  // Use a character that is not part of the JsonPath language.
+  private static final Joiner ALTERNATE_JOINER = Joiner.on('#');
 
   public static Path empty() {
     return create(ImmutableList.of());
@@ -49,9 +51,10 @@ public abstract class Path {
     return JSON_JOINER.join(segments());
   }
 
+  /** A path delimited by a character not in the JsonPath language. */
   @Memoized
   public String alternateDelimiterPath() {
-    return path().replaceAll("\\.", "#");
+    return ALTERNATE_JOINER.join(segments());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -49,6 +49,11 @@ public abstract class Path {
     return JSON_JOINER.join(segments());
   }
 
+  @Memoized
+  public String alternateDelimiterPath() {
+    return path().replaceAll("\\.", "#");
+  }
+
   /**
    * The {@link Path} of the parent. For example, a path {@code applicant.favorites.color} would
    * return {@code applicant.favorites}.
@@ -112,6 +117,11 @@ public abstract class Path {
 
     public Builder append(String segment) {
       segmentsBuilder().add(segment.trim());
+      return this;
+    }
+
+    public Builder append(Path path) {
+      segmentsBuilder().addAll(path.segments());
       return this;
     }
   }

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -119,10 +119,5 @@ public abstract class Path {
       segmentsBuilder().add(segment.trim());
       return this;
     }
-
-    public Builder append(Path path) {
-      segmentsBuilder().addAll(path.segments());
-      return this;
-    }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -30,8 +30,8 @@ public class ApplicantData {
   private static final String METADATA_UPDATES_KEY = "updates";
   private static final String METADATA_LAST_UPDATED_KEY = "last_updated";
   private static final String METADATA_PROGRAM_ID_KEY = "program_id";
-  private static final Path.Builder METADATA_UPDATES_BASE =
-      Path.builder().append(METADATA_PREFIX).append(METADATA_UPDATES_KEY);
+  private static final Path METADATA_UPDATES_BASE =
+      Path.builder().append(METADATA_PREFIX).append(METADATA_UPDATES_KEY).build();
 
   private Locale preferredLocale;
   private DocumentContext jsonData;
@@ -105,7 +105,8 @@ public class ApplicantData {
    * @param timestamp the time, in milliseconds, that the applicant answered this question
    */
   public void putUpdateMetadata(Path questionPath, long programId, long timestamp) {
-    Path updatesBase = METADATA_UPDATES_BASE.append(questionPath.alternateDelimiterPath()).build();
+    Path updatesBase =
+        METADATA_UPDATES_BASE.toBuilder().append(questionPath.alternateDelimiterPath()).build();
     putLong(updatesBase.toBuilder().append(METADATA_PROGRAM_ID_KEY).build(), programId);
     putLong(updatesBase.toBuilder().append(METADATA_LAST_UPDATED_KEY).build(), timestamp);
   }
@@ -116,7 +117,7 @@ public class ApplicantData {
    */
   public Optional<Long> readProgramIdMetadataForQuestionPath(Path questionPath) {
     Path metadataPath =
-        METADATA_UPDATES_BASE
+        METADATA_UPDATES_BASE.toBuilder()
             .append(questionPath.alternateDelimiterPath())
             .append(METADATA_PROGRAM_ID_KEY)
             .build();
@@ -129,10 +130,11 @@ public class ApplicantData {
    */
   public Optional<Long> readUpdateTimestampForQuestionPath(Path questionPath) {
     Path metadataPath =
-        METADATA_UPDATES_BASE
+        METADATA_UPDATES_BASE.toBuilder()
             .append(questionPath.alternateDelimiterPath())
             .append(METADATA_LAST_UPDATED_KEY)
             .build();
+    System.out.println(metadataPath.path());
     return readLong(metadataPath);
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -94,28 +94,43 @@ public class ApplicantData {
     this.jsonData.put(path.parentPath().path(), path.keyName(), value);
   }
 
-  public void putUpdateMetadata(Path applicantDataPath, long programId, long timestamp) {
-    Path updatesBase =
-        METADATA_UPDATES_BASE.append(applicantDataPath.alternateDelimiterPath()).build();
+  /**
+   * Update the metadata for an applicant's answer to the given question path. This includes the
+   * timestamp of the update and the ID of the program the applicant was filling out when they
+   * answered this question.
+   *
+   * @param questionPath the {@link Path} to the question the applicant answered
+   * @param programId the ID of the program the applicant was filling out when they answered this
+   *     question
+   * @param timestamp the time, in milliseconds, that the applicant answered this question
+   */
+  public void putUpdateMetadata(Path questionPath, long programId, long timestamp) {
+    Path updatesBase = METADATA_UPDATES_BASE.append(questionPath.alternateDelimiterPath()).build();
     putLong(updatesBase.toBuilder().append(METADATA_PROGRAM_ID_KEY).build(), programId);
     putLong(updatesBase.toBuilder().append(METADATA_LAST_UPDATED_KEY).build(), timestamp);
   }
 
-  public Optional<Long> readProgramIdMetadataForQuestionPath(Path applicantDataPath) {
+  /**
+   * If the applicant has answered the question at the given {@link Path}, will return the ID of the
+   * program in which they answered this question.
+   */
+  public Optional<Long> readProgramIdMetadataForQuestionPath(Path questionPath) {
     Path metadataPath =
         METADATA_UPDATES_BASE
-            .append(applicantDataPath.alternateDelimiterPath())
+            .append(questionPath.alternateDelimiterPath())
             .append(METADATA_PROGRAM_ID_KEY)
             .build();
     return readLong(metadataPath);
   }
 
-  public Optional<Long> readUpdateTimestampForQuestionPath(Path applicantDataPath) {
+  /**
+   * If the applicant has answered the question at the given {@link Path}, will return the timestamp
+   * for when they last updated their answer.
+   */
+  public Optional<Long> readUpdateTimestampForQuestionPath(Path questionPath) {
     Path metadataPath =
-        Path.builder()
-            .append(METADATA_PREFIX)
-            .append(METADATA_UPDATES_KEY)
-            .append(applicantDataPath.alternateDelimiterPath())
+        METADATA_UPDATES_BASE
+            .append(questionPath.alternateDelimiterPath())
             .append(METADATA_LAST_UPDATED_KEY)
             .build();
     return readLong(metadataPath);
@@ -146,8 +161,8 @@ public class ApplicantData {
   }
 
   /**
-   * Attempt to read a integer at the given path. Returns {@code Optional#empty} if the path does
-   * not exist or a value other than Integer is found.
+   * Attempt to read a long at the given path. Returns {@code Optional#empty} if the path does not
+   * exist or a value other than Long is found.
    */
   public Optional<Long> readLong(Path path) {
     try {

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -21,6 +21,12 @@ public class PathTest {
   }
 
   @Test
+  public void alternateDelimiterPath_returnsCorrectlyDelimitedString() {
+    assertThat(Path.create("applicant.some.path").alternateDelimiterPath())
+        .isEqualTo("applicant#some#path");
+  }
+
+  @Test
   public void segments_emptyPath() {
     assertThat(Path.empty().segments()).isEmpty();
   }
@@ -101,6 +107,9 @@ public class PathTest {
 
     path = path.toBuilder().append("part").build();
     assertThat(path.path()).isEqualTo("applicant.my.path.another.part");
+
+    path = path.toBuilder().append(Path.create("I'm.a.path")).build();
+    assertThat(path.path()).isEqualTo("applicant.my.path.another.part.I'm.a.path");
 
     path = path.toBuilder().setPath("something.new").build();
     assertThat(path.path()).isEqualTo("something.new");

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -108,9 +108,6 @@ public class PathTest {
     path = path.toBuilder().append("part").build();
     assertThat(path.path()).isEqualTo("applicant.my.path.another.part");
 
-    path = path.toBuilder().append(Path.create("I'm.a.path")).build();
-    assertThat(path.path()).isEqualTo("applicant.my.path.another.part.I'm.a.path");
-
     path = path.toBuilder().setPath("something.new").build();
     assertThat(path.path()).isEqualTo("something.new");
   }


### PR DESCRIPTION
### Description
1. Adds methods to `ApplicantData` for reading and writing update timestamps and program IDs
2. Adds a methods on `Path` to support writing metadata - this includes getting a version of the `Path` with alternate delimiters, so we can use the JSON path to a question as a key (i.e. flatten structure)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#519 
