### PR TITLE
Add ability to write and read lists in ApplicantData

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -23,11 +23,11 @@ import services.WellKnownPaths;
 public class ApplicantData {
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
   private static final Locale DEFAULT_LOCALE = Locale.US;
-  private static final Joiner COMMA_JOINER = Joiner.on(',');
-  private static final Splitter COMMA_SPLITTER = Splitter.on(',');
+  private static final Joiner LIST_JOINER = Joiner.on('`');
+  private static final Splitter LIST_SPLITTER = Splitter.on('`');
 
   private Locale preferredLocale;
-  private DocumentContext jsonData;
+  private final DocumentContext jsonData;
 
   public ApplicantData() {
     this(EMPTY_APPLICANT_DATA_JSON);
@@ -114,7 +114,7 @@ public class ApplicantData {
     if (value.isEmpty()) {
       putNull(path);
     } else {
-      put(path, COMMA_JOINER.join(value));
+      put(path, LIST_JOINER.join(value));
     }
   }
 
@@ -174,7 +174,7 @@ public class ApplicantData {
     if (listAsString.isEmpty()) {
       return Optional.empty();
     }
-    return Optional.of(ImmutableList.copyOf(COMMA_SPLITTER.splitToList(listAsString.get())));
+    return Optional.of(ImmutableList.copyOf(LIST_SPLITTER.splitToList(listAsString.get())));
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -23,8 +23,9 @@ import services.WellKnownPaths;
 public class ApplicantData {
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
   private static final Locale DEFAULT_LOCALE = Locale.US;
-  private static final Joiner LIST_JOINER = Joiner.on('`');
-  private static final Splitter LIST_SPLITTER = Splitter.on('`');
+  private static final String LIST_DELIMITER = "`";
+  private static final Joiner LIST_JOINER = Joiner.on(LIST_DELIMITER);
+  private static final Splitter LIST_SPLITTER = Splitter.on(LIST_DELIMITER);
 
   private Locale preferredLocale;
   private final DocumentContext jsonData;
@@ -118,8 +119,8 @@ public class ApplicantData {
     if (value.isEmpty()) {
       putNull(path);
     } else {
-      boolean containsBacktick = value.stream().anyMatch(s -> s.contains("`"));
-      if (containsBacktick) {
+      boolean containsDelimiter = value.stream().anyMatch(s -> s.contains(LIST_DELIMITER));
+      if (containsDelimiter) {
         throw new RuntimeException("Tried to write a list that contained a disallowed character");
       }
       put(path, LIST_JOINER.join(value));

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -115,13 +115,13 @@ public class ApplicantData {
    * Writes a list of strings as a string - if the list is empty, a null value is written. Backticks
    * (`) are not allowed in any of the strings within the list.
    */
-  public void putList(Path path, ImmutableList<String> value) {
+  public void putList(Path path, ImmutableList<String> value) throws IllegalDataException {
     if (value.isEmpty()) {
       putNull(path);
     } else {
       boolean containsDelimiter = value.stream().anyMatch(s -> s.contains(LIST_DELIMITER));
       if (containsDelimiter) {
-        throw new RuntimeException("Tried to write a list that contained a disallowed character");
+        throw new IllegalDataException(path);
       }
       put(path, LIST_JOINER.join(value));
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -2,6 +2,7 @@ package services.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.jayway.jsonpath.DocumentContext;
@@ -22,6 +23,8 @@ import services.WellKnownPaths;
 public class ApplicantData {
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
   private static final Locale DEFAULT_LOCALE = Locale.US;
+  private static final Joiner COMMA_JOINER = Joiner.on(',');
+  private static final Splitter COMMA_SPLITTER = Splitter.on(',');
 
   private Locale preferredLocale;
   private DocumentContext jsonData;
@@ -107,6 +110,14 @@ public class ApplicantData {
     }
   }
 
+  public void putList(Path path, ImmutableList<String> value) {
+    if (value.isEmpty()) {
+      putNull(path);
+    } else {
+      put(path, COMMA_JOINER.join(value));
+    }
+  }
+
   private void putNull(Path path) {
     put(path, null);
   }
@@ -152,6 +163,18 @@ public class ApplicantData {
     } catch (JsonPathTypeMismatchException e) {
       return Optional.empty();
     }
+  }
+
+  /**
+   * Attempt to read a list at the given {@link Path}. Returns {@code Optional#empty} if the path
+   * does not exist or a value other than an {@link ImmutableList} of strings is found.
+   */
+  public Optional<ImmutableList<String>> readList(Path path) {
+    Optional<String> listAsString = readString(path);
+    if (listAsString.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(ImmutableList.copyOf(COMMA_SPLITTER.splitToList(listAsString.get())));
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -110,10 +110,18 @@ public class ApplicantData {
     }
   }
 
+  /**
+   * Writes a list of strings as a string - if the list is empty, a null value is written. Backticks
+   * (`) are not allowed in any of the strings within the list.
+   */
   public void putList(Path path, ImmutableList<String> value) {
     if (value.isEmpty()) {
       putNull(path);
     } else {
+      boolean containsBacktick = value.stream().anyMatch(s -> s.contains("`"));
+      if (containsBacktick) {
+        throw new RuntimeException("Tried to write a list that contained a disallowed character");
+      }
       put(path, LIST_JOINER.join(value));
     }
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/IllegalDataException.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/IllegalDataException.java
@@ -1,0 +1,9 @@
+package services.applicant;
+
+import services.Path;
+
+public class IllegalDataException extends Exception {
+  public IllegalDataException(Path path) {
+    super("Tried to write bad data at path: " + path);
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/IllegalDataException.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/IllegalDataException.java
@@ -1,9 +1,0 @@
-package services.applicant;
-
-import services.Path;
-
-public class IllegalDataException extends Exception {
-  public IllegalDataException(Path path) {
-    super("Tried to write bad data at path: " + path);
-  }
-}

--- a/universal-application-tool-0.0.1/app/services/applicant/JsonPathProvider.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/JsonPathProvider.java
@@ -1,0 +1,43 @@
+package services.applicant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import java.util.EnumSet;
+import javax.inject.Singleton;
+
+@Singleton
+public class JsonPathProvider {
+
+  private static final ParseContext JSON_PATH_PARSE_CONTEXT =
+      JsonPath.using(generateConfiguration());
+
+  /**
+   * Gets a JsonPath {@link ParseContext} that uses Jackson as the JSON provider instead of the
+   * JsonSmart default, which doesn't support all methods in {@link
+   * com.jayway.jsonpath.ReadContext}. See https://github.com/json-path/JsonPath for more
+   * information.
+   *
+   * @return a {@link ParseContext} that uses Jackson's ObjectMapper
+   */
+  public static ParseContext getJsonPath() {
+    return JSON_PATH_PARSE_CONTEXT;
+  }
+
+  private static Configuration generateConfiguration() {
+    ObjectMapper mapper =
+        new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+
+    return Configuration.builder()
+        .jsonProvider(new JacksonJsonProvider(mapper))
+        .mappingProvider(new JacksonMappingProvider(mapper))
+        .options(EnumSet.noneOf(Option.class))
+        .build();
+  }
+}

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -145,14 +145,14 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void putList_writesCommaSeparatedList() {
+  public void putList_writesListAsString() {
     ApplicantData data = new ApplicantData();
     Path path = Path.create("applicant.favorite_fruits");
 
     data.putList(path, ImmutableList.of("apple", "orange"));
 
     assertThat(data.asJsonString())
-        .isEqualTo("{\"applicant\":{\"favorite_fruits\":\"apple,orange\"},\"metadata\":{}}");
+        .isEqualTo("{\"applicant\":{\"favorite_fruits\":\"apple`orange\"},\"metadata\":{}}");
   }
 
   @Test
@@ -177,39 +177,10 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void readLong_findsCorrectValue() throws Exception {
-    String testData = "{ \"applicant\": { \"age\": 30 } }";
-    ApplicantData data = new ApplicantData(testData);
-
-    Optional<Long> found = data.readLong(Path.create("applicant.age"));
-
-    assertThat(found).hasValue(30L);
-  }
-
-  @Test
-  public void readList_findsCorrectValue() {
-    String testData = "{\"applicant\":{\"favorite_fruits\":\"apple,orange\"}}";
-    ApplicantData data = new ApplicantData(testData);
-
-    Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.favorite_fruits"));
-
-    assertThat(found).hasValue(ImmutableList.of("apple", "orange"));
-  }
-
-  @Test
   public void readString_pathNotPresent_returnsEmptyOptional() throws Exception {
     ApplicantData data = new ApplicantData();
 
     Optional<String> found = data.readString(Path.create("my.fake.path"));
-
-    assertThat(found).isEmpty();
-  }
-
-  @Test
-  public void readLong_pathNotPresent_returnsEmptyOptional() throws Exception {
-    ApplicantData data = new ApplicantData();
-
-    Optional<Long> found = data.readLong(Path.create("my.fake.path"));
 
     assertThat(found).isEmpty();
   }
@@ -225,11 +196,69 @@ public class ApplicantDataTest {
   }
 
   @Test
+  public void readLong_findsCorrectValue() throws Exception {
+    String testData = "{ \"applicant\": { \"age\": 30 } }";
+    ApplicantData data = new ApplicantData(testData);
+
+    Optional<Long> found = data.readLong(Path.create("applicant.age"));
+
+    assertThat(found).hasValue(30L);
+  }
+
+  @Test
+  public void readLong_pathNotPresent_returnsEmptyOptional() throws Exception {
+    ApplicantData data = new ApplicantData();
+
+    Optional<Long> found = data.readLong(Path.create("my.fake.path"));
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
   public void readLong_returnsEmptyWhenTypeMismatch() {
     String testData = "{ \"applicant\": { \"object\": { \"name\": \"John\" } } }";
     ApplicantData data = new ApplicantData(testData);
 
     Optional<Long> found = data.readLong(Path.create("applicant.object.name"));
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void readList_findsCorrectValue() {
+    String testData = "{\"applicant\":{\"favorite_fruits\":\"apple`orange\"}}";
+    ApplicantData data = new ApplicantData(testData);
+
+    Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.favorite_fruits"));
+
+    assertThat(found).hasValue(ImmutableList.of("apple", "orange"));
+  }
+
+  @Test
+  public void readListWithOneValue_findsCorrectValue() {
+    String testData = "{\"applicant\":{\"favorite_fruits\":\"apple\"}}";
+    ApplicantData data = new ApplicantData(testData);
+
+    Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.favorite_fruits"));
+
+    assertThat(found).hasValue(ImmutableList.of("apple"));
+  }
+
+  @Test
+  public void readList_pathNotPresent_returnsEmptyOptional() {
+    ApplicantData data = new ApplicantData();
+
+    Optional<ImmutableList<String>> found = data.readList(Path.create("not.here"));
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  public void readList_returnsEmptyWhenTypeMismatch() {
+    String testData = "{ \"applicant\": { \"object\": { \"age\": 12 } } }";
+    ApplicantData data = new ApplicantData(testData);
+
+    Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.object.name"));
 
     assertThat(found).isEmpty();
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -1,7 +1,6 @@
 package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
@@ -146,18 +145,18 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void putList_writesListAsString() throws IllegalDataException {
+  public void putList_writesJsonArray() {
     ApplicantData data = new ApplicantData();
     Path path = Path.create("applicant.favorite_fruits");
 
     data.putList(path, ImmutableList.of("apple", "orange"));
 
     assertThat(data.asJsonString())
-        .isEqualTo("{\"applicant\":{\"favorite_fruits\":\"apple`orange\"},\"metadata\":{}}");
+        .isEqualTo("{\"applicant\":{\"favorite_fruits\":[\"apple\",\"orange\"]},\"metadata\":{}}");
   }
 
   @Test
-  public void putList_writesNullIfListIsEmpty() throws IllegalDataException {
+  public void putList_writesNullIfListIsEmpty() {
     ApplicantData data = new ApplicantData();
     Path path = Path.create("applicant.favorite_fruits");
 
@@ -165,16 +164,6 @@ public class ApplicantDataTest {
 
     assertThat(data.asJsonString())
         .isEqualTo("{\"applicant\":{\"favorite_fruits\":null},\"metadata\":{}}");
-  }
-
-  @Test
-  public void putList_throwsExceptionIfStringContainsBacktick() {
-    ApplicantData data = new ApplicantData();
-    ImmutableList<String> list = ImmutableList.of("not`allowed");
-
-    assertThatThrownBy(() -> data.putList(Path.create("applicant.bad"), list))
-        .isInstanceOf(IllegalDataException.class)
-        .hasMessage("Tried to write bad data at path: applicant.bad");
   }
 
   @Test
@@ -237,7 +226,7 @@ public class ApplicantDataTest {
 
   @Test
   public void readList_findsCorrectValue() {
-    String testData = "{\"applicant\":{\"favorite_fruits\":\"apple`orange\"}}";
+    String testData = "{\"applicant\":{\"favorite_fruits\":[\"apple\",\"orange\"]}}";
     ApplicantData data = new ApplicantData(testData);
 
     Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.favorite_fruits"));
@@ -247,7 +236,7 @@ public class ApplicantDataTest {
 
   @Test
   public void readListWithOneValue_findsCorrectValue() {
-    String testData = "{\"applicant\":{\"favorite_fruits\":\"apple\"}}";
+    String testData = "{\"applicant\":{\"favorite_fruits\":[\"apple\"]}}";
     ApplicantData data = new ApplicantData(testData);
 
     Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.favorite_fruits"));

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -1,6 +1,7 @@
 package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
@@ -164,6 +165,15 @@ public class ApplicantDataTest {
 
     assertThat(data.asJsonString())
         .isEqualTo("{\"applicant\":{\"favorite_fruits\":null},\"metadata\":{}}");
+  }
+
+  @Test
+  public void putList_throwsExceptionIfStringContainsBacktick() {
+    ApplicantData data = new ApplicantData();
+    ImmutableList<String> list = ImmutableList.of("not`allowed");
+
+    assertThatThrownBy(() -> data.putList(Path.empty(), list))
+        .hasMessage("Tried to write a list that contained a disallowed character");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -146,7 +146,7 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void putList_writesListAsString() {
+  public void putList_writesListAsString() throws IllegalDataException {
     ApplicantData data = new ApplicantData();
     Path path = Path.create("applicant.favorite_fruits");
 
@@ -157,7 +157,7 @@ public class ApplicantDataTest {
   }
 
   @Test
-  public void putList_writesNullIfListIsEmpty() {
+  public void putList_writesNullIfListIsEmpty() throws IllegalDataException {
     ApplicantData data = new ApplicantData();
     Path path = Path.create("applicant.favorite_fruits");
 
@@ -172,8 +172,9 @@ public class ApplicantDataTest {
     ApplicantData data = new ApplicantData();
     ImmutableList<String> list = ImmutableList.of("not`allowed");
 
-    assertThatThrownBy(() -> data.putList(Path.empty(), list))
-        .hasMessage("Tried to write a list that contained a disallowed character");
+    assertThatThrownBy(() -> data.putList(Path.create("applicant.bad"), list))
+        .isInstanceOf(IllegalDataException.class)
+        .hasMessage("Tried to write bad data at path: applicant.bad");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -2,6 +2,7 @@ package services.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import java.time.Instant;
 import java.util.Locale;
@@ -144,6 +145,28 @@ public class ApplicantDataTest {
   }
 
   @Test
+  public void putList_writesCommaSeparatedList() {
+    ApplicantData data = new ApplicantData();
+    Path path = Path.create("applicant.favorite_fruits");
+
+    data.putList(path, ImmutableList.of("apple", "orange"));
+
+    assertThat(data.asJsonString())
+        .isEqualTo("{\"applicant\":{\"favorite_fruits\":\"apple,orange\"},\"metadata\":{}}");
+  }
+
+  @Test
+  public void putList_writesNullIfListIsEmpty() {
+    ApplicantData data = new ApplicantData();
+    Path path = Path.create("applicant.favorite_fruits");
+
+    data.putList(path, ImmutableList.of());
+
+    assertThat(data.asJsonString())
+        .isEqualTo("{\"applicant\":{\"favorite_fruits\":null},\"metadata\":{}}");
+  }
+
+  @Test
   public void readString_findsCorrectValue() throws Exception {
     String testData = "{ \"applicant\": { \"favorites\": { \"color\": \"orange\"} } }";
     ApplicantData data = new ApplicantData(testData);
@@ -161,6 +184,16 @@ public class ApplicantDataTest {
     Optional<Long> found = data.readLong(Path.create("applicant.age"));
 
     assertThat(found).hasValue(30L);
+  }
+
+  @Test
+  public void readList_findsCorrectValue() {
+    String testData = "{\"applicant\":{\"favorite_fruits\":\"apple,orange\"}}";
+    ApplicantData data = new ApplicantData(testData);
+
+    Optional<ImmutableList<String>> found = data.readList(Path.create("applicant.favorite_fruits"));
+
+    assertThat(found).hasValue(ImmutableList.of("apple", "orange"));
   }
 
   @Test


### PR DESCRIPTION
### Description
We will want the ability to record which options an applicant selected from a list of things (useful for dropdown, checkbox, etc. questions). To do this, we need the ability to write and read lists at paths.

1) Changes JsonPath's JsonProvider to Jackson, which supports `TypeRef` reading
2) Reorders tests to keep those for the same type together

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
