### PR TITLE
Only show published programs (or in-progress ones) to applicants.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
@@ -16,7 +16,6 @@ import play.mvc.Result;
 import services.applicant.ApplicantService;
 import services.applicant.Block;
 import services.program.ProgramNotFoundException;
-import services.program.ProgramService;
 import views.applicant.ProgramIndexView;
 
 /** Controller for handling methods for an applicant applying to programs. */

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
@@ -25,7 +25,6 @@ public class ApplicantProgramsController extends Controller {
   private final HttpExecutionContext httpContext;
   private final ApplicantService applicantService;
   private final MessagesApi messagesApi;
-  private final ProgramService programService;
   private final ProgramIndexView programIndexView;
 
   @Inject
@@ -33,19 +32,17 @@ public class ApplicantProgramsController extends Controller {
       HttpExecutionContext httpContext,
       ApplicantService applicantService,
       MessagesApi messagesApi,
-      ProgramService programService,
       ProgramIndexView programIndexView) {
     this.httpContext = httpContext;
     this.applicantService = applicantService;
     this.messagesApi = checkNotNull(messagesApi);
-    this.programService = checkNotNull(programService);
     this.programIndexView = checkNotNull(programIndexView);
   }
 
   public CompletionStage<Result> index(Request request, long applicantId) {
     Optional<String> banner = request.flash().get("banner");
-    return programService
-        .listProgramDefinitionsAsync()
+    return applicantService
+        .relevantPrograms(applicantId)
         .thenApplyAsync(
             programs -> {
               return ok(

--- a/universal-application-tool-0.0.1/app/repository/ApplicantRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicantRepository.java
@@ -45,7 +45,8 @@ public class ApplicantRepository {
                 ebeanServer
                     .find(Program.class)
                     .alias("p")
-                    .where().or()
+                    .where()
+                    .or()
                     .eq("lifecycle_stage", LifecycleStage.ACTIVE)
                     .exists(
                         ebeanServer
@@ -54,7 +55,7 @@ public class ApplicantRepository {
                             .eq("applicant.id", id)
                             .raw("program.id = p.id")
                             .query())
-                        .endOr()
+                    .endOr()
                     .findList(),
             executionContext.current())
         .thenApplyAsync(

--- a/universal-application-tool-0.0.1/app/repository/ApplicantRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicantRepository.java
@@ -39,7 +39,11 @@ public class ApplicantRepository {
         () -> ebeanServer.find(Applicant.class).setId(id).findOneOrEmpty(), executionContext);
   }
 
-  public CompletionStage<ImmutableList<ProgramDefinition>> programsForApplicant(long id) {
+  /**
+   * Returns all programs that are appropriate to serve to an applicant - which is any active
+   * program, plus any program where they have an application in the draft stage.
+   */
+  public CompletionStage<ImmutableList<ProgramDefinition>> programsForApplicant(long applicantId) {
     return supplyAsync(
             () ->
                 ebeanServer
@@ -52,7 +56,8 @@ public class ApplicantRepository {
                         ebeanServer
                             .find(Application.class)
                             .where()
-                            .eq("applicant.id", id)
+                            .eq("applicant.id", applicantId)
+                            .eq("lifecycle_stage", LifecycleStage.DRAFT)
                             .raw("program.id = p.id")
                             .query())
                     .endOr()

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -47,5 +47,9 @@ public interface ApplicantService {
 
   String applicantName(Application application);
 
+  /**
+   * Returns all programs that are appropriate to serve to an applicant - which is any active
+   * program, plus any program where they have an application in the draft stage.
+   */
   CompletionStage<ImmutableList<ProgramDefinition>> relevantPrograms(long applicantId);
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -1,10 +1,12 @@
 package services.applicant;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.concurrent.CompletionStage;
 import models.Applicant;
 import models.Application;
 import services.ErrorAnd;
+import services.program.ProgramDefinition;
 
 /**
  * The service responsible for accessing the Applicant resource. Applicants can view program
@@ -44,4 +46,6 @@ public interface ApplicantService {
       long applicantId, long programId);
 
   String applicantName(Application application);
+
+  CompletionStage<ImmutableList<ProgramDefinition>> relevantPrograms(long applicantId);
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -2,6 +2,7 @@ package services.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.time.Clock;
@@ -156,6 +157,11 @@ public class ApplicantServiceImpl implements ApplicantService {
       log.error("Application {} does not include an applicant name.");
       return "<Anonymous Applicant>";
     }
+  }
+
+  @Override
+  public CompletionStage<ImmutableList<ProgramDefinition>> relevantPrograms(long applicantId) {
+    return applicantRepository.programsForApplicant(applicantId);
   }
 
   /** In-place update of {@link Applicant}'s data. */

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -35,6 +35,7 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
 
     addQuestionsToProgramFirstBlock(programName, "name", "color");
     addQuestionsToProgramNewBlock(programName, "address");
+    publishExistingProgram(programName);
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/app/ApplicationReviewBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicationReviewBrowserTest.java
@@ -23,6 +23,7 @@ public class ApplicationReviewBrowserTest extends BaseBrowserTest {
     addProgram(programName);
 
     addQuestionsToProgramFirstBlock(programName, "name");
+    publishExistingProgram(programName);
 
     logout();
     loginAsGuest();

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -169,9 +169,12 @@ public class BaseBrowserTest extends WithBrowser {
 
   protected void publishExistingProgram(String programName) {
     goTo(controllers.admin.routes.AdminProgramController.index());
-    browser.$("div", containingText(programName)).$("button", containingText("Publish")).first().click();
+    browser
+        .$("div", containingText(programName))
+        .$("button", containingText("Publish"))
+        .first()
+        .click();
   }
-
 
   /** Adds the questions with the given names to the first block in the given program. */
   protected void addQuestionsToProgramFirstBlock(String programName, String... questionNames) {

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -167,6 +167,12 @@ public class BaseBrowserTest extends WithBrowser {
     browser.$("a", withId("manage-questions-link")).first().click();
   }
 
+  protected void publishExistingProgram(String programName) {
+    goTo(controllers.admin.routes.AdminProgramController.index());
+    browser.$("div", containingText(programName)).$("button", containingText("Publish")).first().click();
+  }
+
+
   /** Adds the questions with the given names to the first block in the given program. */
   protected void addQuestionsToProgramFirstBlock(String programName, String... questionNames) {
     manageExistingProgramQuestions(programName);

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -10,6 +10,7 @@ import static play.test.Helpers.stubMessagesApi;
 
 import java.util.Locale;
 import models.Applicant;
+import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -42,19 +43,21 @@ public class ApplicantProgramsControllerTest extends WithPostgresContainer {
 
   @Test
   public void index_withPrograms_returnsAllPrograms() {
-    resourceCreator().insertProgram("one");
-    resourceCreator().insertProgram("two");
+    resourceCreator().insertProgram("one", LifecycleStage.ACTIVE);
+    resourceCreator().insertProgram("two", LifecycleStage.ACTIVE);
+    resourceCreator().insertProgram("three", LifecycleStage.DRAFT);
 
     Result result = controller.index(fakeRequest().build(), 1L).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("one");
     assertThat(contentAsString(result)).contains("two");
+    assertThat(contentAsString(result)).doesNotContain("three");
   }
 
   @Test
   public void index_withProgram_includesApplyButtonWithRedirect() {
-    Program program = resourceCreator().insertProgram("program");
+    Program program = resourceCreator().insertProgram("program", LifecycleStage.ACTIVE);
 
     Result result = controller.index(fakeRequest().build(), 1L).toCompletableFuture().join();
 

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -42,7 +42,7 @@ public class ApplicantProgramsControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void index_withPrograms_returnsAllPrograms() {
+  public void index_withPrograms_returnsOnlyRelevantPrograms() {
     resourceCreator().insertProgram("one", LifecycleStage.ACTIVE);
     resourceCreator().insertProgram("two", LifecycleStage.ACTIVE);
     resourceCreator().insertProgram("three", LifecycleStage.DRAFT);

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -1,6 +1,7 @@
 package support;
 
 import com.google.common.collect.ImmutableList;
+import models.LifecycleStage;
 import models.Program;
 import models.Question;
 import services.program.BlockDefinition;
@@ -45,6 +46,11 @@ public class ProgramBuilder {
 
   public ProgramBuilder withDescription(String description) {
     builder.setDescription(description);
+    return this;
+  }
+
+  public ProgramBuilder withLifecycleStage(LifecycleStage lifecycleStage) {
+    builder.setLifecycleStage(lifecycleStage);
     return this;
   }
 

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -54,7 +54,9 @@ public class ResourceCreator {
   }
 
   public Program insertProgram(String name, LifecycleStage lifecycleStage) {
-    return ProgramBuilder.newProgram(name, "description").withLifecycleStage(lifecycleStage).build();
+    return ProgramBuilder.newProgram(name, "description")
+        .withLifecycleStage(lifecycleStage)
+        .build();
   }
 
   public Program insertProgram(String name) {

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.UUID;
 import models.Applicant;
+import models.LifecycleStage;
 import models.Program;
 import models.Question;
 import play.inject.Injector;
@@ -50,6 +51,10 @@ public class ResourceCreator {
                 ImmutableMap.of(Locale.US, "question?"),
                 ImmutableMap.of(Locale.US, "help text")))
         .getResult();
+  }
+
+  public Program insertProgram(String name, LifecycleStage lifecycleStage) {
+    return ProgramBuilder.newProgram(name, "description").withLifecycleStage(lifecycleStage).build();
   }
 
   public Program insertProgram(String name) {


### PR DESCRIPTION
### Description
Adds a new query to the applicant repository (and service, as a pass-through) to show only the programs that are relevant to the user - published non-obsolete programs, and programs that are in-progress.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Related to #508.