### PR TITLE
Mount sbt cache volumes in dev container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,4 +32,8 @@ services:
     build: .
     volumes:
       - ./universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1
+      - ~/.coursier:/root/.coursier
+      - ~/.sbt:/root/.sbt
+      - ~/.ivy:/root/.ivy2
+
     command: ~run


### PR DESCRIPTION
Following advice from joshuasuereth:

> I think your caching issues are 100% related to your docker setup.  While I love docker, sbt relies on access to "global directories" where it caches things between invocations. If you can local-mount the following it should help:
> - `*/target directories`
> - `~/.coursier`
> - `~/.sbt`
> - `~/.ivy`

