### PR TITLE
Create `TextQuestionForm extends QuestionForm`

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -44,8 +44,8 @@ public class AdminProgramController extends CiviFormController {
   }
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public Result index() {
-    return ok(listView.render(this.service.listProgramDefinitions()));
+  public Result index(Request request) {
+    return ok(listView.render(this.service.listProgramDefinitions(), request));
   }
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
@@ -73,6 +73,29 @@ public class AdminProgramController extends CiviFormController {
       return ok(editView.render(request, program));
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
+    }
+  }
+
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  public Result publish(Request request, long id) {
+    try {
+      service.publishProgram(id);
+      return redirect(routes.AdminProgramController.index());
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    } catch (Exception e) {
+      return badRequest(e.toString());
+    }
+  }
+
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  public Result newVersionFrom(Request request, long id) {
+    try {
+      return redirect(routes.AdminProgramController.edit(service.newDraftOf(id).id()));
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    } catch (Exception e) {
+      return badRequest(e.toString());
     }
   }
 

--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -62,8 +62,10 @@ public class QuestionController extends CiviFormController {
             readOnlyService -> {
               try {
                 try {
-                  QuestionDefinition definition = questionForm.getBuilder().setVersion(1L).build();
-                  ErrorAnd<QuestionDefinition, CiviFormError> result = service.create(definition);
+                  QuestionDefinition questionDefinition =
+                      questionForm.getBuilder().setVersion(1L).build();
+                  ErrorAnd<QuestionDefinition, CiviFormError> result =
+                      service.create(questionDefinition);
                   if (result.isError()) {
                     String errorMessage = joinErrors(result.getErrors());
                     return ok(editView.renderNewQuestionForm(request, questionForm, errorMessage));
@@ -91,8 +93,8 @@ public class QuestionController extends CiviFormController {
         .thenApplyAsync(
             readOnlyService -> {
               try {
-                QuestionDefinition definition = readOnlyService.getQuestionDefinition(id);
-                return ok(editView.renderEditQuestionForm(request, definition));
+                QuestionDefinition questionDefinition = readOnlyService.getQuestionDefinition(id);
+                return ok(editView.renderEditQuestionForm(request, questionDefinition));
               } catch (QuestionNotFoundException e) {
                 return badRequest(e.toString());
               }
@@ -132,8 +134,9 @@ public class QuestionController extends CiviFormController {
     QuestionForm questionForm = form.bindFromRequest(request).get();
     try {
       try {
-        QuestionDefinition definition = questionForm.getBuilder().setId(id).setVersion(1L).build();
-        ErrorAnd<QuestionDefinition, CiviFormError> result = service.update(definition);
+        QuestionDefinition questionDefinition =
+            questionForm.getBuilder().setId(id).setVersion(1L).build();
+        ErrorAnd<QuestionDefinition, CiviFormError> result = service.update(questionDefinition);
         if (result.isError()) {
           String errorMessage = joinErrors(result.getErrors());
           return ok(editView.renderEditQuestionForm(request, id, questionForm, errorMessage));

--- a/universal-application-tool-0.0.1/app/forms/QuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/QuestionForm.java
@@ -14,7 +14,7 @@ import services.question.TranslationNotFoundException;
 public class QuestionForm {
   private String questionName;
   private String questionDescription;
-  private Path questionPath;
+  private Path questionParentPath;
   private String questionType;
   private String questionText;
   private String questionHelpText;
@@ -22,7 +22,7 @@ public class QuestionForm {
   public QuestionForm() {
     questionName = "";
     questionDescription = "";
-    questionPath = Path.empty();
+    questionParentPath = Path.empty();
     questionType = "TEXT";
     questionText = "";
     questionHelpText = "";
@@ -31,7 +31,7 @@ public class QuestionForm {
   public QuestionForm(QuestionDefinition qd) {
     questionName = qd.getName();
     questionDescription = qd.getDescription();
-    questionPath = qd.getPath();
+    questionParentPath = qd.getPath().parentPath();
     questionType = qd.getQuestionType().name();
 
     try {
@@ -63,12 +63,18 @@ public class QuestionForm {
     this.questionDescription = checkNotNull(questionDescription);
   }
 
-  public Path getQuestionPath() {
-    return questionPath;
+  public Path getQuestionParentPath() {
+    return questionParentPath;
   }
 
-  public void setQuestionPath(String questionPath) {
-    this.questionPath = Path.create(checkNotNull(questionPath));
+  public void setQuestionParentPath(String questionParentPath) {
+    this.questionParentPath = Path.create(checkNotNull(questionParentPath));
+  }
+
+  public Path getQuestionPath() {
+    String questionNameFormattedForPath =
+        questionName.replaceAll("\\s", "_").replaceAll("[^a-zA-Z_]", "");
+    return questionParentPath.join(questionNameFormattedForPath);
   }
 
   public String getQuestionType() {
@@ -102,11 +108,12 @@ public class QuestionForm {
         questionHelpText.isEmpty()
             ? ImmutableMap.of()
             : ImmutableMap.of(Locale.US, questionHelpText);
+
     QuestionDefinitionBuilder builder =
         new QuestionDefinitionBuilder()
             .setQuestionType(QuestionType.of(questionType))
             .setName(questionName)
-            .setPath(questionPath)
+            .setPath(getQuestionPath())
             .setDescription(questionDescription)
             .setQuestionText(questionTextMap)
             .setQuestionHelpText(questionHelpTextMap);

--- a/universal-application-tool-0.0.1/app/forms/TextQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/TextQuestionForm.java
@@ -19,7 +19,7 @@ public class TextQuestionForm extends QuestionForm {
   }
 
   public TextQuestionForm(TextQuestionDefinition qd) {
-    super();
+    super(qd);
     textMinLength = qd.getMinLength();
     textMaxLength = qd.getMaxLength();
   }

--- a/universal-application-tool-0.0.1/app/forms/TextQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/TextQuestionForm.java
@@ -1,0 +1,58 @@
+package forms;
+
+import java.util.OptionalInt;
+import services.question.InvalidQuestionTypeException;
+import services.question.QuestionDefinitionBuilder;
+import services.question.TextQuestionDefinition;
+
+public class TextQuestionForm extends QuestionForm {
+  private OptionalInt textMinLength;
+  private OptionalInt textMaxLength;
+
+  public TextQuestionForm() {
+    super();
+    textMinLength = OptionalInt.empty();
+    textMaxLength = OptionalInt.empty();
+    // TODO(https://github.com/seattle-uat/civiform/issues/590): Use QuestionType instead of String
+    //  for this?
+    setQuestionType("TEXT");
+  }
+
+  public TextQuestionForm(TextQuestionDefinition qd) {
+    super();
+    textMinLength = qd.getMinLength();
+    textMaxLength = qd.getMaxLength();
+  }
+
+  public OptionalInt getTextMinLength() {
+    return textMinLength;
+  }
+
+  public void setTextMinLength(int textMinLength) {
+    this.textMinLength = OptionalInt.of(textMinLength);
+  }
+
+  public OptionalInt getTextMaxLength() {
+    return textMaxLength;
+  }
+
+  public void setTextMaxLength(int textMaxLength) {
+    this.textMaxLength = OptionalInt.of(textMaxLength);
+  }
+
+  @Override
+  public QuestionDefinitionBuilder getBuilder() throws InvalidQuestionTypeException {
+    TextQuestionDefinition.TextValidationPredicates.Builder textValidationPredicatesBuilder =
+            TextQuestionDefinition.TextValidationPredicates.builder();
+
+    if (getTextMinLength().isPresent()) {
+      textValidationPredicatesBuilder.setMinLength(getTextMinLength().getAsInt());
+    }
+
+    if (getTextMaxLength().isPresent()) {
+      textValidationPredicatesBuilder.setMaxLength(getTextMaxLength().getAsInt());
+    }
+
+    return super.getBuilder().setValidationPredicates(textValidationPredicatesBuilder.build());
+  }
+}

--- a/universal-application-tool-0.0.1/app/forms/TextQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/TextQuestionForm.java
@@ -43,7 +43,7 @@ public class TextQuestionForm extends QuestionForm {
   @Override
   public QuestionDefinitionBuilder getBuilder() throws InvalidQuestionTypeException {
     TextQuestionDefinition.TextValidationPredicates.Builder textValidationPredicatesBuilder =
-            TextQuestionDefinition.TextValidationPredicates.builder();
+        TextQuestionDefinition.TextValidationPredicates.builder();
 
     if (getTextMinLength().isPresent()) {
       textValidationPredicatesBuilder.setMinLength(getTextMinLength().getAsInt());

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -46,11 +46,7 @@ public class Program extends BaseModel {
     this.name = definition.name();
     this.description = definition.description();
     this.blockDefinitions = definition.blockDefinitions();
-  }
-
-  public Program(ProgramDefinition definition, LifecycleStage lifecycleStage) {
-    this(definition);
-    this.lifecycleStage = lifecycleStage;
+    this.lifecycleStage = definition.lifecycleStage();
   }
 
   /**
@@ -60,6 +56,7 @@ public class Program extends BaseModel {
   public Program(String name, String description) {
     this.name = name;
     this.description = description;
+    this.lifecycleStage = LifecycleStage.DRAFT;
     BlockDefinition emptyBlock =
         BlockDefinition.builder()
             .setId(1L)
@@ -77,6 +74,7 @@ public class Program extends BaseModel {
     this.name = this.programDefinition.name();
     this.description = this.programDefinition.description();
     this.blockDefinitions = this.programDefinition.blockDefinitions();
+    this.lifecycleStage = this.programDefinition.lifecycleStage();
   }
 
   /** Populates {@link ProgramDefinition} from column values. */
@@ -90,6 +88,7 @@ public class Program extends BaseModel {
             .setName(this.name)
             .setDescription(this.description)
             .setBlockDefinitions(this.blockDefinitions)
+            .setLifecycleStage(this.lifecycleStage)
             .build();
   }
 
@@ -103,6 +102,8 @@ public class Program extends BaseModel {
 
   public void setLifecycleStage(LifecycleStage lifecycleStage) {
     this.lifecycleStage = lifecycleStage;
+    this.programDefinition =
+        this.programDefinition.toBuilder().setLifecycleStage(lifecycleStage).build();
   }
 
   public Long getVersion() {

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -33,8 +33,9 @@ public abstract class Path {
     return create(ImmutableList.copyOf(JSON_SPLITTER.splitToList(path)));
   }
 
-  private static Path create(ImmutableList<String> pathSegments) {
-    return new AutoValue_Path(pathSegments);
+  private static Path create(ImmutableList<String> segments) {
+    return new AutoValue_Path(
+        segments.stream().map(String::toLowerCase).collect(ImmutableList.toImmutableList()));
   }
 
   /**
@@ -48,7 +49,11 @@ public abstract class Path {
     return segments().isEmpty();
   }
 
-  /** A single path in JSON notation, without the $. JsonPath prefix. */
+  /**
+   * A single path in JSON notation, without the $. JsonPath prefix.
+   *
+   * <p>TODO: get rid of this method. Methods should use {@link Path} or {@link #toString()}.
+   */
   @Memoized
   public String path() {
     return JSON_JOINER.join(segments());
@@ -70,6 +75,15 @@ public abstract class Path {
       return Path.empty();
     }
     return Path.create(segments().subList(0, segments().size() - 1));
+  }
+
+  /**
+   * Append a segment to the path.
+   *
+   * <p>TODO: refactor things that use `toBuilder().append(seg).build()` with {@link #join(String)};
+   */
+  public Path join(String segment) {
+    return toBuilder().append(segment.toLowerCase()).build();
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -26,6 +26,9 @@ public abstract class ProgramDefinition {
   /** A human readable description of a Program. */
   public abstract String description();
 
+  /** The lifecycle stage of the Program. */
+  public abstract LifecycleStage lifecycleStage();
+
   /** The list of {@link BlockDefinition}s that make up the program. */
   public abstract ImmutableList<BlockDefinition> blockDefinitions();
 
@@ -83,10 +86,6 @@ public abstract class ProgramDefinition {
     return new Program(this);
   }
 
-  public Program toProgram(LifecycleStage lifecycleStage) {
-    return new Program(this, lifecycleStage);
-  }
-
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
@@ -101,6 +100,8 @@ public abstract class ProgramDefinition {
     public abstract Builder setBlockDefinitions(ImmutableList<BlockDefinition> blockDefinitions);
 
     public abstract Builder setExportDefinitions(ImmutableList<ExportDefinition> exportDefinitions);
+
+    public abstract Builder setLifecycleStage(LifecycleStage lifecycleStage);
 
     public abstract ImmutableList.Builder<BlockDefinition> blockDefinitionsBuilder();
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -213,4 +213,15 @@ public interface ProgramService {
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   ImmutableList<Application> getProgramApplications(long programId) throws ProgramNotFoundException;
+
+  /**
+   * Publish the draft identified by `id`. Move any programs with the same name to the "obsolete"
+   * state.
+   */
+  void publishProgram(long id) throws ProgramNotFoundException;
+
+  CompletionStage<Void> publishProgramAsync(long id);
+
+  /** Create a new draft starting from the program specified by `id`. */
+  ProgramDefinition newDraftOf(long id) throws ProgramNotFoundException;
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -116,11 +116,7 @@ public class ProgramServiceImpl implements ProgramService {
       return ErrorAnd.error(errors);
     }
     Program program =
-        programDefinition.toBuilder()
-            .setName(name)
-            .setDescription(description)
-            .build()
-            .toProgram(LifecycleStage.DRAFT);
+        programDefinition.toBuilder().setName(name).setDescription(description).build().toProgram();
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
                 programRepository.updateProgramSync(program).getProgramDefinition())
@@ -175,10 +171,7 @@ public class ProgramServiceImpl implements ProgramService {
             .build();
 
     Program program =
-        programDefinition.toBuilder()
-            .addBlockDefinition(blockDefinition)
-            .build()
-            .toProgram(LifecycleStage.DRAFT);
+        programDefinition.toBuilder().addBlockDefinition(blockDefinition).build().toProgram();
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()
@@ -348,10 +341,7 @@ public class ProgramServiceImpl implements ProgramService {
     }
 
     Program program =
-        programDefinition.toBuilder()
-            .setBlockDefinitions(newBlocks)
-            .build()
-            .toProgram(LifecycleStage.DRAFT);
+        programDefinition.toBuilder().setBlockDefinitions(newBlocks).build().toProgram();
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()
@@ -367,6 +357,37 @@ public class ProgramServiceImpl implements ProgramService {
       throw new ProgramNotFoundException(programId);
     }
     return programMaybe.get().getApplications();
+  }
+
+  @Override
+  public void publishProgram(long id) throws ProgramNotFoundException {
+    try {
+      this.publishProgramAsync(id).toCompletableFuture().join();
+    } catch (CompletionException e) {
+      if (e.getCause() instanceof ProgramNotFoundException) {
+        throw new ProgramNotFoundException(id);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public CompletionStage<Void> publishProgramAsync(long id) {
+    return programRepository
+        .lookupProgram(id)
+        .thenApplyAsync(
+            programMaybe ->
+                programMaybe.orElseThrow(
+                    () -> new RuntimeException(new ProgramNotFoundException(id))),
+            httpExecutionContext.current())
+        .thenComposeAsync(programRepository::publishProgramAsync);
+  }
+
+  @Override
+  public ProgramDefinition newDraftOf(long id) throws ProgramNotFoundException {
+    ProgramDefinition program =
+        this.getProgramDefinition(id).toBuilder().setLifecycleStage(LifecycleStage.DRAFT).build();
+    return programRepository.insertProgramSync(program.toProgram()).getProgramDefinition();
   }
 
   private int getBlockDefinitionIndex(ProgramDefinition programDefinition, Long blockDefinitionId)
@@ -395,12 +416,11 @@ public class ProgramServiceImpl implements ProgramService {
     ImmutableList<BlockDefinition> updatedBlockDefinitions =
         ImmutableList.copyOf(mutableBlockDefinitions);
 
-    // Implicitly "draft" since we are editing.
     Program program =
         programDefinition.toBuilder()
             .setBlockDefinitions(updatedBlockDefinitions)
             .build()
-            .toProgram(LifecycleStage.DRAFT);
+            .toProgram();
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -146,13 +146,7 @@ public final class QuestionEditView extends BaseHtmlView {
                 .setPlaceholderText("The description displayed in the question builder")
                 .setValue(questionForm.getQuestionDescription())
                 .getContainer(),
-            FieldWithLabel.input()
-                .setId("question-path-input")
-                .setFieldName("questionPath")
-                .setLabelText("Path")
-                .setPlaceholderText("The path used to store question data")
-                .setValue(questionForm.getQuestionPath().path())
-                .getContainer(),
+            questionParentPathSelect(),
             FieldWithLabel.textArea()
                 .setId("question-text-textarea")
                 .setFieldName("questionText")
@@ -171,6 +165,20 @@ public final class QuestionEditView extends BaseHtmlView {
 
     formTag.with(QuestionConfig.buildQuestionConfig(questionType));
     return formTag;
+  }
+
+  private DomContent questionParentPathSelect() {
+    // TODO: add repeated element paths when they exist (issue #405)
+    ImmutableList<SimpleEntry<String, String>> options =
+        ImmutableList.of(new SimpleEntry<>("Applicant", "applicant"));
+
+    return new SelectWithLabel()
+        .setId("question-parent-path-select")
+        .setFieldName("questionParentPath")
+        .setLabelText("Question parent path")
+        .setOptions(options)
+        .setValue("Applicant")
+        .getContainer();
   }
 
   private DomContent formQuestionTypeSelect(QuestionType selectedType) {

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -59,15 +59,15 @@ public final class QuestionEditView extends BaseHtmlView {
     return layout.renderFull(mainContent);
   }
 
-  public Content renderEditQuestionForm(Request request, QuestionDefinition question) {
-    QuestionForm questionForm = new QuestionForm(question);
-    QuestionType questionType = question.getQuestionType();
+  public Content renderEditQuestionForm(Request request, QuestionDefinition questionDefinition) {
+    QuestionForm questionForm = new QuestionForm(questionDefinition);
+    QuestionType questionType = questionDefinition.getQuestionType();
     String title = String.format("Edit %s question", questionType.toString().toLowerCase());
 
     ContainerTag formContent =
         buildQuestionContainer(title)
             .with(
-                buildEditQuestionForm(question.getId(), questionForm)
+                buildEditQuestionForm(questionDefinition.getId(), questionForm)
                     .with(makeCsrfTokenInputTag(request)));
     ContainerTag previewContent = buildPreviewContent(questionType);
     ContainerTag mainContent = main(formContent, previewContent);

--- a/universal-application-tool-0.0.1/app/views/components/LinkElement.java
+++ b/universal-application-tool-0.0.1/app/views/components/LinkElement.java
@@ -1,10 +1,18 @@
 package views.components;
 
 import static j2html.TagCreator.a;
+import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.form;
+import static j2html.TagCreator.input;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import j2html.TagCreator;
 import j2html.tags.ContainerTag;
+import play.filters.csrf.CSRF;
+import play.mvc.Http;
+import scala.Option;
 import views.style.BaseStyles;
 import views.style.StyleUtils;
 import views.style.Styles;
@@ -65,5 +73,21 @@ public class LinkElement {
     ContainerTag tag = Strings.isNullOrEmpty(href) ? div(text) : a(text).withHref(href);
     return tag.withCondId(!Strings.isNullOrEmpty(id), id)
         .withClasses(DEFAULT_LINK_BUTTON_STYLES, styles);
+  }
+
+  public ContainerTag asHiddenForm(Http.Request request) {
+    Preconditions.checkNotNull(href);
+    Option<CSRF.Token> csrfTokenMaybe = CSRF.getToken(request.asScala());
+    String csrfToken = "";
+    if (csrfTokenMaybe.isDefined()) {
+      csrfToken = csrfTokenMaybe.get().value();
+    }
+
+    return form(
+            input().isHidden().withValue(csrfToken).withName("csrfToken"),
+            button(TagCreator.text(text)).withType("submit"))
+        .withMethod("POST")
+        .withAction(href)
+        .withCondId(!Strings.isNullOrEmpty(id), id);
   }
 }

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -8,11 +8,13 @@ GET     /playIndex                  controllers.HomeController.playIndex()
 GET     /securePlayIndex            controllers.HomeController.securePlayIndex()
 
 # A controller for pages for an admin to create and maintain programs
-GET     /admin/programs                    controllers.admin.AdminProgramController.index
-GET     /admin/programs/new                controllers.admin.AdminProgramController.newOne(request: Request)
-GET     /admin/programs/:programId/edit    controllers.admin.AdminProgramController.edit(request: Request, programId: Long)
-POST    /admin/programs                    controllers.admin.AdminProgramController.create(request: Request)
-POST    /admin/programs/:programId         controllers.admin.AdminProgramController.update(request: Request, programId: Long)
+GET     /admin/programs                       controllers.admin.AdminProgramController.index(request: Request)
+GET     /admin/programs/new                   controllers.admin.AdminProgramController.newOne(request: Request)
+GET     /admin/programs/:programId/edit       controllers.admin.AdminProgramController.edit(request: Request, programId: Long)
+POST    /admin/programs/:programId/publish    controllers.admin.AdminProgramController.publish(request: Request, programId: Long)
+POST    /admin/programs/:programId/newVersion controllers.admin.AdminProgramController.newVersionFrom(request: Request, programId: Long)
+POST    /admin/programs                       controllers.admin.AdminProgramController.create(request: Request)
+POST    /admin/programs/:programId            controllers.admin.AdminProgramController.update(request: Request, programId: Long)
 
 # A controller for pages for an admin to create and maintain blocks for a program
 GET     /admin/programs/:programId/blocks                    controllers.admin.AdminProgramBlocksController.index(programId: Long)

--- a/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicantProgramBrowserTest.java
@@ -26,9 +26,9 @@ public class ApplicantProgramBrowserTest extends BaseBrowserTest {
 
     loginAsAdmin();
 
-    addNameQuestion("name", "applicant.name");
-    addTextQuestion("color", "applicant.color");
-    addAddressQuestion("address", "applicant.address");
+    addNameQuestion("name");
+    addTextQuestion("color");
+    addAddressQuestion("address");
 
     String programName = "Mock program";
     addProgram(programName);

--- a/universal-application-tool-0.0.1/test/app/ApplicationReviewBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ApplicationReviewBrowserTest.java
@@ -7,7 +7,6 @@ import static org.fluentlenium.core.filter.FilterConstructor.withText;
 import controllers.admin.routes;
 import org.junit.Before;
 import org.junit.Test;
-import services.WellKnownPaths;
 
 public class ApplicationReviewBrowserTest extends BaseBrowserTest {
 
@@ -17,7 +16,7 @@ public class ApplicationReviewBrowserTest extends BaseBrowserTest {
 
     loginAsAdmin();
 
-    addNameQuestion("name", WellKnownPaths.APPLICANT_NAME.path());
+    addNameQuestion("name");
 
     String programName = "Mock program";
     addProgram(programName);

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -31,6 +31,7 @@ public class BaseBrowserTest extends WithBrowser {
 
   private static final String LOCALHOST = "http://localhost:";
   protected static final String BASE_URL = LOCALHOST + play.api.test.Helpers.testServerPort();
+  private static final String APPLICANT_ROOT = "applicant";
 
   @Override
   protected Application provideApplication() {
@@ -113,23 +114,23 @@ public class BaseBrowserTest extends WithBrowser {
 
   /** Adds a test question through the admin flow. This requires the admin to be logged in. */
   protected void addQuestion(String questionName) {
-    addQuestion(questionName, questionName.replace(" ", "."), QuestionType.TEXT);
+    addQuestion(questionName, APPLICANT_ROOT, QuestionType.TEXT);
   }
 
-  protected void addTextQuestion(String questionName, String path) {
-    addQuestion(questionName, path, QuestionType.TEXT);
+  protected void addTextQuestion(String questionName) {
+    addQuestion(questionName, APPLICANT_ROOT, QuestionType.TEXT);
   }
 
-  protected void addNameQuestion(String questionName, String path) {
-    addQuestion(questionName, path, QuestionType.NAME);
+  protected void addNameQuestion(String questionName) {
+    addQuestion(questionName, APPLICANT_ROOT, QuestionType.NAME);
   }
 
-  protected void addAddressQuestion(String questionName, String path) {
-    addQuestion(questionName, path, QuestionType.ADDRESS);
+  protected void addAddressQuestion(String questionName) {
+    addQuestion(questionName, APPLICANT_ROOT, QuestionType.ADDRESS);
   }
 
   /** Adds a question through the admin flow. This requires the admin to be logged in. */
-  protected void addQuestion(String questionName, String path, QuestionType questionType) {
+  protected void addQuestion(String questionName, String parentPath, QuestionType questionType) {
     // Go to admin question index and click "Create a new question".
     goTo(controllers.admin.routes.QuestionController.index());
     browser.$(By.id("create-question-button")).first().click();
@@ -140,7 +141,7 @@ public class BaseBrowserTest extends WithBrowser {
     // Fill out the question form and click submit.
     fillInput("questionName", questionName);
     fillTextArea("questionDescription", "question description");
-    fillInput("questionPath", path);
+    selectAnOption("questionParentPath", parentPath);
     fillTextArea("questionText", "question text");
 
     // Check that the question form contains a Question Settings section.

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
@@ -30,7 +30,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
   @Test
   public void index_withNoPrograms() {
-    Result result = controller.index();
+    Result result = controller.index(Helpers.fakeRequest().build());
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
     assertThat(result.charset()).hasValue("utf-8");
@@ -42,7 +42,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     ProgramBuilder.newProgram("one").build();
     ProgramBuilder.newProgram("two").build();
 
-    Result result = controller.index();
+    Result result = controller.index(Helpers.fakeRequest().build());
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("one");
@@ -86,7 +86,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
-    Result redirectResult = controller.index();
+    Result redirectResult = controller.index(Helpers.fakeRequest().build());
     assertThat(contentAsString(redirectResult)).contains("New Program");
     assertThat(contentAsString(redirectResult)).contains("This is a new program");
   }
@@ -104,7 +104,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
-    Result redirectResult = controller.index();
+    Result redirectResult = controller.index(Helpers.fakeRequest().build());
     assertThat(contentAsString(redirectResult)).contains("Existing One");
     assertThat(contentAsString(redirectResult)).contains("New Program");
     assertThat(contentAsString(redirectResult)).contains("This is a new program");
@@ -173,7 +173,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
-    Result redirectResult = controller.index();
+    Result redirectResult = controller.index(Helpers.fakeRequest().build());
     assertThat(contentAsString(redirectResult)).contains("Create new program");
     assertThat(contentAsString(redirectResult)).doesNotContain("Existing One");
   }

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.OK;
+import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 
 import com.google.common.collect.ImmutableMap;
@@ -58,7 +59,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
   public void create_failsWithErrorMessageAndPopulatedFields() throws Exception {
     buildQuestionsList();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
-    formData.put("questionName", "name").put("questionPath", "#invalid_path!");
+    formData.put("questionName", "name").put("questionParentPath", "#invalid_path!");
     Request request = addCSRFToken(Helpers.fakeRequest().bodyForm(formData.build())).build();
     controller
         .create(request)
@@ -194,19 +195,20 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_redirectsOnSuccess() {
-    Question question = resourceCreator().insertQuestion("my.path");
+    Question question = resourceCreator().insertQuestion("my.path.name");
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "name")
         .put("questionDescription", "desc")
-        .put("questionPath", "my.path")
+        .put("questionParentPath", "my.path")
         .put("questionType", "TEXT")
         .put("questionText", "question text updated!")
         .put("questionHelpText", ":-)");
-    RequestBuilder requestBuilder = Helpers.fakeRequest().bodyForm(formData.build());
+    RequestBuilder requestBuilder = addCSRFToken(Helpers.fakeRequest().bodyForm(formData.build()));
 
     Result result = controller.update(requestBuilder.build(), question.id);
 
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.QuestionController.index().url());
     assertThat(result.flash().get("message").get()).contains("updated");
   }
@@ -215,7 +217,9 @@ public class QuestionControllerTest extends WithPostgresContainer {
   public void update_failsWithErrorMessageAndPopulatedFields() {
     Question question = resourceCreator().insertQuestion("my.path");
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
-    formData.put("questionPath", "invalid.path").put("questionText", "question text updated!");
+    formData
+        .put("questionParentPath", "invalid.path")
+        .put("questionText", "question text updated!");
     Request request = addCSRFToken(Helpers.fakeRequest().bodyForm(formData.build())).build();
 
     Result result = controller.update(request, question.id);

--- a/universal-application-tool-0.0.1/test/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/export/CsvExporterTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import models.Applicant;
+import models.LifecycleStage;
 import models.Program;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
@@ -41,6 +42,7 @@ public class CsvExporterTest {
             .setId(1L)
             .setName("fake program")
             .setDescription("fake program description")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .addExportDefinition(
                 ExportDefinition.builder()
                     .setEngine(ExportEngine.CSV)

--- a/universal-application-tool-0.0.1/test/export/PdfExporterTest.java
+++ b/universal-application-tool-0.0.1/test/export/PdfExporterTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import models.Applicant;
+import models.LifecycleStage;
 import models.Program;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDField;
@@ -35,6 +36,7 @@ public class PdfExporterTest {
             .setId(1L)
             .setName("fake program")
             .setDescription("fake program description")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .addExportDefinition(
                 ExportDefinition.builder()
                     .setEngine(ExportEngine.PDF)

--- a/universal-application-tool-0.0.1/test/forms/QuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/QuestionFormTest.java
@@ -17,7 +17,7 @@ public class QuestionFormTest {
     QuestionForm form = new QuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
-    form.setQuestionPath("my.question.path");
+    form.setQuestionParentPath("my.question.path");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
     form.setQuestionType("TEXT");
@@ -31,7 +31,7 @@ public class QuestionFormTest {
         new TextQuestionDefinition(
             1L,
             "name",
-            Path.create("my.question.path"),
+            Path.create("my.question.path.name"),
             "description",
             ImmutableMap.of(Locale.US, "What is the question text?"),
             ImmutableMap.of());

--- a/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
@@ -1,15 +1,14 @@
 package forms;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 import org.junit.Test;
 import services.Path;
 import services.question.QuestionDefinition;
 import services.question.QuestionDefinitionBuilder;
 import services.question.TextQuestionDefinition;
-
-import java.util.Locale;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TextQuestionFormTest {
 
@@ -30,14 +29,14 @@ public class TextQuestionFormTest {
     builder.setVersion(1L);
 
     TextQuestionDefinition expected =
-            new TextQuestionDefinition(
-                    1L,
-                    "name",
-                    Path.create("my.question.path"),
-                    "description",
-                    ImmutableMap.of(Locale.US, "What is the question text?"),
-                    ImmutableMap.of(),
-                    TextQuestionDefinition.TextValidationPredicates.create(4, 6));
+        new TextQuestionDefinition(
+            1L,
+            "name",
+            Path.create("my.question.path"),
+            "description",
+            ImmutableMap.of(Locale.US, "What is the question text?"),
+            ImmutableMap.of(),
+            TextQuestionDefinition.TextValidationPredicates.create(4, 6));
 
     QuestionDefinition actual = builder.build();
 

--- a/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
@@ -46,14 +46,14 @@ public class TextQuestionFormTest {
   @Test
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
     TextQuestionDefinition originalQd =
-            new TextQuestionDefinition(
-                    1L,
-                    "name",
-                    Path.create("my.question.path"),
-                    "description",
-                    ImmutableMap.of(Locale.US, "What is the question text?"),
-                    ImmutableMap.of(),
-                    TextQuestionDefinition.TextValidationPredicates.create(4, 6));
+        new TextQuestionDefinition(
+            1L,
+            "name",
+            Path.create("my.question.path"),
+            "description",
+            ImmutableMap.of(Locale.US, "What is the question text?"),
+            ImmutableMap.of(),
+            TextQuestionDefinition.TextValidationPredicates.create(4, 6));
 
     TextQuestionForm form = new TextQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
@@ -17,7 +17,7 @@ public class TextQuestionFormTest {
     TextQuestionForm form = new TextQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
-    form.setQuestionPath("my.question.path");
+    form.setQuestionParentPath("my.question.path");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
     form.setTextMinLength(4);
@@ -32,7 +32,7 @@ public class TextQuestionFormTest {
         new TextQuestionDefinition(
             1L,
             "name",
-            Path.create("my.question.path"),
+            Path.create("my.question.path.name"),
             "description",
             ImmutableMap.of(Locale.US, "What is the question text?"),
             ImmutableMap.of(),
@@ -49,7 +49,7 @@ public class TextQuestionFormTest {
         new TextQuestionDefinition(
             1L,
             "name",
-            Path.create("my.question.path"),
+            Path.create("my.question.path.name"),
             "description",
             ImmutableMap.of(Locale.US, "What is the question text?"),
             ImmutableMap.of(),

--- a/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/TextQuestionFormTest.java
@@ -42,4 +42,28 @@ public class TextQuestionFormTest {
 
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
+    TextQuestionDefinition originalQd =
+            new TextQuestionDefinition(
+                    1L,
+                    "name",
+                    Path.create("my.question.path"),
+                    "description",
+                    ImmutableMap.of(Locale.US, "What is the question text?"),
+                    ImmutableMap.of(),
+                    TextQuestionDefinition.TextValidationPredicates.create(4, 6));
+
+    TextQuestionForm form = new TextQuestionForm(originalQd);
+    QuestionDefinitionBuilder builder = form.getBuilder();
+
+    // The QuestionForm does not set version, which is needed in order to build the
+    // QuestionDefinition. How we get this value hasn't been determined.
+    builder.setVersion(1L);
+
+    QuestionDefinition actual = builder.build();
+
+    assertThat(actual).isEqualTo(originalQd);
+  }
 }

--- a/universal-application-tool-0.0.1/test/forms/TextQuestionFormText.java
+++ b/universal-application-tool-0.0.1/test/forms/TextQuestionFormText.java
@@ -1,0 +1,46 @@
+package forms;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import services.Path;
+import services.question.QuestionDefinition;
+import services.question.QuestionDefinitionBuilder;
+import services.question.TextQuestionDefinition;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TextQuestionFormTest {
+
+  @Test
+  public void getBuilder_returnsCompleteBuilder() throws Exception {
+    TextQuestionForm form = new TextQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionPath("my.question.path");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("");
+    form.setTextMinLength(4);
+    form.setTextMaxLength(6);
+    QuestionDefinitionBuilder builder = form.getBuilder();
+
+    // The QuestionForm does not set version, which is needed in order to build the
+    // QuestionDefinition. How we get this value hasn't been determined.
+    builder.setVersion(1L);
+
+    TextQuestionDefinition expected =
+            new TextQuestionDefinition(
+                    1L,
+                    "name",
+                    Path.create("my.question.path"),
+                    "description",
+                    ImmutableMap.of(Locale.US, "What is the question text?"),
+                    ImmutableMap.of(),
+                    TextQuestionDefinition.TextValidationPredicates.create(4, 6));
+
+    QuestionDefinition actual = builder.build();
+
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/universal-application-tool-0.0.1/test/models/ProgramTest.java
+++ b/universal-application-tool-0.0.1/test/models/ProgramTest.java
@@ -56,6 +56,7 @@ public class ProgramTest extends WithPostgresContainer {
             .setId(1L)
             .setName("ProgramTest")
             .setDescription("desc")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .setBlockDefinitions(ImmutableList.of(blockDefinition))
             .build();
     Program program = new Program(definition);
@@ -120,6 +121,7 @@ public class ProgramTest extends WithPostgresContainer {
             .setId(1L)
             .setName("ProgramTest")
             .setDescription("desc")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .setBlockDefinitions(ImmutableList.of(blockDefinition))
             .build();
     Program program = new Program(definition);

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Optional;
+import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,5 +73,21 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
 
     assertThat(updated.getProgramDefinition().id()).isEqualTo(existing.id);
     assertThat(updated.getProgramDefinition().name()).isEqualTo("new name");
+  }
+
+  @Test
+  public void publishProgram() {
+    Program active = resourceCreator().insertProgram("name");
+    active.setLifecycleStage(LifecycleStage.ACTIVE);
+    active.save();
+    Program draft = resourceCreator().insertProgram("name");
+    draft.setLifecycleStage(LifecycleStage.DRAFT);
+    draft.save();
+
+    repo.publishProgram(draft);
+
+    assertThat(draft.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
+    active.refresh();
+    assertThat(active.getLifecycleStage()).isEqualTo(LifecycleStage.OBSOLETE);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import models.Applicant;
+import models.LifecycleStage;
 import org.junit.Before;
 import org.junit.Test;
 import repository.WithPostgresContainer;
@@ -142,6 +143,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                 .setId(123L)
                 .setName("The Program")
                 .setDescription("This program is for testing.")
+                .setLifecycleStage(LifecycleStage.ACTIVE)
                 .build());
 
     Optional<Block> maybeBlock = subject.getBlockAfter(321L);

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
+import models.LifecycleStage;
 import org.junit.Test;
 import services.Path;
 import services.question.QuestionDefinition;
@@ -24,6 +25,7 @@ public class ProgramDefinitionTest {
         .setId(123L)
         .setName("The Program")
         .setDescription("This program is for testing.")
+        .setLifecycleStage(LifecycleStage.ACTIVE)
         .addBlockDefinition(blockA)
         .build();
   }
@@ -41,6 +43,7 @@ public class ProgramDefinitionTest {
             .setId(123L)
             .setName("The Program")
             .setDescription("This program is for testing.")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .addBlockDefinition(blockA)
             .build();
 
@@ -54,6 +57,7 @@ public class ProgramDefinitionTest {
             .setId(123L)
             .setName("The Program")
             .setDescription("This program is for testing.")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .build();
 
     assertThat(program.getBlockDefinitionByIndex(0)).isEmpty();
@@ -116,6 +120,7 @@ public class ProgramDefinitionTest {
             .setId(123L)
             .setName("The Program")
             .setDescription("This program is for testing.")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
             .addBlockDefinition(blockA)
             .addBlockDefinition(blockB)
             .build();

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -9,6 +9,7 @@ import forms.BlockForm;
 import java.util.Locale;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
@@ -694,5 +695,21 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     QuestionDefinition questionResult =
         blockResult.programQuestionDefinitions().get(0).getQuestionDefinition();
     assertThat(questionResult).isInstanceOf(NameQuestionDefinition.class);
+  }
+
+  @Test
+  public void newProgramFromExisting() throws Exception {
+    Program program = ProgramBuilder.newProgram().build();
+    program.setLifecycleStage(LifecycleStage.ACTIVE);
+    program.save();
+
+    ProgramDefinition newDraft = ps.newDraftOf(program.id);
+    assertThat(newDraft.lifecycleStage()).isEqualTo(LifecycleStage.DRAFT);
+    assertThat(program.getLifecycleStage()).isEqualTo(LifecycleStage.ACTIVE);
+    assertThat(newDraft.name()).isEqualTo(program.getProgramDefinition().name());
+    assertThat(newDraft.blockDefinitions())
+        .isEqualTo(program.getProgramDefinition().blockDefinitions());
+    assertThat(newDraft.description()).isEqualTo(program.getProgramDefinition().description());
+    assertThat(newDraft.id()).isNotEqualTo(program.getProgramDefinition().id());
   }
 }

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
@@ -129,7 +129,7 @@ public class ReadOnlyQuestionServiceImplTest {
   public void getQuestionDefinition_forInvalidPath() {
     assertThatThrownBy(() -> service.getQuestionDefinition(invalidPath))
         .isInstanceOf(InvalidPathException.class)
-        .hasMessage("Path not found: " + invalidPath.path());
+        .hasMessage("Path not found: " + invalidPath);
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -22,18 +22,12 @@ public class ProgramBuilder {
    * Creates {@link ProgramBuilder} with a new {@link Program} with an empty name and description.
    */
   public static ProgramBuilder newProgram() {
-    Program program = new Program("", "");
-    program.save();
-    return new ProgramBuilder(
-        program.getProgramDefinition().toBuilder().setBlockDefinitions(ImmutableList.of()));
+    return newProgram("");
   }
 
   /** Creates a {@link ProgramBuilder} with a new {@link Program} with an empty description. */
   public static ProgramBuilder newProgram(String name) {
-    Program program = new Program(name, "");
-    program.save();
-    return new ProgramBuilder(
-        program.getProgramDefinition().toBuilder().setBlockDefinitions(ImmutableList.of()));
+    return newProgram(name, "");
   }
 
   /** Creates a {@link ProgramBuilder} with a new {@link Program}. */


### PR DESCRIPTION
### Description
Add a new `TextQuestionForm` class that will be used to bind POST requests for creating **text** questions specifically. It's the same as a `QuestionForm`, but has additional text question-specific configurations.

More type-specific form classes to follow. In order to keep PRs small and manageable for review, this class is not currently used outside of its unit tests. That will come in following PRs.

### Checklist
- [x] Created tests which fail without the change 

### Issue(s)
Works toward #589 
