### PR TITLE
Add tests that fail if a new QuestionType enum is added

### DIFF
--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -30,6 +30,9 @@ lazy val root = (project in file("."))
       "org.junit.jupiter" % "junit-jupiter-params" % "5.4.2" % Test,
       "com.h2database" % "h2" % "1.4.199" % Test,
 
+      // Parameterized testing
+      "pl.pragmatists" % "JUnitParams" % "1.1.0" % Test,
+
       // Testing libraries for dealing with CompletionStage...
       "org.assertj" % "assertj-core" % "3.14.0" % Test,
       "org.awaitility" % "awaitility" % "4.0.1" % Test,

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
@@ -8,6 +8,8 @@ import java.util.Locale;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import services.Path;
 import services.question.AddressQuestionDefinition;
 import services.question.NameQuestionDefinition;
@@ -16,6 +18,7 @@ import services.question.QuestionDefinitionBuilder;
 import services.question.QuestionType;
 import services.question.TextQuestionDefinition;
 import services.question.TextQuestionDefinition.TextValidationPredicates;
+import services.question.UnsupportedQuestionTypeException;
 
 public class ApplicantQuestionTest {
 
@@ -59,6 +62,16 @@ public class ApplicantQuestionTest {
   public void setUp() {
     applicant = new Applicant();
     applicantData = applicant.getApplicantData();
+  }
+
+  @ParameterizedTest
+  @EnumSource(QuestionType.class)
+  public void errorsPresenterExtendedForAllTypes(QuestionType type)
+      throws UnsupportedQuestionTypeException {
+    QuestionDefinitionBuilder builder = QuestionDefinitionBuilder.sample(type);
+    ApplicantQuestion question = new ApplicantQuestion(builder.build(), new ApplicantData());
+
+    assertThat(question.errorsPresenter().hasTypeSpecificErrors()).isFalse();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
@@ -5,11 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import java.util.Locale;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.runner.RunWith;
 import services.Path;
 import services.question.AddressQuestionDefinition;
 import services.question.NameQuestionDefinition;
@@ -20,6 +21,7 @@ import services.question.TextQuestionDefinition;
 import services.question.TextQuestionDefinition.TextValidationPredicates;
 import services.question.UnsupportedQuestionTypeException;
 
+@RunWith(JUnitParamsRunner.class)
 public class ApplicantQuestionTest {
 
   private static final TextQuestionDefinition textQuestionDefinition =
@@ -64,8 +66,8 @@ public class ApplicantQuestionTest {
     applicantData = applicant.getApplicantData();
   }
 
-  @ParameterizedTest
-  @EnumSource(QuestionType.class)
+  @Test
+  @Parameters(source = QuestionType.class)
   public void errorsPresenterExtendedForAllTypes(QuestionType type)
       throws UnsupportedQuestionTypeException {
     QuestionDefinitionBuilder builder = QuestionDefinitionBuilder.sample(type);

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
+import java.util.EnumSet;
 import java.util.Locale;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -66,14 +67,20 @@ public class ApplicantQuestionTest {
     applicantData = applicant.getApplicantData();
   }
 
+  // TODO(https://github.com/seattle-uat/civiform/issues/405): Change this to just use
+  // @Parameters(source = QuestionType.class) once RepeatedQuestionDefinition exists.
   @Test
-  @Parameters(source = QuestionType.class)
+  @Parameters(method = "types")
   public void errorsPresenterExtendedForAllTypes(QuestionType type)
       throws UnsupportedQuestionTypeException {
     QuestionDefinitionBuilder builder = QuestionDefinitionBuilder.sample(type);
     ApplicantQuestion question = new ApplicantQuestion(builder.build(), new ApplicantData());
 
     assertThat(question.errorsPresenter().hasTypeSpecificErrors()).isFalse();
+  }
+
+  private EnumSet<QuestionType> types() {
+    return EnumSet.complementOf(EnumSet.of(QuestionType.REPEATER));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -8,13 +8,15 @@ import java.util.Locale;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import services.CiviFormError;
 import services.Path;
 import services.question.AddressQuestionDefinition.AddressValidationPredicates;
 import services.question.TextQuestionDefinition.TextValidationPredicates;
 
 public class QuestionDefinitionTest {
-  QuestionDefinitionBuilder builder;
+  private QuestionDefinitionBuilder builder;
 
   @Before
   public void setup() {
@@ -28,6 +30,17 @@ public class QuestionDefinitionTest {
             .setQuestionText(ImmutableMap.of(Locale.US, "question?"))
             .setQuestionHelpText(ImmutableMap.of(Locale.US, "help text"))
             .setValidationPredicates(TextValidationPredicates.builder().setMaxLength(128).build());
+  }
+
+  @ParameterizedTest
+  @EnumSource(QuestionType.class)
+  public void allTypesContainMetadataScalars(QuestionType type)
+      throws UnsupportedQuestionTypeException {
+    QuestionDefinitionBuilder builder = QuestionDefinitionBuilder.sample(type);
+    QuestionDefinition definition = builder.build();
+
+    assertThat(definition.getScalars()).containsKey(definition.getLastUpdatedTimePath());
+    assertThat(definition.getScalars()).containsKey(definition.getProgramIdPath());
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -4,17 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.runner.RunWith;
 import services.CiviFormError;
 import services.Path;
 import services.question.AddressQuestionDefinition.AddressValidationPredicates;
 import services.question.TextQuestionDefinition.TextValidationPredicates;
 
+@RunWith(JUnitParamsRunner.class)
 public class QuestionDefinitionTest {
   private QuestionDefinitionBuilder builder;
 
@@ -32,8 +35,8 @@ public class QuestionDefinitionTest {
             .setValidationPredicates(TextValidationPredicates.builder().setMaxLength(128).build());
   }
 
-  @ParameterizedTest
-  @EnumSource(QuestionType.class)
+  @Test
+  @Parameters(method = "questionTypeParameters")
   public void allTypesContainMetadataScalars(QuestionType type)
       throws UnsupportedQuestionTypeException {
     QuestionDefinitionBuilder builder = QuestionDefinitionBuilder.sample(type);
@@ -41,6 +44,10 @@ public class QuestionDefinitionTest {
 
     assertThat(definition.getScalars()).containsKey(definition.getLastUpdatedTimePath());
     assertThat(definition.getScalars()).containsKey(definition.getProgramIdPath());
+  }
+
+  private EnumSet<QuestionType> questionTypeParameters() {
+    return EnumSet.complementOf(EnumSet.of(QuestionType.REPEATER));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -35,6 +35,8 @@ public class QuestionDefinitionTest {
             .setValidationPredicates(TextValidationPredicates.builder().setMaxLength(128).build());
   }
 
+  // TODO(https://github.com/seattle-uat/civiform/issues/405): Change this to just use
+  // @Parameters(source = QuestionType.class) once RepeatedQuestionDefinition exists.
   @Test
   @Parameters(method = "questionTypeParameters")
   public void allTypesContainMetadataScalars(QuestionType type)

--- a/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
+++ b/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
@@ -1,0 +1,33 @@
+package views.admin.question;
+
+import static j2html.TagCreator.div;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import j2html.tags.ContainerTag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import services.question.QuestionType;
+import views.admin.questions.QuestionConfig;
+import views.components.Icons;
+
+public class QuestionConfigTest {
+
+  private static final ContainerTag DEFAULT_CONFIG = div();
+
+  @ParameterizedTest
+  @EnumSource(
+      value = QuestionType.class,
+      names = {"REPEATER", "NAME"},
+      mode = EnumSource.Mode.EXCLUDE)
+  public void allHandledTypesHaveCustomConfig(QuestionType type) {
+    assertThat(QuestionConfig.buildQuestionConfig(type)).isNotEqualTo(DEFAULT_CONFIG);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = QuestionType.class,
+      names = {"REPEATER", "NAME"})
+  public void unhandledQuestionTypesDefaultToDefaultConfig(QuestionType type) {
+    assertThat(Icons.questionTypeSvg(type, 0)).isEqualTo(DEFAULT_CONFIG);
+  }
+}

--- a/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
+++ b/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
@@ -4,8 +4,9 @@ import static j2html.TagCreator.div;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import j2html.tags.ContainerTag;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import java.util.EnumSet;
+import junitparams.Parameters;
+import org.junit.Test;
 import services.question.QuestionType;
 import views.admin.questions.QuestionConfig;
 import views.components.Icons;
@@ -13,21 +14,26 @@ import views.components.Icons;
 public class QuestionConfigTest {
 
   private static final ContainerTag DEFAULT_CONFIG = div();
+  private static final EnumSet<QuestionType> TYPES_WITH_NO_CONFIG =
+      EnumSet.of(QuestionType.NAME, QuestionType.REPEATER);
 
-  @ParameterizedTest
-  @EnumSource(
-      value = QuestionType.class,
-      names = {"REPEATER", "NAME"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @Test
+  @Parameters(method = "handledTypes")
   public void allHandledTypesHaveCustomConfig(QuestionType type) {
     assertThat(QuestionConfig.buildQuestionConfig(type)).isNotEqualTo(DEFAULT_CONFIG);
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = QuestionType.class,
-      names = {"REPEATER", "NAME"})
+  private EnumSet<QuestionType> handledTypes() {
+    return EnumSet.complementOf(TYPES_WITH_NO_CONFIG);
+  }
+
+  @Test
+  @Parameters(method = "defaultTypes")
   public void unhandledQuestionTypesDefaultToDefaultConfig(QuestionType type) {
     assertThat(Icons.questionTypeSvg(type, 0)).isEqualTo(DEFAULT_CONFIG);
+  }
+
+  private EnumSet<QuestionType> defaultTypes() {
+    return TYPES_WITH_NO_CONFIG;
   }
 }

--- a/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
+++ b/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import j2html.tags.ContainerTag;
 import java.util.EnumSet;
+import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import services.question.QuestionType;
 import views.admin.questions.QuestionConfig;
-import views.components.Icons;
 
+@RunWith(JUnitParamsRunner.class)
 public class QuestionConfigTest {
 
   private static final ContainerTag DEFAULT_CONFIG = div();
@@ -30,7 +32,7 @@ public class QuestionConfigTest {
   @Test
   @Parameters(method = "defaultTypes")
   public void unhandledQuestionTypesDefaultToDefaultConfig(QuestionType type) {
-    assertThat(Icons.questionTypeSvg(type, 0)).isEqualTo(DEFAULT_CONFIG);
+    assertThat(QuestionConfig.buildQuestionConfig(type)).isEqualTo(DEFAULT_CONFIG);
   }
 
   private EnumSet<QuestionType> defaultTypes() {

--- a/universal-application-tool-0.0.1/test/views/components/IconsTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/IconsTest.java
@@ -1,0 +1,30 @@
+package views.components;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import j2html.tags.ContainerTag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import services.question.QuestionType;
+
+public class IconsTest {
+
+  private static final ContainerTag TEXT_ICON = Icons.questionTypeSvg(QuestionType.TEXT, 0);
+
+  @ParameterizedTest
+  @EnumSource(
+      value = QuestionType.class,
+      names = {"TEXT"},
+      mode = EnumSource.Mode.EXCLUDE)
+  public void allHandledTypesHaveCustomIcons(QuestionType type) {
+    assertThat(Icons.questionTypeSvg(type, 0)).isNotEqualTo(TEXT_ICON);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = QuestionType.class,
+      names = {"TEXT"})
+  public void unhandledQuestionTypesDefaultToTextIcon(QuestionType type) {
+    assertThat(Icons.questionTypeSvg(type, 0)).isEqualTo(TEXT_ICON);
+  }
+}

--- a/universal-application-tool-0.0.1/test/views/components/IconsTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/IconsTest.java
@@ -3,28 +3,34 @@ package views.components;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import j2html.tags.ContainerTag;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import java.util.EnumSet;
+import junitparams.Parameters;
+import org.junit.Test;
 import services.question.QuestionType;
 
 public class IconsTest {
 
   private static final ContainerTag TEXT_ICON = Icons.questionTypeSvg(QuestionType.TEXT, 0);
+  private static final EnumSet<QuestionType> TYPES_WITH_DEFAULT_ICON =
+      EnumSet.of(QuestionType.TEXT);
 
-  @ParameterizedTest
-  @EnumSource(
-      value = QuestionType.class,
-      names = {"TEXT"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @Test
+  @Parameters(method = "handledTypes")
   public void allHandledTypesHaveCustomIcons(QuestionType type) {
     assertThat(Icons.questionTypeSvg(type, 0)).isNotEqualTo(TEXT_ICON);
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = QuestionType.class,
-      names = {"TEXT"})
+  private EnumSet<QuestionType> handledTypes() {
+    return EnumSet.complementOf(TYPES_WITH_DEFAULT_ICON);
+  }
+
+  @Test
+  @Parameters(method = "defaultTypes")
   public void unhandledQuestionTypesDefaultToTextIcon(QuestionType type) {
     assertThat(Icons.questionTypeSvg(type, 0)).isEqualTo(TEXT_ICON);
+  }
+
+  private EnumSet<QuestionType> defaultTypes() {
+    return TYPES_WITH_DEFAULT_ICON;
   }
 }

--- a/universal-application-tool-0.0.1/test/views/components/IconsTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/IconsTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import j2html.tags.ContainerTag;
 import java.util.EnumSet;
+import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import services.question.QuestionType;
 
+@RunWith(JUnitParamsRunner.class)
 public class IconsTest {
 
   private static final ContainerTag TEXT_ICON = Icons.questionTypeSvg(QuestionType.TEXT, 0);

--- a/universal-application-tool-0.0.1/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -3,15 +3,18 @@ package views.questiontypes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import j2html.tags.Tag;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import services.question.QuestionType;
 import services.question.UnsupportedQuestionTypeException;
 
+@RunWith(JUnitParamsRunner.class)
 public class ApplicantQuestionRendererFactoryTest {
 
-  @ParameterizedTest
-  @EnumSource(QuestionType.class)
+  @Test
+  @Parameters(source = QuestionType.class)
   public void rendererExistsForAllTypes(QuestionType type) throws UnsupportedQuestionTypeException {
     ApplicantQuestionRendererFactory factory = new ApplicantQuestionRendererFactory();
 

--- a/universal-application-tool-0.0.1/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -1,0 +1,22 @@
+package views.questiontypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import j2html.tags.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import services.question.QuestionType;
+import services.question.UnsupportedQuestionTypeException;
+
+public class ApplicantQuestionRendererFactoryTest {
+
+  @ParameterizedTest
+  @EnumSource(QuestionType.class)
+  public void rendererExistsForAllTypes(QuestionType type) throws UnsupportedQuestionTypeException {
+    ApplicantQuestionRendererFactory factory = new ApplicantQuestionRendererFactory();
+
+    ApplicantQuestionRenderer renderer = factory.getSampleRenderer(type);
+
+    assertThat(renderer.render()).isInstanceOf(Tag.class);
+  }
+}

--- a/universal-application-tool-0.0.1/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -3,6 +3,7 @@ package views.questiontypes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import j2html.tags.Tag;
+import java.util.EnumSet;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
@@ -13,13 +14,19 @@ import services.question.UnsupportedQuestionTypeException;
 @RunWith(JUnitParamsRunner.class)
 public class ApplicantQuestionRendererFactoryTest {
 
+  // TODO(https://github.com/seattle-uat/civiform/issues/405): Change this to just use
+  // @Parameters(source = QuestionType.class) once RepeatedQuestionDefinition exists.
   @Test
-  @Parameters(source = QuestionType.class)
+  @Parameters(method = "types")
   public void rendererExistsForAllTypes(QuestionType type) throws UnsupportedQuestionTypeException {
     ApplicantQuestionRendererFactory factory = new ApplicantQuestionRendererFactory();
 
     ApplicantQuestionRenderer renderer = factory.getSampleRenderer(type);
 
     assertThat(renderer.render()).isInstanceOf(Tag.class);
+  }
+
+  private EnumSet<QuestionType> types() {
+    return EnumSet.complementOf(EnumSet.of(QuestionType.REPEATER));
   }
 }


### PR DESCRIPTION
### Description
Adds tests that fail if a new `QuestionType` enum is added, so that it is harder to miss files that should be changed when adding a new question type.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #581 

Sample test failure (added a NEW_TYPE enum):
![Screen Shot 2021-03-23 at 11 57 15 AM](https://user-images.githubusercontent.com/8559046/112203475-cedccc80-8bcf-11eb-8a7e-bb4a4fbbc1ac.png)
