### PR TITLE
[WIP] Update Path to include the JsonPath start token $

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -120,7 +120,7 @@ public class ApplicantData {
    * @param value the value to place; values of type Map will create the equivalent JSON structure
    */
   private void put(Path path, Object value) {
-    if (!path.parentPath().isEmpty() && !hasPath(path.parentPath())) {
+    if (!hasPath(path.parentPath())) {
       put(path.parentPath(), new HashMap<>());
     }
     jsonData.put(path.parentPath().toString(), path.keyName(), value);

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -7,12 +7,12 @@ import org.junit.Test;
 public class PathTest {
 
   @Test
-  public void pathWithPrefix_removesOnlyPrefixAndWhitespace() {
+  public void pathWithPrefix_removesWhitespace() {
     String path = "favorite.color";
-    assertThat(Path.create("$.applicant." + path).path()).isEqualTo("applicant.favorite.color");
-    assertThat(Path.create(path).path()).isEqualTo(path);
-    assertThat(Path.create("      applicant.hello   ").path()).isEqualTo("applicant.hello");
-    assertThat(Path.create("    $.applicant  ").path()).isEqualTo("applicant");
+    assertThat(Path.create("$.applicant." + path).path()).isEqualTo("$.applicant.favorite.color");
+    assertThat(Path.create(path).path()).isEqualTo("$." + path);
+    assertThat(Path.create("      applicant.hello   ").path()).isEqualTo("$.applicant.hello");
+    assertThat(Path.create("    $.applicant  ").path()).isEqualTo("$.applicant");
   }
 
   @Test
@@ -22,18 +22,18 @@ public class PathTest {
 
   @Test
   public void segments_emptyPath() {
-    assertThat(Path.empty().segments()).isEmpty();
+    assertThat(Path.empty().segments()).containsOnly("$");
   }
 
   @Test
   public void segments_oneSegment() {
-    assertThat(Path.create("applicant").segments()).containsExactly("applicant");
+    assertThat(Path.create("applicant").segments()).containsExactly("$", "applicant");
   }
 
   @Test
   public void segments() {
     Path path = Path.create("my.super.long.path");
-    assertThat(path.segments()).containsExactly("my", "super", "long", "path");
+    assertThat(path.segments()).containsExactly("$", "my", "super", "long", "path");
   }
 
   @Test
@@ -45,7 +45,7 @@ public class PathTest {
   @Test
   public void parentPath_oneSegment() {
     Path path = Path.create("applicant");
-    assertThat(path.parentPath()).isEqualTo(Path.create(""));
+    assertThat(path.parentPath()).isEqualTo(Path.create("$"));
   }
 
   @Test
@@ -57,7 +57,7 @@ public class PathTest {
   @Test
   public void keyName_emptyPath() {
     Path path = Path.empty();
-    assertThat(path.keyName()).isEqualTo("");
+    assertThat(path.keyName()).isEqualTo("$");
   }
 
   @Test
@@ -75,15 +75,15 @@ public class PathTest {
   @Test
   public void pathBuilder() {
     Path path = Path.builder().setPath("applicant.my.path").build();
-    assertThat(path.path()).isEqualTo("applicant.my.path");
+    assertThat(path.path()).isEqualTo("$.applicant.my.path");
 
     path = path.toBuilder().append("another").build();
-    assertThat(path.path()).isEqualTo("applicant.my.path.another");
+    assertThat(path.path()).isEqualTo("$.applicant.my.path.another");
 
     path = path.toBuilder().append("part").build();
-    assertThat(path.path()).isEqualTo("applicant.my.path.another.part");
+    assertThat(path.path()).isEqualTo("$.applicant.my.path.another.part");
 
     path = path.toBuilder().setPath("something.new").build();
-    assertThat(path.path()).isEqualTo("something.new");
+    assertThat(path.path()).isEqualTo("$.something.new");
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -79,6 +79,16 @@ public class ApplicantDataTest {
   }
 
   @Test
+  public void putAtRoot() {
+    ApplicantData data = new ApplicantData();
+
+    data.putString(Path.create("root"), "tree");
+
+    assertThat(data.asJsonString())
+        .isEqualTo("{\"applicant\":{},\"metadata\":{},\"root\":\"tree\"}");
+  }
+
+  @Test
   public void putLong_addsAScalar() {
     ApplicantData data = new ApplicantData();
 


### PR DESCRIPTION
### Description
1. Enforce all that all `Path` objects start with `$` (the JsonPath start token)
2. Update `put` on `ApplicantData` to allow putting values at root - JsonPath does not like `put("", "key", "value")` but will work for `put("$", "key", "value")`

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
