### PR TITLE
Write metadata for every question an applicant answered

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -124,6 +124,9 @@ public final class ApplicantProgramBlocksController extends Controller {
                 } else if (cause instanceof ProgramBlockNotFoundException) {
                   logger.error("Exception while updating applicant data", cause);
                   return badRequest("Unable to process this request");
+                } else if (cause instanceof IllegalArgumentException) {
+                  logger.error(cause.getMessage());
+                  return badRequest();
                 }
                 throw new RuntimeException(cause);
               }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -4,10 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.spi.mapper.MappingException;
 import java.time.Instant;
 import java.util.HashMap;
@@ -22,12 +21,7 @@ import org.slf4j.LoggerFactory;
 import services.Path;
 
 public class ApplicantData {
-  // Suppress errors thrown by JsonPath and instead return null if a path does not exist in a JSON
-  // blob.
-  private static final Configuration CONFIGURATION =
-      Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS);
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
-
   private static final Logger LOG = LoggerFactory.getLogger(ApplicantData.class);
   private static final Locale DEFAULT_LOCALE = Locale.US;
 
@@ -44,7 +38,7 @@ public class ApplicantData {
 
   public ApplicantData(Locale preferredLocale, String jsonData) {
     this.preferredLocale = preferredLocale;
-    this.jsonData = JsonPath.using(CONFIGURATION).parse(checkNotNull(jsonData));
+    this.jsonData = JsonPath.parse(checkNotNull(jsonData));
   }
 
   public Locale preferredLocale() {
@@ -53,6 +47,29 @@ public class ApplicantData {
 
   public void setPreferredLocale(Locale locale) {
     this.preferredLocale = locale;
+  }
+
+  public boolean hasPath(Path path) {
+    try {
+      this.jsonData.read(path.path());
+    } catch (PathNotFoundException e) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if there is any value at the given {@link Path}; false otherwise.
+   *
+   * @param path the {@link Path} to check
+   * @return true if there is a non-null value at the given path; false otherwise
+   */
+  public boolean hasValueAtPath(Path path) {
+    try {
+      return read(path, Object.class).isPresent();
+    } catch (JsonPathTypeMismatchException e) {
+      return false;
+    }
   }
 
   public void putString(Path path, String value) {
@@ -91,7 +108,7 @@ public class ApplicantData {
     path.parentPaths()
         .forEach(
             segmentPath -> {
-              if (this.jsonData.read(segmentPath.path()) == null) {
+              if (!hasPath(segmentPath)) {
                 this.jsonData.put(
                     segmentPath.parentPath().path(), segmentPath.keyName(), new HashMap<>());
               }
@@ -136,6 +153,8 @@ public class ApplicantData {
   private <T> Optional<T> read(Path path, Class<T> type) throws JsonPathTypeMismatchException {
     try {
       return Optional.ofNullable(this.jsonData.read(path.path(), type));
+    } catch (PathNotFoundException e) {
+      return Optional.empty();
     } catch (MappingException e) {
       throw new JsonPathTypeMismatchException(path.path(), type, e);
     }
@@ -162,14 +181,6 @@ public class ApplicantData {
       return this.jsonData.jsonString().equals(that.jsonData.jsonString());
     }
     return false;
-  }
-
-  public boolean hasPath(Path path) {
-    try {
-      return read(path, Object.class).isPresent();
-    } catch (JsonPathTypeMismatchException e) {
-      return false;
-    }
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -65,7 +65,8 @@ public class ApplicantData {
   }
 
   /**
-   * Returns true if there is any value at the given {@link Path}; false otherwise.
+   * Returns true if there is a non-null value at the given {@link Path}; false otherwise. Will
+   * return false if there is a null value at the path.
    *
    * @param path the {@link Path} to check
    * @return true if there is a non-null value at the given path; false otherwise

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -47,6 +47,14 @@ public class ApplicantData {
     this.preferredLocale = locale;
   }
 
+  /**
+   * Checks whether the given path exists in the JSON data. Returns true if the path is present;
+   * false otherwise. Semantically, this checks whether the applicant has answered this question
+   * before.
+   *
+   * @param path the {@link Path} to check
+   * @return true if path is present for this applicant; false otherwise
+   */
   public boolean hasPath(Path path) {
     try {
       this.jsonData.read(path.path());
@@ -70,6 +78,10 @@ public class ApplicantData {
     }
   }
 
+  /**
+   * Write the given string at the given {@link Path}. If the string is empty, it will write a null
+   * value instead.
+   */
   public void putString(Path path, String value) {
     if (value.isEmpty()) {
       putNull(path);
@@ -82,6 +94,10 @@ public class ApplicantData {
     put(path, value);
   }
 
+  /**
+   * Parses and writes a long value, given as a string. If the string is empty, a null value is
+   * written.
+   */
   public void putLong(Path path, String value) {
     if (value.isEmpty()) {
       putNull(path);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -57,15 +56,27 @@ public class ApplicantData {
   }
 
   public void putString(Path path, String value) {
+    if (value.isEmpty()) {
+      putNull(path);
+    } else {
+      put(path, value);
+    }
+  }
+
+  public void putLong(Path path, long value) {
     put(path, value);
   }
 
-  public void putInteger(Path path, int value) {
-    put(path, value);
+  public void putLong(Path path, String value) {
+    if (value.isEmpty()) {
+      putNull(path);
+    } else {
+      put(path, Long.parseLong(value));
+    }
   }
 
-  public <K, V> void putObject(Path path, ImmutableMap<K, V> value) {
-    put(path, value);
+  private void putNull(Path path) {
+    put(path, null);
   }
 
   /**
@@ -105,9 +116,9 @@ public class ApplicantData {
    * Attempt to read a integer at the given path. Returns {@code Optional#empty} if the path does
    * not exist or a value other than Integer is found.
    */
-  public Optional<Integer> readInteger(Path path) {
+  public Optional<Long> readLong(Path path) {
     try {
-      return this.read(path, Integer.class);
+      return this.read(path, Long.class);
     } catch (JsonPathTypeMismatchException e) {
       return Optional.empty();
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -130,7 +130,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getStreetErrors() {
-      if (hasStreetValue() && getStreetValue().isEmpty()) {
+      if (streetAnswered() && getStreetValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("Street is required."));
       }
 
@@ -138,7 +138,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getCityErrors() {
-      if (hasCityValue() && getCityValue().isEmpty()) {
+      if (cityAnswered() && getCityValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("City is required."));
       }
 
@@ -147,7 +147,7 @@ public class ApplicantQuestion {
 
     public ImmutableSet<ValidationErrorMessage> getStateErrors() {
       // TODO: Validate state further.
-      if (hasStateValue() && getStateValue().isEmpty()) {
+      if (stateAnswered() && getStateValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("State is required."));
       }
 
@@ -155,7 +155,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getZipErrors() {
-      if (hasZipValue()) {
+      if (zipAnswered()) {
         Optional<String> zipValue = getZipValue();
         if (zipValue.isEmpty()) {
           return ImmutableSet.of(ValidationErrorMessage.create("Zip code is required."));
@@ -251,6 +251,22 @@ public class ApplicantQuestion {
 
     public Path getZipPath() {
       return getQuestionDefinition().getZipPath();
+    }
+
+    private boolean streetAnswered() {
+      return applicantData.hasPath(getStreetPath());
+    }
+
+    private boolean cityAnswered() {
+      return applicantData.hasPath(getCityPath());
+    }
+
+    private boolean stateAnswered() {
+      return applicantData.hasPath(getStatePath());
+    }
+
+    private boolean zipAnswered() {
+      return applicantData.hasPath(getZipPath());
     }
   }
 
@@ -366,7 +382,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getFirstNameErrors() {
-      if (hasFirstNameValue() && getFirstNameValue().isEmpty()) {
+      if (firstNameAnswered() && getFirstNameValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("First name is required."));
       }
 
@@ -374,7 +390,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getLastNameErrors() {
-      if (hasLastNameValue() && getLastNameValue().isEmpty()) {
+      if (lastNameAnswered() && getLastNameValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("Last name is required."));
       }
 
@@ -447,6 +463,14 @@ public class ApplicantQuestion {
 
     public Path getLastNamePath() {
       return getQuestionDefinition().getLastNamePath();
+    }
+
+    private boolean firstNameAnswered() {
+      return applicantData.hasPath(getFirstNamePath());
+    }
+
+    private boolean lastNameAnswered() {
+      return applicantData.hasPath(getLastNamePath());
     }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -130,7 +130,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getStreetErrors() {
-      if (hasStreetValue() && getStreetValue().get().isEmpty()) {
+      if (hasStreetValue() && getStreetValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("Street is required."));
       }
 
@@ -138,7 +138,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getCityErrors() {
-      if (hasCityValue() && getCityValue().get().isEmpty()) {
+      if (hasCityValue() && getCityValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("City is required."));
       }
 
@@ -147,7 +147,7 @@ public class ApplicantQuestion {
 
     public ImmutableSet<ValidationErrorMessage> getStateErrors() {
       // TODO: Validate state further.
-      if (hasStateValue() && getStateValue().get().isEmpty()) {
+      if (hasStateValue() && getStateValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("State is required."));
       }
 
@@ -156,13 +156,13 @@ public class ApplicantQuestion {
 
     public ImmutableSet<ValidationErrorMessage> getZipErrors() {
       if (hasZipValue()) {
-        String zipValue = getZipValue().get();
+        Optional<String> zipValue = getZipValue();
         if (zipValue.isEmpty()) {
           return ImmutableSet.of(ValidationErrorMessage.create("Zip code is required."));
         }
 
         Pattern pattern = Pattern.compile("^[0-9]{5}(?:-[0-9]{4})?$");
-        Matcher matcher = pattern.matcher(zipValue);
+        Matcher matcher = pattern.matcher(zipValue.get());
         if (!matcher.matches()) {
           return ImmutableSet.of(ValidationErrorMessage.create("Invalid zip code."));
         }
@@ -366,7 +366,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getFirstNameErrors() {
-      if (hasFirstNameValue() && getFirstNameValue().get().isEmpty()) {
+      if (hasFirstNameValue() && getFirstNameValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("First name is required."));
       }
 
@@ -374,7 +374,7 @@ public class ApplicantQuestion {
     }
 
     public ImmutableSet<ValidationErrorMessage> getLastNameErrors() {
-      if (hasLastNameValue() && getLastNameValue().get().isEmpty()) {
+      if (hasLastNameValue() && getLastNameValue().isEmpty()) {
         return ImmutableSet.of(ValidationErrorMessage.create("Last name is required."));
       }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -1,7 +1,6 @@
 package services.applicant;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.concurrent.CompletionStage;
 import models.Applicant;
 import services.ErrorAnd;
@@ -26,13 +25,6 @@ public interface ApplicantService {
    *     {@link ErrorAnd} is returned in the error state.
    *     <p>A ProgramNotFoundException may be thrown when the future completes if the programId does
    *     not correspond to a real Program.
-   */
-  CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, Exception>> stageAndUpdateIfValid(
-      long applicantId, long programId, long blockId, ImmutableSet<Update> updates);
-
-  /**
-   * Equivalent to the other {@link ApplicantService#stageAndUpdateIfValid(long, long, long,
-   * ImmutableSet<Update>)}, but takes a map representing the {@link Update}s.
    */
   CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, Exception>> stageAndUpdateIfValid(
       long applicantId, long programId, long blockId, ImmutableMap<String, String> updateMap);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -90,9 +90,8 @@ public class ApplicantServiceImpl implements ApplicantService {
     boolean updatePathsContainReservedKeys =
         updates.stream().anyMatch(u -> RESERVED_SCALAR_KEYS.contains(u.path().keyName()));
     if (updatePathsContainReservedKeys) {
-      return CompletableFuture.completedFuture(
-          ErrorAnd.error(
-              ImmutableSet.of(new IllegalArgumentException("Path contained reserved scalar key"))));
+      return CompletableFuture.failedFuture(
+          new IllegalArgumentException("Path contained reserved scalar key"));
     }
 
     return stageAndUpdateIfValid(applicantId, programId, blockId, updates);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -29,15 +29,15 @@ import services.question.ScalarType;
 import services.question.UnsupportedScalarTypeException;
 
 public class ApplicantServiceImpl implements ApplicantService {
+  private static final ImmutableSet<String> RESERVED_SCALAR_KEYS =
+      ImmutableSet.of(
+          QuestionDefinition.METADATA_UPDATE_TIME_KEY,
+          QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY);
 
   private final ApplicantRepository applicantRepository;
   private final ProgramService programService;
   private final Clock clock;
   private final HttpExecutionContext httpExecutionContext;
-  private static final ImmutableSet<String> RESERVED_SCALAR_KEYS =
-      ImmutableSet.of(
-          QuestionDefinition.METADATA_UPDATE_TIME_KEY,
-          QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY);
   private final Logger log = LoggerFactory.getLogger(ApplicantService.class);
 
   @Inject

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -18,6 +19,7 @@ import services.program.PathNotInBlockException;
 import services.program.ProgramBlockNotFoundException;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
+import services.question.QuestionDefinition;
 import services.question.ScalarType;
 import services.question.UnsupportedScalarTypeException;
 
@@ -25,20 +27,72 @@ public class ApplicantServiceImpl implements ApplicantService {
 
   private final ApplicantRepository applicantRepository;
   private final ProgramService programService;
+  private final Clock clock;
   private final HttpExecutionContext httpExecutionContext;
+  private static final ImmutableSet<String> RESERVED_SCALAR_KEYS =
+      ImmutableSet.of(
+          QuestionDefinition.METADATA_UPDATE_TIME_KEY,
+          QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY);
 
   @Inject
   public ApplicantServiceImpl(
       ApplicantRepository applicantRepository,
       ProgramService programService,
+      Clock clock,
       HttpExecutionContext httpExecutionContext) {
     this.applicantRepository = checkNotNull(applicantRepository);
     this.programService = checkNotNull(programService);
+    this.clock = checkNotNull(clock);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
   }
 
   @Override
+  public CompletionStage<Applicant> createApplicant(long userId) {
+    Applicant applicant = new Applicant();
+    return applicantRepository.insertApplicant(applicant).thenApply((unused) -> applicant);
+  }
+
+  @Override
+  public CompletionStage<ReadOnlyApplicantProgramService> getReadOnlyApplicantProgramService(
+      long applicantId, long programId) {
+    CompletableFuture<Optional<Applicant>> applicantCompletableFuture =
+        applicantRepository.lookupApplicant(applicantId).toCompletableFuture();
+    CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
+        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+
+    return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
+        .thenApplyAsync(
+            (v) -> {
+              Applicant applicant = applicantCompletableFuture.join().get();
+              ProgramDefinition programDefinition = programDefinitionCompletableFuture.join();
+
+              return new ReadOnlyApplicantProgramServiceImpl(
+                  applicant.getApplicantData(), programDefinition);
+            },
+            httpExecutionContext.current());
+  }
+
+  @Override
   public CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, Exception>>
+      stageAndUpdateIfValid(
+          long applicantId, long programId, long blockId, ImmutableMap<String, String> updateMap) {
+    ImmutableSet<Update> updates =
+        updateMap.entrySet().stream()
+            .map(entry -> Update.create(Path.create(entry.getKey()), entry.getValue()))
+            .collect(ImmutableSet.toImmutableSet());
+
+    boolean updatePathsContainReservedKeys =
+        updates.stream().anyMatch(u -> RESERVED_SCALAR_KEYS.contains(u.path().keyName()));
+    if (updatePathsContainReservedKeys) {
+      return CompletableFuture.completedFuture(
+          ErrorAnd.error(
+              ImmutableSet.of(new IllegalArgumentException("Path contained reserved scalar key"))));
+    }
+
+    return stageAndUpdateIfValid(applicantId, programId, blockId, updates);
+  }
+
+  protected CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, Exception>>
       stageAndUpdateIfValid(
           long applicantId, long programId, long blockId, ImmutableSet<Update> updates) {
     CompletableFuture<Optional<Applicant>> applicantCompletableFuture =
@@ -85,44 +139,6 @@ public class ApplicantServiceImpl implements ApplicantService {
             httpExecutionContext.current());
   }
 
-  @Override
-  public CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, Exception>>
-      stageAndUpdateIfValid(
-          long applicantId, long programId, long blockId, ImmutableMap<String, String> updateMap) {
-    ImmutableSet<Update> updates =
-        updateMap.entrySet().stream()
-            .map(entry -> Update.create(Path.create(entry.getKey()), entry.getValue()))
-            .collect(ImmutableSet.toImmutableSet());
-
-    return stageAndUpdateIfValid(applicantId, programId, blockId, updates);
-  }
-
-  @Override
-  public CompletionStage<Applicant> createApplicant(long userId) {
-    Applicant applicant = new Applicant();
-    return applicantRepository.insertApplicant(applicant).thenApply((unused) -> applicant);
-  }
-
-  @Override
-  public CompletionStage<ReadOnlyApplicantProgramService> getReadOnlyApplicantProgramService(
-      long applicantId, long programId) {
-    CompletableFuture<Optional<Applicant>> applicantCompletableFuture =
-        applicantRepository.lookupApplicant(applicantId).toCompletableFuture();
-    CompletableFuture<ProgramDefinition> programDefinitionCompletableFuture =
-        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
-
-    return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
-        .thenApplyAsync(
-            (v) -> {
-              Applicant applicant = applicantCompletableFuture.join().get();
-              ProgramDefinition programDefinition = programDefinitionCompletableFuture.join();
-
-              return new ReadOnlyApplicantProgramServiceImpl(
-                  applicant.getApplicantData(), programDefinition);
-            },
-            httpExecutionContext.current());
-  }
-
   /** In-place update of {@link Applicant}'s data. */
   private void stageUpdates(
       Applicant applicant,
@@ -136,28 +152,44 @@ public class ApplicantServiceImpl implements ApplicantService {
         programDefinition
             .getBlockDefinition(blockId)
             .orElseThrow(() -> new ProgramBlockNotFoundException(programDefinition.id(), blockId));
-    stageUpdates(applicant.getApplicantData(), blockDefinition, updates);
+    stageUpdates(applicant.getApplicantData(), blockDefinition, programDefinition.id(), updates);
   }
 
   /** In-place update of {@link ApplicantData}. */
   private void stageUpdates(
-      ApplicantData applicantData, BlockDefinition blockDefinition, ImmutableSet<Update> updates)
+      ApplicantData applicantData,
+      BlockDefinition blockDefinition,
+      long programId,
+      ImmutableSet<Update> updates)
       throws UnsupportedScalarTypeException, PathNotInBlockException {
+    ImmutableSet.Builder<Path> questionPaths = ImmutableSet.builder();
     for (Update update : updates) {
       ScalarType type =
           blockDefinition
               .getScalarType(update.path())
               .orElseThrow(() -> new PathNotInBlockException(blockDefinition, update.path()));
+      questionPaths.add(update.path().parentPath());
       switch (type) {
         case STRING:
           applicantData.putString(update.path(), update.value());
           break;
-        case INT:
-          applicantData.putInteger(update.path(), Integer.valueOf(update.value()));
+        case LONG:
+          applicantData.putLong(update.path(), update.value());
           break;
         default:
           throw new UnsupportedScalarTypeException(type);
       }
     }
+
+    questionPaths.build().forEach(path -> writeMetadataForPath(path, applicantData, programId));
+  }
+
+  private void writeMetadataForPath(Path path, ApplicantData data, long programId) {
+    data.putLong(
+        path.toBuilder().append(QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY).build(),
+        programId);
+    data.putLong(
+        path.toBuilder().append(QuestionDefinition.METADATA_UPDATE_TIME_KEY).build(),
+        clock.millis());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/AddressQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/AddressQuestionDefinition.java
@@ -78,15 +78,14 @@ public class AddressQuestionDefinition extends QuestionDefinition {
 
   @Override
   public ImmutableMap<Path, ScalarType> getScalars() {
-    return ImmutableMap.of(
-        getStreetPath(),
-        getStreetType(),
-        getCityPath(),
-        getCityType(),
-        getStatePath(),
-        getStateType(),
-        getZipPath(),
-        getZipType());
+    return ImmutableMap.<Path, ScalarType>builder()
+        .put(getStreetPath(), getStreetType())
+        .put(getCityPath(), getCityType())
+        .put(getStatePath(), getStateType())
+        .put(getZipPath(), getZipType())
+        .put(getLastUpdatedTimePath(), getLastUpdatedTimeType())
+        .put(getProgramIdPath(), getProgramIdType())
+        .build();
   }
 
   public Path getStreetPath() {

--- a/universal-application-tool-0.0.1/app/services/question/NameQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/NameQuestionDefinition.java
@@ -84,7 +84,11 @@ public class NameQuestionDefinition extends QuestionDefinition {
         getMiddleNamePath(),
         getMiddleNameType(),
         getLastNamePath(),
-        getLastNameType());
+        getLastNameType(),
+        getLastUpdatedTimePath(),
+        getLastUpdatedTimeType(),
+        getProgramIdPath(),
+        getProgramIdType());
   }
 
   public Path getFirstNamePath() {

--- a/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
@@ -18,6 +18,9 @@ import services.Path;
 
 /** Defines a single question. */
 public abstract class QuestionDefinition {
+  public static final String METADATA_UPDATE_TIME_KEY = "updated_at";
+  public static final String METADATA_UPDATE_PROGRAM_ID_KEY = "updated_in_program";
+
   private final OptionalLong id;
   private final long version;
   private final String name;
@@ -26,9 +29,6 @@ public abstract class QuestionDefinition {
   private final ImmutableMap<Locale, String> questionText;
   private final ImmutableMap<Locale, String> questionHelpText;
   private final ValidationPredicates validationPredicates;
-
-  public static final String METADATA_UPDATE_TIME_KEY = "updated_at";
-  public static final String METADATA_UPDATE_PROGRAM_ID_KEY = "updated_in_program";
 
   public QuestionDefinition(
       OptionalLong id,

--- a/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
@@ -27,6 +27,9 @@ public abstract class QuestionDefinition {
   private final ImmutableMap<Locale, String> questionHelpText;
   private final ValidationPredicates validationPredicates;
 
+  protected final String METADATA_UPDATE_TIME_KEY = "updated_at";
+  protected final String METADATA_UPDATE_PROGRAM_ID_KEY = "updated_in_program";
+
   public QuestionDefinition(
       OptionalLong id,
       long version,
@@ -159,6 +162,22 @@ public abstract class QuestionDefinition {
 
   /** Get the type of this question. */
   public abstract QuestionType getQuestionType();
+
+  public Path getLastUpdatedTimePath() {
+    return getPath().toBuilder().append(METADATA_UPDATE_TIME_KEY).build();
+  }
+
+  public ScalarType getLastUpdatedTimeType() {
+    return ScalarType.LONG;
+  }
+
+  public Path getProgramIdPath() {
+    return getPath().toBuilder().append(METADATA_UPDATE_PROGRAM_ID_KEY).build();
+  }
+
+  public ScalarType getProgramIdType() {
+    return ScalarType.LONG;
+  }
 
   /** Get a map of scalars stored by this question definition. */
   public abstract ImmutableMap<Path, ScalarType> getScalars();

--- a/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
@@ -27,8 +27,8 @@ public abstract class QuestionDefinition {
   private final ImmutableMap<Locale, String> questionHelpText;
   private final ValidationPredicates validationPredicates;
 
-  protected final String METADATA_UPDATE_TIME_KEY = "updated_at";
-  protected final String METADATA_UPDATE_PROGRAM_ID_KEY = "updated_in_program";
+  public static final String METADATA_UPDATE_TIME_KEY = "updated_at";
+  public static final String METADATA_UPDATE_PROGRAM_ID_KEY = "updated_in_program";
 
   public QuestionDefinition(
       OptionalLong id,

--- a/universal-application-tool-0.0.1/app/services/question/ScalarType.java
+++ b/universal-application-tool-0.0.1/app/services/question/ScalarType.java
@@ -9,7 +9,6 @@ import java.util.Optional;
  * models.Applicant} JSON column and serialized using {@link services.applicant.ApplicantData}.
  */
 public enum ScalarType {
-  INT(int.class),
   LONG(long.class),
   STRING(String.class);
 

--- a/universal-application-tool-0.0.1/app/services/question/ScalarType.java
+++ b/universal-application-tool-0.0.1/app/services/question/ScalarType.java
@@ -10,6 +10,7 @@ import java.util.Optional;
  */
 public enum ScalarType {
   INT(int.class),
+  LONG(long.class),
   STRING(String.class);
 
   private final Class classOf;

--- a/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
@@ -113,7 +113,13 @@ public class TextQuestionDefinition extends QuestionDefinition {
 
   @Override
   public ImmutableMap<Path, ScalarType> getScalars() {
-    return ImmutableMap.of(getTextPath(), getTextType());
+    return ImmutableMap.of(
+        getTextPath(),
+        getTextType(),
+        getLastUpdatedTimePath(),
+        getLastUpdatedTimeType(),
+        getProgramIdPath(),
+        getProgramIdType());
   }
 
   public Path getTextPath() {

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.WithPostgresContainer;
+import services.question.QuestionDefinition;
 import support.ProgramBuilder;
 import support.TestQuestionBank;
 
@@ -122,6 +123,20 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
     Request request =
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, 1L))
             .bodyForm(ImmutableMap.of("fake.path", "value"))
+            .build();
+
+    Result result =
+        subject.update(request, applicant.id, program.id, 1L).toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(BAD_REQUEST);
+  }
+
+  @Test
+  public void update_reservedPathsInRequest_returnsBadRequest() {
+    String reservedPath = "metadata." + QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY;
+    Request request =
+        fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, 1L))
+            .bodyForm(ImmutableMap.of(reservedPath, "value"))
             .build();
 
     Result result =

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -2,7 +2,6 @@ package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import java.time.Instant;
 import java.util.Locale;
@@ -39,16 +38,16 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void put_addsAScalar() {
+  public void putLong_addsAScalar() {
     ApplicantData data = new ApplicantData();
 
-    data.putInteger(Path.create("applicant.age"), 99);
+    data.putLong(Path.create("applicant.age"), 99);
 
     assertThat(data.asJsonString()).isEqualTo("{\"applicant\":{\"age\":99},\"metadata\":{}}");
   }
 
   @Test
-  public void put_addsANestedScalar() {
+  public void putString_addsANestedScalar() {
     ApplicantData data = new ApplicantData();
     String expected =
         "{\"applicant\":{\"favorites\":{\"food\":{\"apple\":\"Granny Smith\"}}},\"metadata\":{}}";
@@ -59,15 +58,27 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void put_addsAMap() {
+  public void putString_writesNullIfStringIsEmpty() {
     ApplicantData data = new ApplicantData();
-    ImmutableMap<String, String> map = ImmutableMap.of("sandwich", "PB&J", "color", "blue");
-    String expected =
-        "{\"applicant\":{\"favorites\":{\"sandwich\":\"PB&J\",\"color\":\"blue\"}},\"metadata\":{}}";
+    Path path = Path.create("applicant.name");
+    String expected = "{\"applicant\":{\"name\":null},\"metadata\":{}}";
 
-    data.putObject(Path.create("applicant.favorites"), map);
+    data.putString(path, "");
 
     assertThat(data.asJsonString()).isEqualTo(expected);
+    assertThat(data.readString(path)).isEmpty();
+  }
+
+  @Test
+  public void putLong_writesNullIfStringIsEmpty() {
+    ApplicantData data = new ApplicantData();
+    Path path = Path.create("applicant.age");
+    String expected = "{\"applicant\":{\"age\":null},\"metadata\":{}}";
+
+    data.putLong(path, "");
+
+    assertThat(data.asJsonString()).isEqualTo(expected);
+    assertThat(data.readLong(path)).isEmpty();
   }
 
   @Test
@@ -81,13 +92,13 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void readInteger_findsCorrectValue() throws Exception {
+  public void readLong_findsCorrectValue() throws Exception {
     String testData = "{ \"applicant\": { \"age\": 30 } }";
     ApplicantData data = new ApplicantData(testData);
 
-    Optional<Integer> found = data.readInteger(Path.create("applicant.age"));
+    Optional<Long> found = data.readLong(Path.create("applicant.age"));
 
-    assertThat(found).hasValue(30);
+    assertThat(found).hasValue(30L);
   }
 
   @Test
@@ -100,10 +111,10 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void readInteger_pathNotPresent_returnsEmptyOptional() throws Exception {
+  public void readLong_pathNotPresent_returnsEmptyOptional() throws Exception {
     ApplicantData data = new ApplicantData();
 
-    Optional<Integer> found = data.readInteger(Path.create("my.fake.path"));
+    Optional<Long> found = data.readLong(Path.create("my.fake.path"));
 
     assertThat(found).isEmpty();
   }
@@ -119,11 +130,11 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void readInteger_returnsEmptyWhenTypeMismatch() {
+  public void readLong_returnsEmptyWhenTypeMismatch() {
     String testData = "{ \"applicant\": { \"object\": { \"name\": \"John\" } } }";
     ApplicantData data = new ApplicantData(testData);
 
-    Optional<Integer> found = data.readInteger(Path.create("applicant.object.name"));
+    Optional<Long> found = data.readLong(Path.create("applicant.object.name"));
 
     assertThat(found).isEmpty();
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -38,6 +38,47 @@ public class ApplicantDataTest {
   }
 
   @Test
+  public void hasPath_returnsTrueForExistingPath() {
+    ApplicantData data = new ApplicantData();
+    Path path = Path.create("applicant.school");
+    data.putString(path, "Elementary School");
+
+    assertThat(data.hasPath(path)).isTrue();
+  }
+
+  @Test
+  public void hasPath_returnsFalseForMissingPath() {
+    ApplicantData data = new ApplicantData();
+
+    assertThat(data.hasPath(Path.create("I_don't_exist!"))).isFalse();
+  }
+
+  @Test
+  public void hasValueAtPath_returnsTrueIfValuePresent() {
+    ApplicantData data = new ApplicantData();
+    Path path = Path.create("applicant.horses");
+    data.putLong(path, 278);
+
+    assertThat(data.hasValueAtPath(path)).isTrue();
+  }
+
+  @Test
+  public void hasValueAtPath_returnsFalseForNull() {
+    ApplicantData data = new ApplicantData();
+    Path path = Path.create("applicant.horses");
+    data.putLong(path, "");
+
+    assertThat(data.hasValueAtPath(path)).isFalse();
+  }
+
+  @Test
+  public void hasValueAtPath_returnsFalseForMissingPath() {
+    ApplicantData data = new ApplicantData();
+
+    assertThat(data.hasValueAtPath(Path.create("not_here!"))).isFalse();
+  }
+
+  @Test
   public void putLong_addsAScalar() {
     ApplicantData data = new ApplicantData();
 

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -1,6 +1,7 @@
 package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.collect.ImmutableList;
@@ -195,15 +196,15 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     String reservedScalar = "applicant.name." + QuestionDefinition.METADATA_UPDATE_TIME_KEY;
     ImmutableMap<String, String> updates = ImmutableMap.of(reservedScalar, "12345");
 
-    ErrorAnd<ReadOnlyApplicantProgramService, Exception> errorAnd =
-        subject
-            .stageAndUpdateIfValid(applicant.id, programDefinition.id(), 1L, updates)
-            .toCompletableFuture()
-            .join();
-
-    assertThat(errorAnd.hasResult()).isFalse();
-    assertThat(errorAnd.getErrors()).hasSize(1);
-    assertThat(errorAnd.getErrors().asList().get(0)).isInstanceOf(IllegalArgumentException.class);
+    assertThatExceptionOfType(CompletionException.class)
+        .isThrownBy(
+            () ->
+                subject
+                    .stageAndUpdateIfValid(applicant.id, programDefinition.id(), 1L, updates)
+                    .toCompletableFuture()
+                    .join())
+        .withCauseInstanceOf(IllegalArgumentException.class)
+        .withMessageContaining("Path contained reserved scalar key");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -90,7 +90,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void stageAndUpdateIfValid_updatesMetadataForEachQuestionOnce() {
+  public void stageAndUpdateIfValid_updatesMetadataForQuestionOnce() {
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
 
     ImmutableSet<Update> updates =
@@ -110,7 +110,12 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     ApplicantData applicantDataAfter =
         applicantRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
 
-    assertThat(applicantDataAfter.asJsonString()).contains("" + programDefinition.id());
+    Path programIdPath =
+        Path.create("applicant.name." + QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY);
+    Path timestampPath =
+        Path.create("applicant.name." + QuestionDefinition.METADATA_UPDATE_TIME_KEY);
+    assertThat(applicantDataAfter.readLong(programIdPath)).hasValue(programDefinition.id());
+    assertThat(applicantDataAfter.readLong(timestampPath)).isPresent();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -2,7 +2,6 @@ package services.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
@@ -212,8 +211,15 @@ public class QuestionDefinitionTest {
             "description",
             ImmutableMap.of(),
             ImmutableMap.of());
-    assertThat(question.getScalars())
-        .containsOnly(entry(Path.create("path.to.question.text"), ScalarType.STRING));
+    ImmutableMap<Path, ScalarType> expectedScalars =
+        ImmutableMap.of(
+            Path.create("path.to.question.text"),
+            ScalarType.STRING,
+            Path.create("path.to.question.updated_at"),
+            ScalarType.LONG,
+            Path.create("path.to.question.updated_in_program"),
+            ScalarType.LONG);
+    assertThat(question.getScalars()).containsAllEntriesOf(expectedScalars);
     assertThat(question.getScalarType(Path.create("path.to.question.text")).get())
         .isEqualTo(ScalarType.STRING);
     assertThat(

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -23,7 +23,7 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
           "description",
           ImmutableMap.of(Locale.US, "question?"),
           ImmutableMap.of(Locale.US, "help text"),
-          TextValidationPredicates.create(1, 3));
+          TextValidationPredicates.create(2, 3));
 
   private final ApplicantData applicantData = new ApplicantData();
 
@@ -44,11 +44,11 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
 
   @Test
   public void render_withMinLengthError() {
-    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "");
+    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "a");
 
     Tag result = renderer.render();
 
-    assertThat(result.render()).contains("This answer must be at least 1 characters long.");
+    assertThat(result.render()).contains("This answer must be at least 2 characters long.");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -23,7 +23,7 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
           "description",
           ImmutableMap.of(Locale.US, "question?"),
           ImmutableMap.of(Locale.US, "help text"),
-          TextValidationPredicates.create(2, 3));
+          TextValidationPredicates.create(1, 3));
 
   private final ApplicantData applicantData = new ApplicantData();
 
@@ -44,12 +44,11 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
 
   @Test
   public void render_withMinLengthError() {
-
-    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "a");
+    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "");
 
     Tag result = renderer.render();
 
-    assertThat(result.render()).contains("This answer must be at least 2 characters long.");
+    assertThat(result.render()).contains("This answer must be at least 1 characters long.");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -23,7 +23,7 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
           "description",
           ImmutableMap.of(Locale.US, "question?"),
           ImmutableMap.of(Locale.US, "help text"),
-          TextValidationPredicates.create(1, 3));
+          TextValidationPredicates.create(2, 3));
 
   private final ApplicantData applicantData = new ApplicantData();
 
@@ -44,11 +44,12 @@ public class TextQuestionRendererTest extends WithPostgresContainer {
 
   @Test
   public void render_withMinLengthError() {
-    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "");
+
+    applicantData.putString(TEXT_QUESTION_DEFINITION.getTextPath(), "a");
 
     Tag result = renderer.render();
 
-    assertThat(result.render()).contains("This answer must be at least 1 characters long.");
+    assertThat(result.render()).contains("This answer must be at least 2 characters long.");
   }
 
   @Test


### PR DESCRIPTION
### Main Updates and Files Changed
1. Add `updated_at` and `updated_in_program` metadata to questions themselves (i.e. they are scalars)
    1. _QuestionDefinition, NameQuestionDefinition, AddressQuestionDefinition, TextQuestionDefinition_
2. Change `ScalarType.INT` to `ScalarType.LONG` - we will represent all whole numbers as longs
    1. _ScalarType, ApplicantData (methods for int --> long)_
3. For each question path in updates for a block, write two pieces of metadata (updated time and program ID)
    1. _ApplicantServiceImpl + Test_
4. Remove `stageAndUpdateIfValid` method on `ApplicantService` that exposes internal `Update` details, and instead only expose the method which uses `ImmutableMap`
    1. _ApplicantService, ApplicantServiceImpl (reordered methods)_
5. Update `ApplicantData` methods to avoid writing the empty string
6. Update logic in `ApplicantQuestion` to check whether an applicant has answered a question, instead of checking for presence of a value
    1. _ApplicantQuestion + Test_

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#519 
