### PR TITLE
Local s3 - Closes #482

### DIFF
--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+aws --endpoint-url=http://localhost:4566 s3api create-bucket --bucket civiform-local-s3 --region us-west-2

--- a/bin/localstack/purge-s3
+++ b/bin/localstack/purge-s3
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+aws --endpoint-url=http://localhost:4566 s3 rm s3://civiform-local-s3/ --recursive

--- a/bin/localstack/wait
+++ b/bin/localstack/wait
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Wait until localhost:4566 is responsive
+echo "Waiting for localstack to get set up. This may take a minute or two"
+wget -O /tmp/localstack_health_check_slkhdfsg.html -o /tmp/localstack_health_check_slkhdfsg.log http://localhost:4566/health
+
+# Wait until all services change from 'starting' to 'running'
+HEALTHCHECK=$(</tmp/localstack_health_check_slkhdfsg.html)
+while [[ $HEALTHCHECK == *"starting"* ]]
+do
+    sleep 2
+    wget -O /tmp/localstack_health_check_slkhdfsg.html -o /tmp/localstack_health_check_slkhdfsg.log http://localhost:4566/health
+    HEALTHCHECK=$(</tmp/localstack_health_check_slkhdfsg.html)
+done
+
+# Not needed anymore. Deletion here reduces (slight?) chance of wget write error on next 
+# startup causing false indication that status has changed from 'starting' to 'running'
+rm -f /tmp/localstack_health_check_slkhdfsg.html
+rm -f /tmp/localstack_health_check_slkhdfsg.log

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -4,7 +4,18 @@
 $( dirname ${BASH_SOURCE[0]})/pull-image
 
 if [ -f ".secrets" ]; then
-	. .secrets
+    . .secrets
 fi
 
+# start localstack
+docker-compose up -d localstack
+
+# wait till localstack running
+# otherwise other services crash
+$( dirname ${BASH_SOURCE[0]})/localstack/wait
+
+# Ensure local s3 created
+$( dirname ${BASH_SOURCE[0]})/localstack/mk-s3
+
+# start everything else
 docker-compose up

--- a/bin/stop-dev
+++ b/bin/stop-dev
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,17 @@ version: '3.1'
 
 services:
 
+  localstack:
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=s3
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
   db:
     image: postgres:12.5
     restart: always
@@ -10,6 +21,8 @@ services:
       - 5432:5432
     environment:
       POSTGRES_PASSWORD: example
+
+    depends_on: [localstack]
 
   civiform:
     image: civiform
@@ -23,8 +36,8 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
-      - AWS_S3_REGION
-      - AWS_S3_BUCKET_NAME
+      - AWS_S3_REGION=us-west-2
+      - AWS_S3_BUCKET_NAME=civiform-local-s3
       - IDCS_CLIENT_ID
       - IDCS_SECRET
       - ADFS_CLIENT_ID
@@ -35,5 +48,7 @@ services:
       - ~/.coursier:/root/.coursier
       - ~/.sbt:/root/.sbt
       - ~/.ivy:/root/.ivy2
+
+    depends_on: [localstack]
 
     command: ~run

--- a/universal-application-tool-0.0.1/app/repository/AmazonS3Client.java
+++ b/universal-application-tool-0.0.1/app/repository/AmazonS3Client.java
@@ -3,17 +3,21 @@ package repository;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.typesafe.config.Config;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.Environment;
 import play.inject.ApplicationLifecycle;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -23,18 +27,21 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 public class AmazonS3Client {
   public static final String AWS_S3_REGION = "aws.s3.region";
   public static final String AWS_S3_BUCKET = "aws.s3.bucket";
+  public static final String AWS_LOCAL_ENDPOINT = "aws.local.endpoint";
   private static final Logger log = LoggerFactory.getLogger("s3client");
 
   private final ApplicationLifecycle appLifecycle;
   private final Config config;
+  private final Environment environment;
   private Region region;
   private String bucket;
   private S3Client s3;
 
   @Inject
-  public AmazonS3Client(ApplicationLifecycle appLifecycle, Config config) {
+  public AmazonS3Client(ApplicationLifecycle appLifecycle, Config config, Environment environment) {
     this.appLifecycle = checkNotNull(appLifecycle);
     this.config = checkNotNull(config);
+    this.environment = checkNotNull(environment);
 
     log.info("aws s3 enabled: " + String.valueOf(enabled()));
     if (enabled()) {
@@ -103,9 +110,22 @@ public class AmazonS3Client {
 
   private void connect() {
     String regionName = config.getString(AWS_S3_REGION);
+    String endpoint;
     region = Region.of(regionName);
     bucket = config.getString(AWS_S3_BUCKET);
+    URI endpointOverride;
+    S3ClientBuilder s3ClientBuilder;
 
-    s3 = S3Client.builder().region(region).build();
+    endpoint = config.getString(AWS_LOCAL_ENDPOINT);
+    s3ClientBuilder = S3Client.builder().region(region);
+    if (environment.isDev()) {
+      try {
+        endpointOverride = new URI(endpoint);
+        s3ClientBuilder = s3ClientBuilder.endpointOverride(endpointOverride);
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    s3 = s3ClientBuilder.region(region).build();
   }
 }

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -20,6 +20,7 @@ lazy val root = (project in file("."))
 
       // Amazon AWS SDK
       "software.amazon.awssdk" % "aws-sdk-java" % "2.15.81",
+
       // Database and database testing libraries
       "org.postgresql" % "postgresql" % "42.2.18",
       "org.testcontainers" % "postgresql" % "1.15.1" % Test,

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -386,3 +386,4 @@ ebean.default = "models.*"
 
 aws.s3.region=${?AWS_S3_REGION}
 aws.s3.bucket=${?AWS_S3_BUCKET_NAME}
+aws.local.endpoint="http://localstack:4566"


### PR DESCRIPTION
### Description
Adds docker-compose file to set up basic localstack, as well as commands to create local s3 bucket

Defines a `DEV_ENV=1` environment var in dev docker-compose.yaml to inform app whether too look for local s3 buck and (attempts to) add java code in to hook up app backend to local s3 bucket

### Checklist
- Note: *I haven't been able to test whether the browser tests actually work though, since I can't seem to get a UI set up on my system. Will have to look at that further*
- [ ] Automate tests to demonstrate that browser tests store files locally across shutdown / startup of localstack
- [ ] Need to update the [contributing guide](https://github.com/seattle-uat/civiform/wiki/Contributing) to include localstack handling scripts
- [x] Make sure localstack handling commands are elegant enough according to dev preferenes

### Issue(s)
Fixes #482 