### PR TITLE
Remove Path.parentPaths()

### DIFF
--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -5,7 +5,6 @@ import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
 
 /**
  * Represents a path into the applicant JSON data. Stored as the path to data without the JsonPath
@@ -71,24 +70,6 @@ public abstract class Path {
       return "";
     }
     return segments().get(segments().size() - 1);
-  }
-
-  /**
-   * List of JSON annotation paths for each segment of the parent path. For example, a Path of
-   * personality.favorites.color.blue would return [personality, personality.favorites,
-   * personality.favorites.color].
-   */
-  @Memoized
-  public ImmutableList<Path> parentPaths() {
-    ArrayList<Path> parentPaths = new ArrayList<>();
-    Path currentPath = parentPath();
-
-    while (!currentPath.path().isEmpty()) {
-      parentPaths.add(0, currentPath);
-      currentPath = currentPath.parentPath();
-    }
-
-    return ImmutableList.copyOf(parentPaths);
   }
 
   public abstract Builder toBuilder();

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -42,10 +42,20 @@ public abstract class Path {
    */
   public abstract ImmutableList<String> segments();
 
+  public boolean isEmpty() {
+    return segments().isEmpty();
+  }
+
   /** A single path in JSON notation, without the $. JsonPath prefix. */
   @Memoized
   public String path() {
     return JSON_JOINER.join(segments());
+  }
+
+  @Memoized
+  @Override
+  public String toString() {
+    return path();
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -120,16 +120,10 @@ public class ApplicantData {
    * @param value the value to place; values of type Map will create the equivalent JSON structure
    */
   private void put(Path path, Object value) {
-    path.parentPaths()
-        .forEach(
-            segmentPath -> {
-              if (!hasPath(segmentPath)) {
-                this.jsonData.put(
-                    segmentPath.parentPath().path(), segmentPath.keyName(), new HashMap<>());
-              }
-            });
-
-    this.jsonData.put(path.parentPath().path(), path.keyName(), value);
+    if (!hasPath(path.parentPath())) {
+      put(path.parentPath(), new HashMap<>());
+    }
+    jsonData.put(path.parentPath().toString(), path.keyName(), value);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -120,7 +120,7 @@ public class ApplicantData {
    * @param value the value to place; values of type Map will create the equivalent JSON structure
    */
   private void put(Path path, Object value) {
-    if (!hasPath(path.parentPath())) {
+    if (!path.parentPath().isEmpty() && !hasPath(path.parentPath())) {
       put(path.parentPath(), new HashMap<>());
     }
     jsonData.put(path.parentPath().toString(), path.keyName(), value);

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -73,25 +73,6 @@ public class PathTest {
   }
 
   @Test
-  public void parentPaths_emptyPath() {
-    Path path = Path.empty();
-    assertThat(path.parentPaths()).isEmpty();
-  }
-
-  @Test
-  public void parentPaths_oneSegment() {
-    Path path = Path.create("applicant");
-    assertThat(path.parentPaths()).isEmpty();
-  }
-
-  @Test
-  public void parentPaths() {
-    Path path = Path.create("animals.favorites.dog");
-    assertThat(path.parentPaths())
-        .containsExactly(Path.create("animals"), Path.create("animals.favorites"));
-  }
-
-  @Test
   public void pathBuilder() {
     Path path = Path.builder().setPath("applicant.my.path").build();
     assertThat(path.path()).isEqualTo("applicant.my.path");


### PR DESCRIPTION
The order of paths was very specific and felt dangerous to use, and it was only used in one place (ApplicantData.put) which can be done with recursion.

### Description
Path.parentPaths() is removed in favor for recursion, which is not dependent on the order of paths. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
