### PR TITLE
Allow adding paths that do not begin  with applicant

### DIFF
--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -12,8 +12,9 @@ import com.google.common.collect.ImmutableList;
  */
 @AutoValue
 public abstract class Path {
+  public static final String JSON_PATH_START_TOKEN = "$";
   private static final char JSON_PATH_DIVIDER = '.';
-  private static final String JSON_PATH_START = "$" + JSON_PATH_DIVIDER;
+  private static final String JSON_PATH_START = JSON_PATH_START_TOKEN + JSON_PATH_DIVIDER;
   private static final Splitter JSON_SPLITTER = Splitter.on(JSON_PATH_DIVIDER);
   private static final Joiner JSON_JOINER = Joiner.on(JSON_PATH_DIVIDER);
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -120,6 +120,10 @@ public class ApplicantData {
    * @param value the value to place; values of type Map will create the equivalent JSON structure
    */
   private void put(Path path, Object value) {
+    if (path.parentPath().isEmpty()) {
+      jsonData.put(Path.JSON_PATH_START_TOKEN, path.keyName(), value);
+      return;
+    }
     if (!hasPath(path.parentPath())) {
       put(path.parentPath(), new HashMap<>());
     }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -79,6 +79,27 @@ public class ApplicantDataTest {
   }
 
   @Test
+  public void putScalarAtRoot() {
+    ApplicantData data = new ApplicantData();
+
+    data.putString(Path.create("root"), "value");
+
+    assertThat(data.asJsonString())
+        .isEqualTo("{\"applicant\":{},\"metadata\":{},\"root\":\"value\"}");
+  }
+
+  @Test
+  public void putNestedPathAtRoot() {
+    ApplicantData data = new ApplicantData();
+
+    data.putString(Path.create("new.path.at.root"), "hooray");
+
+    assertThat(data.asJsonString())
+        .isEqualTo(
+            "{\"applicant\":{},\"metadata\":{},\"new\":{\"path\":{\"at\":{\"root\":\"hooray\"}}}}");
+  }
+
+  @Test
   public void putLong_addsAScalar() {
     ApplicantData data = new ApplicantData();
 


### PR DESCRIPTION
### Description
`put` methods in `ApplicantData` should be able to handle paths at the JSON root

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
