### PR TITLE
Rename getBlockDefinitionByIndex to distinguish getting by index from getting by id

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -38,7 +38,7 @@ public abstract class ProgramDefinition {
   }
 
   /** Returns the {@link BlockDefinition} at the specified block index if available. */
-  public Optional<BlockDefinition> getBlockDefinition(int blockIndex) {
+  public Optional<BlockDefinition> getBlockDefinitionByIndex(int blockIndex) {
     if (blockIndex < 0 || blockIndex >= blockDefinitions().size()) {
       return Optional.empty();
     }

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -125,20 +125,20 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
             .build();
 
     Result result =
-        controller.update(request, program.id(), program.getBlockDefinition(0).get().id());
+        controller.update(request, program.id(), program.getBlockDefinitionByIndex(0).get().id());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .hasValue(
             routes.AdminProgramBlocksController.edit(
-                    program.id(), program.getBlockDefinition(0).get().id())
+                    program.id(), program.getBlockDefinitionByIndex(0).get().id())
                 .url());
 
     Result redirectResult =
         controller.edit(
             addCSRFToken(fakeRequest()).build(),
             program.id(),
-            program.getBlockDefinition(0).get().id());
+            program.getBlockDefinitionByIndex(0).get().id());
     assertThat(contentAsString(redirectResult)).contains("updated name");
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -44,7 +44,7 @@ public class ProgramDefinitionTest {
             .addBlockDefinition(blockA)
             .build();
 
-    assertThat(program.getBlockDefinition(0)).hasValue(blockA);
+    assertThat(program.getBlockDefinitionByIndex(0)).hasValue(blockA);
   }
 
   @Test
@@ -56,7 +56,7 @@ public class ProgramDefinitionTest {
             .setDescription("This program is for testing.")
             .build();
 
-    assertThat(program.getBlockDefinition(0)).isEmpty();
+    assertThat(program.getBlockDefinitionByIndex(0)).isEmpty();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -188,8 +188,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     assertThat(result.hasResult()).isTrue();
     assertThat(result.getResult().blockDefinitions()).hasSize(1);
-    assertThat(result.getResult().getBlockDefinition(0).get().id()).isEqualTo(1L);
-    assertThat(result.getResult().getBlockDefinition(0).get().name()).isEqualTo("Block 1");
+    assertThat(result.getResult().getBlockDefinitionByIndex(0).get().id()).isEqualTo(1L);
+    assertThat(result.getResult().getBlockDefinitionByIndex(0).get().name()).isEqualTo("Block 1");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilderTest.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilderTest.java
@@ -36,17 +36,17 @@ public class ProgramBuilderTest extends WithPostgresContainer {
     assertThat(programDefinition.description()).isEqualTo("a new description");
 
     assertThat(programDefinition.blockDefinitions()).hasSize(3);
-    assertThat(programDefinition.getBlockDefinition(0).get().id()).isEqualTo(1L);
-    assertThat(programDefinition.getBlockDefinition(0).get().name()).isEqualTo("block 1");
-    assertThat(programDefinition.getBlockDefinition(0).get().description())
+    assertThat(programDefinition.getBlockDefinitionByIndex(0).get().id()).isEqualTo(1L);
+    assertThat(programDefinition.getBlockDefinitionByIndex(0).get().name()).isEqualTo("block 1");
+    assertThat(programDefinition.getBlockDefinitionByIndex(0).get().description())
         .isEqualTo("block 1 description");
-    assertThat(programDefinition.getBlockDefinition(1).get().id()).isEqualTo(2L);
-    assertThat(programDefinition.getBlockDefinition(1).get().name()).isEqualTo("block 2");
-    assertThat(programDefinition.getBlockDefinition(1).get().description())
+    assertThat(programDefinition.getBlockDefinitionByIndex(1).get().id()).isEqualTo(2L);
+    assertThat(programDefinition.getBlockDefinitionByIndex(1).get().name()).isEqualTo("block 2");
+    assertThat(programDefinition.getBlockDefinitionByIndex(1).get().description())
         .isEqualTo("block 2 description");
-    assertThat(programDefinition.getBlockDefinition(2).get().id()).isEqualTo(3L);
-    assertThat(programDefinition.getBlockDefinition(2).get().name()).isEqualTo("block 3");
-    assertThat(programDefinition.getBlockDefinition(2).get().description())
+    assertThat(programDefinition.getBlockDefinitionByIndex(2).get().id()).isEqualTo(3L);
+    assertThat(programDefinition.getBlockDefinitionByIndex(2).get().name()).isEqualTo("block 3");
+    assertThat(programDefinition.getBlockDefinitionByIndex(2).get().description())
         .isEqualTo("block 3 description");
   }
 
@@ -54,8 +54,8 @@ public class ProgramBuilderTest extends WithPostgresContainer {
   public void createProgramWithEmptyBlock() {
     ProgramDefinition program = ProgramBuilder.newProgram("name", "desc").buildDefinition();
 
-    assertThat(program.getBlockDefinition(0).get().name()).isEqualTo("");
-    assertThat(program.getBlockDefinition(0).get().description()).isEqualTo("");
+    assertThat(program.getBlockDefinitionByIndex(0).get().name()).isEqualTo("");
+    assertThat(program.getBlockDefinitionByIndex(0).get().description()).isEqualTo("");
   }
 
   @Test


### PR DESCRIPTION
### Description
getBlockDefinition was overloaded by two signatures, one with an int argument (index) and one with a long argument (id). Rename getting by index to distinguish two semantics. This function is only used in tests.

### Checklist
- [x] Created tests which fail without the change (if possible)
