### PR TITLE
Add notion of lifecycle stages to backend - predecessor to versioning

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -184,7 +184,8 @@ public final class ApplicantProgramBlocksController extends Controller {
         .thenApplyAsync(
             applicationMaybe -> {
               if (applicationMaybe.isEmpty()) {
-                return found(endOfProgramSubmission).flashing("banner", "Error saving program.");
+                return found(endOfProgramSubmission)
+                    .flashing("banner", "Error saving application.");
               }
               Application application = applicationMaybe.get();
               // Placeholder application ID display.

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -1,12 +1,12 @@
 package models;
 
 import io.ebean.annotation.DbJson;
+import io.ebean.annotation.UpdatedTimestamp;
 import java.time.Instant;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
-import services.WellKnownPaths;
 import services.applicant.ApplicantData;
 
 @Entity
@@ -16,18 +16,22 @@ public class Application extends BaseModel {
 
   @ManyToOne private Program program;
 
+  @Constraints.Required private LifecycleStage lifecycleStage;
+
+  @UpdatedTimestamp private Instant submitTime;
+
   // used by generated code
   @SuppressWarnings("UnusedVariable")
   @Constraints.Required
   @DbJson
   private String object;
 
-  public Application(Applicant applicant, Program program, Instant submitTime) {
+  public Application(Applicant applicant, Program program, LifecycleStage lifecycleStage) {
     this.applicant = applicant;
     ApplicantData data = applicant.getApplicantData();
-    data.putString(WellKnownPaths.APPLICATION_SUBMITTED_TIME, submitTime.toString());
     this.object = data.asJsonString();
     this.program = program;
+    this.lifecycleStage = lifecycleStage;
   }
 
   public Applicant getApplicant() {
@@ -40,5 +44,17 @@ public class Application extends BaseModel {
 
   public ApplicantData getApplicantData() {
     return new ApplicantData(this.object);
+  }
+
+  public LifecycleStage getLifecycleStage() {
+    return this.lifecycleStage;
+  }
+
+  public Instant getSubmitTime() {
+    return this.submitTime;
+  }
+
+  public void setLifecycleStage(LifecycleStage stage) {
+    this.lifecycleStage = stage;
   }
 }

--- a/universal-application-tool-0.0.1/app/models/LifecycleStage.java
+++ b/universal-application-tool-0.0.1/app/models/LifecycleStage.java
@@ -1,0 +1,22 @@
+package models;
+
+import io.ebean.annotation.DbEnumType;
+import io.ebean.annotation.DbEnumValue;
+
+public enum LifecycleStage {
+  DRAFT("draft"),
+  ACTIVE("active"),
+  OBSOLETE("obsolete"),
+  DELETED("deleted");
+
+  private final String stage;
+
+  LifecycleStage(String stage) {
+    this.stage = stage;
+  }
+
+  @DbEnumValue(storage = DbEnumType.VARCHAR)
+  public String getValue() {
+    return this.stage;
+  }
+}

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -29,6 +29,8 @@ public class Program extends BaseModel {
 
   private @Constraints.Required @DbJson ImmutableList<BlockDefinition> blockDefinitions;
 
+  @Constraints.Required private LifecycleStage lifecycleStage;
+
   @OneToMany(mappedBy = "program")
   private List<Application> applications;
 
@@ -42,6 +44,11 @@ public class Program extends BaseModel {
     this.name = definition.name();
     this.description = definition.description();
     this.blockDefinitions = definition.blockDefinitions();
+  }
+
+  public Program(ProgramDefinition definition, LifecycleStage lifecycleStage) {
+    this(definition);
+    this.lifecycleStage = lifecycleStage;
   }
 
   /**
@@ -86,5 +93,13 @@ public class Program extends BaseModel {
 
   public ImmutableList<Application> getApplications() {
     return ImmutableList.copyOf(applications);
+  }
+
+  public LifecycleStage getLifecycleStage() {
+    return this.lifecycleStage;
+  }
+
+  public void setLifecycleStage(LifecycleStage lifecycleStage) {
+    this.lifecycleStage = lifecycleStage;
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -29,6 +29,8 @@ public class Program extends BaseModel {
 
   private @Constraints.Required @DbJson ImmutableList<BlockDefinition> blockDefinitions;
 
+  private @Constraints.Required Long version;
+
   @Constraints.Required private LifecycleStage lifecycleStage;
 
   @OneToMany(mappedBy = "program")
@@ -101,5 +103,13 @@ public class Program extends BaseModel {
 
   public void setLifecycleStage(LifecycleStage lifecycleStage) {
     this.lifecycleStage = lifecycleStage;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Question.java
+++ b/universal-application-tool-0.0.1/app/models/Question.java
@@ -41,6 +41,8 @@ public class Question extends BaseModel {
 
   private @Constraints.Required @DbJsonB String validationPredicates;
 
+  @Constraints.Required private LifecycleStage lifecycleStage;
+
   public String getPath() {
     return path;
   }
@@ -58,6 +60,11 @@ public class Question extends BaseModel {
     questionHelpText = questionDefinition.getQuestionHelpText();
     questionType = questionDefinition.getQuestionType().toString();
     validationPredicates = questionDefinition.getValidationPredicatesAsString();
+  }
+
+  public Question(QuestionDefinition questionDefinition, LifecycleStage lifecycleStage) {
+    this(questionDefinition);
+    this.lifecycleStage = lifecycleStage;
   }
 
   /** Populates column values from {@link QuestionDefinition}. */
@@ -98,5 +105,13 @@ public class Question extends BaseModel {
 
   public QuestionDefinition getQuestionDefinition() {
     return checkNotNull(questionDefinition);
+  }
+
+  public LifecycleStage getLifecycleStage() {
+    return this.lifecycleStage;
+  }
+
+  public void setLifecycleStage(LifecycleStage lifecycleStage) {
+    this.lifecycleStage = lifecycleStage;
   }
 }

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -33,8 +33,8 @@ public class ApplicationRepository {
       ApplicantRepository applicantRepository,
       EbeanConfig ebeanConfig,
       DatabaseExecutionContext executionContext) {
-    this.programRepository = programRepository;
-    this.applicantRepository = applicantRepository;
+    this.programRepository = checkNotNull(programRepository);
+    this.applicantRepository = checkNotNull(applicantRepository);
     this.ebeanServer = Ebean.getServer(checkNotNull(ebeanConfig).defaultServer());
     this.executionContext = checkNotNull(executionContext);
   }

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -5,62 +5,168 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
-import java.time.Clock;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import javax.inject.Inject;
 import models.Applicant;
 import models.Application;
+import models.LifecycleStage;
 import models.Program;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.db.ebean.EbeanConfig;
+import services.applicant.ApplicantNotFoundException;
+import services.program.ProgramNotFoundException;
 
 public class ApplicationRepository {
   private final ProgramRepository programRepository;
   private final ApplicantRepository applicantRepository;
-  private final Clock clock;
   private final EbeanServer ebeanServer;
   private final DatabaseExecutionContext executionContext;
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationRepository.class);
 
   @Inject
   public ApplicationRepository(
       ProgramRepository programRepository,
       ApplicantRepository applicantRepository,
-      Clock clock,
       EbeanConfig ebeanConfig,
       DatabaseExecutionContext executionContext) {
     this.programRepository = programRepository;
     this.applicantRepository = applicantRepository;
-    this.clock = clock;
     this.ebeanServer = Ebean.getServer(checkNotNull(ebeanConfig).defaultServer());
     this.executionContext = checkNotNull(executionContext);
   }
 
+  /**
+   * Submit an application, which will delete any in-progress drafts, obsolete any submitted
+   * applications to a program with the same name (to include past versions of the same program),
+   * and create a new application in the active state.
+   */
   public CompletionStage<Application> submitApplication(Applicant applicant, Program program) {
     return supplyAsync(
         () -> {
-          Application application = new Application(applicant, program, clock.instant());
-          application.save();
-          return application;
-        });
+          return submitApplicationInternal(applicant, program);
+        },
+        executionContext.current());
   }
 
   public CompletionStage<Optional<Application>> submitApplication(
       long applicantId, long programId) {
+    return this.perform(
+        applicantId,
+        programId,
+        (ApplicationArguments appArgs) ->
+            submitApplicationInternal(appArgs.applicant, appArgs.program));
+  }
+
+  private Application submitApplicationInternal(Applicant applicant, Program program) {
+    ebeanServer.beginTransaction();
+    try {
+      List<Application> oldApplications =
+          ebeanServer
+              .createQuery(Application.class)
+              .where()
+              .eq("applicant.id", applicant.id)
+              .eq("program.name", program.getProgramDefinition().name())
+              .findList();
+      for (Application application : oldApplications) {
+        // Delete any in-progress drafts, and mark obsolete any old applications.
+        if (application.getLifecycleStage() == LifecycleStage.DRAFT) {
+          application.setLifecycleStage(LifecycleStage.DELETED);
+        } else {
+          application.setLifecycleStage(LifecycleStage.OBSOLETE);
+        }
+      }
+      Application application = new Application(applicant, program, LifecycleStage.ACTIVE);
+      application.save();
+      ebeanServer.commitTransaction();
+      return application;
+    } finally {
+      ebeanServer.endTransaction();
+    }
+  }
+
+  private CompletionStage<Optional<Application>> perform(
+      long applicantId, long programId, Function<ApplicationArguments, Application> fn) {
     CompletionStage<Optional<Applicant>> applicantDb =
         applicantRepository.lookupApplicant(applicantId);
     CompletionStage<Optional<Program>> programDb = programRepository.lookupProgram(programId);
-    return applicantDb.thenCombineAsync(
-        programDb,
-        (applicantMaybe, programMaybe) -> {
-          if (applicantMaybe.isEmpty() || programMaybe.isEmpty()) {
-            return Optional.empty();
-          }
-          Applicant applicant = applicantMaybe.get();
-          Program program = programMaybe.get();
-          Application application = new Application(applicant, program, clock.instant());
-          application.save();
-          return Optional.of(application);
-        });
+    return applicantDb
+        .thenCombineAsync(
+            programDb,
+            (applicantMaybe, programMaybe) -> {
+              if (applicantMaybe.isEmpty()) {
+                throw new RuntimeException(new ApplicantNotFoundException(applicantId));
+              }
+              if (programMaybe.isEmpty()) {
+                throw new RuntimeException(new ProgramNotFoundException(programId));
+              }
+              return new ApplicationArguments(programMaybe.get(), applicantMaybe.get());
+            })
+        .thenApplyAsync(fn)
+        .thenApplyAsync(application -> Optional.of(application))
+        .exceptionally(
+            exception -> {
+              LOG.error(exception.toString());
+              exception.printStackTrace();
+              return Optional.empty();
+            });
+  }
+
+  // Need to transmit both arguments to submitApplication through the CompletionStage pipeline.
+  // Not useful in the API, not needed more broadly.
+  private static class ApplicationArguments {
+    public Program program;
+    public Applicant applicant;
+
+    public ApplicationArguments(Program program, Applicant applicant) {
+      this.program = program;
+      this.applicant = applicant;
+    }
+  }
+
+  private Application createOrUpdateDraftApplicationInternal(Applicant applicant, Program program) {
+    ebeanServer.beginTransaction();
+    try {
+      Optional<Application> existingDraft =
+          ebeanServer
+              .createQuery(Application.class)
+              .where()
+              .eq("applicant.id", applicant.id)
+              .eq("program.id", program.id)
+              .eq("lifecycle_stage", LifecycleStage.DRAFT)
+              .findOneOrEmpty();
+      Application application =
+          existingDraft.orElse(new Application(applicant, program, LifecycleStage.DRAFT));
+      application.save();
+      ebeanServer.commitTransaction();
+      return application;
+    } finally {
+      ebeanServer.endTransaction();
+    }
+  }
+
+  /**
+   * Create a draft application for the specified program. Update the draft application if one
+   * already exists.
+   */
+  public CompletionStage<Application> createOrUpdateDraft(Applicant applicant, Program program) {
+    return supplyAsync(
+        () -> {
+          return createOrUpdateDraftApplicationInternal(applicant, program);
+        },
+        executionContext.current());
+  }
+
+  public CompletionStage<Optional<Application>> createOrUpdateDraft(
+      long applicantId, long programId) {
+    return this.perform(
+        applicantId,
+        programId,
+        (ApplicationArguments appArgs) ->
+            createOrUpdateDraftApplicationInternal(appArgs.applicant, appArgs.program));
   }
 
   public CompletionStage<Optional<Application>> getApplication(long applicationId) {

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -73,11 +73,12 @@ public class ApplicationRepository {
               .findList();
       for (Application application : oldApplications) {
         // Delete any in-progress drafts, and mark obsolete any old applications.
-        if (application.getLifecycleStage() == LifecycleStage.DRAFT) {
+        if (application.getLifecycleStage().equals(LifecycleStage.DRAFT)) {
           application.setLifecycleStage(LifecycleStage.DELETED);
         } else {
           application.setLifecycleStage(LifecycleStage.OBSOLETE);
         }
+        application.save();
       }
       Application application = new Application(applicant, program, LifecycleStage.ACTIVE);
       application.save();

--- a/universal-application-tool-0.0.1/app/services/WellKnownPaths.java
+++ b/universal-application-tool-0.0.1/app/services/WellKnownPaths.java
@@ -1,7 +1,6 @@
 package services;
 
 public class WellKnownPaths {
-  public static Path APPLICATION_SUBMITTED_TIME = Path.create("metadata.submitted_time");
   public static Path APPLICANT_FIRST_NAME = Path.create("applicant.name.first");
   public static Path APPLICANT_MIDDLE_NAME = Path.create("applicant.name.middle");
   public static Path APPLICANT_LAST_NAME = Path.create("applicant.name.last");

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
+import models.LifecycleStage;
 import models.Program;
 import services.question.QuestionDefinition;
 
@@ -80,6 +81,10 @@ public abstract class ProgramDefinition {
 
   public Program toProgram() {
     return new Program(this);
+  }
+
+  public Program toProgram(LifecycleStage lifecycleStage) {
+    return new Program(this, lifecycleStage);
   }
 
   public abstract Builder toBuilder();

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import models.Application;
+import models.LifecycleStage;
 import models.Program;
 import play.db.ebean.Transactional;
 import play.libs.concurrent.HttpExecutionContext;
@@ -115,7 +116,7 @@ public class ProgramServiceImpl implements ProgramService {
       return ErrorAnd.error(errors);
     }
     Program program =
-        programDefinition.toBuilder().setName(name).setDescription(description).build().toProgram();
+        programDefinition.toBuilder().setName(name).setDescription(description).build().toProgram(LifecycleStage.DRAFT);
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
                 programRepository.updateProgramSync(program).getProgramDefinition())
@@ -170,7 +171,10 @@ public class ProgramServiceImpl implements ProgramService {
             .build();
 
     Program program =
-        programDefinition.toBuilder().addBlockDefinition(blockDefinition).build().toProgram();
+        programDefinition.toBuilder()
+            .addBlockDefinition(blockDefinition)
+            .build()
+            .toProgram(LifecycleStage.DRAFT);
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()
@@ -340,7 +344,10 @@ public class ProgramServiceImpl implements ProgramService {
     }
 
     Program program =
-        programDefinition.toBuilder().setBlockDefinitions(newBlocks).build().toProgram();
+        programDefinition.toBuilder()
+            .setBlockDefinitions(newBlocks)
+            .build()
+            .toProgram(LifecycleStage.DRAFT);
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()
@@ -384,11 +391,12 @@ public class ProgramServiceImpl implements ProgramService {
     ImmutableList<BlockDefinition> updatedBlockDefinitions =
         ImmutableList.copyOf(mutableBlockDefinitions);
 
+    // Implicitly "draft" since we are editing.
     Program program =
         programDefinition.toBuilder()
             .setBlockDefinitions(updatedBlockDefinitions)
             .build()
-            .toProgram();
+            .toProgram(LifecycleStage.DRAFT);
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -116,7 +116,11 @@ public class ProgramServiceImpl implements ProgramService {
       return ErrorAnd.error(errors);
     }
     Program program =
-        programDefinition.toBuilder().setName(name).setDescription(description).build().toProgram(LifecycleStage.DRAFT);
+        programDefinition.toBuilder()
+            .setName(name)
+            .setDescription(description)
+            .build()
+            .toProgram(LifecycleStage.DRAFT);
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
                 programRepository.updateProgramSync(program).getProgramDefinition())

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
@@ -10,12 +10,10 @@ import static j2html.TagCreator.p;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import j2html.tags.Tag;
-import java.util.NoSuchElementException;
 import models.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.twirl.api.Content;
-import services.WellKnownPaths;
 import services.applicant.ApplicantService;
 import views.BaseHtmlView;
 import views.admin.AdminLayout;
@@ -64,12 +62,8 @@ public final class ProgramApplicationListView extends BaseHtmlView {
     String applicantName = applicantService.applicantName(application);
     String lastEditText;
     try {
-      lastEditText =
-          application
-              .getApplicantData()
-              .readString(WellKnownPaths.APPLICATION_SUBMITTED_TIME)
-              .get();
-    } catch (NoSuchElementException e) {
+      lastEditText = application.getSubmitTime().toString();
+    } catch (NullPointerException e) {
       log.error("Application {} submitted without submission time marked.", applicationId);
       lastEditText = "<ERROR>";
     }

--- a/universal-application-tool-0.0.1/conf/evolutions/default/9.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/9.sql
@@ -1,0 +1,18 @@
+# --- Add versioning and lifecycle management.
+
+# --- !Ups
+
+alter table questions add constraint nameversion unique(name, version);
+alter table questions add column lifecycle_stage varchar;
+alter table programs add column lifecycle_stage varchar;
+alter table applications add column lifecycle_stage varchar;
+alter table applications add column submit_time timestamp;
+alter table programs add column version bigint;
+
+# --- !Downs
+alter table questions drop constraint if exists nameversion cascade;
+alter table questions drop column if exists lifecycle_stage;
+alter table programs drop column if exists lifecycle_stage;
+alter table applications drop column if exists lifecycle_stage;
+alter table applications drop column if exists submit_time;
+alter table programs drop column if exists version;

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -77,6 +77,7 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
     // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Expect review
     //  page when it is implemented.
     // All blocks complete. Back to list of programs.
+    assertThat(bodySource()).contains("Successfully saved application");
     assertThat(browser.$("p", containingText("Successfully saved application")).present()).isTrue();
     assertThat(browser.$("h1", withText("Programs")).present()).isTrue();
     assertThat(browser.$("h2", withText("Mock program")).present()).isTrue();

--- a/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
@@ -2,6 +2,7 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import models.Applicant;
 import models.Application;
 import models.LifecycleStage;
@@ -48,6 +49,20 @@ public class ApplicationRepositoryTest extends WithPostgresContainer {
     assertThat(
             repo.getApplication(appTwo.id).toCompletableFuture().join().get().getLifecycleStage())
         .isEqualTo(LifecycleStage.DELETED);
+  }
+
+  @Test
+  public void createOrUpdateDraftApplication_updatesExistingDraft() {
+    Applicant applicant = saveApplicant("Alice");
+    Program program = saveProgram("Program");
+    Application application =
+        repo.createOrUpdateDraft(applicant, program).toCompletableFuture().join();
+    Instant initialSubmitTime = application.getSubmitTime();
+    Application applicationTwo =
+        repo.createOrUpdateDraft(applicant, program).toCompletableFuture().join();
+
+    assertThat(application.id).isEqualTo(applicationTwo.id);
+    assertThat(applicationTwo.getSubmitTime()).isAfter(initialSubmitTime);
   }
 
   private Applicant saveApplicant(String name) {

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -2,6 +2,7 @@ package support;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
+import java.util.UUID;
 import models.Applicant;
 import models.Program;
 import models.Question;
@@ -25,9 +26,14 @@ public class ResourceCreator {
   }
 
   public Question insertQuestion(String pathString, long version) {
+    String name = UUID.randomUUID().toString();
+    return insertQuestion(pathString, version, name);
+  }
+
+  public Question insertQuestion(String pathString, long version, String name) {
     QuestionDefinition definition =
         new TextQuestionDefinition(
-            version, "", Path.create(pathString), "", ImmutableMap.of(), ImmutableMap.of());
+            version, name, Path.create(pathString), "", ImmutableMap.of(), ImmutableMap.of());
     Question question = new Question(definition);
     question.save();
     return question;


### PR DESCRIPTION
### Description
This makes the necessary database changes for applications, programs, and questions to have lifecycle states.  All three go `DRAFT` (editable but not visible to others) -> `ACTIVE` (visible to others, not editable) -> `OBSOLETE` (usable by in-progress or existing apps / programs, not visible to new ones) -> `DELETED` (no longer visible to anyone).

Also updates application submit logic to use these states, since that's the easiest of the three!  Doesn't do anything to UX yet.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Related to #508.