### PR TITLE
Enhance waiting logic for localstack

### DIFF
--- a/bin/localstack/wait
+++ b/bin/localstack/wait
@@ -1,19 +1,13 @@
 #!/bin/bash
 
-# Wait until localhost:4566 is responsive
-echo "Waiting for localstack to get set up. This may take a minute or two"
-wget -O /tmp/localstack_health_check_slkhdfsg.html -o /tmp/localstack_health_check_slkhdfsg.log http://localhost:4566/health
+start_time=$(date +%s)
+deadline=$(($start_time + 200))
 
-# Wait until all services change from 'starting' to 'running'
-HEALTHCHECK=$(</tmp/localstack_health_check_slkhdfsg.html)
-while [[ $HEALTHCHECK == *"starting"* ]]
-do
-    sleep 2
-    wget -O /tmp/localstack_health_check_slkhdfsg.html -o /tmp/localstack_health_check_slkhdfsg.log http://localhost:4566/health
-    HEALTHCHECK=$(</tmp/localstack_health_check_slkhdfsg.html)
+echo "Waiting for localstack to get set up. This may take a minute or two..."
+
+until HEALTHCHECK=$(curl --silent --fail --max-time 2 http://localhost:4566/health) && [[ $HEALTHCHECK == *'"s3": "running"'* ]]; do
+    if (( $(date +%s) > $deadline )); then
+        echo "deadline exceeded waiting for localstack start"
+        exit 1
+    fi
 done
-
-# Not needed anymore. Deletion here reduces (slight?) chance of wget write error on next 
-# startup causing false indication that status has changed from 'starting' to 'running'
-rm -f /tmp/localstack_health_check_slkhdfsg.html
-rm -f /tmp/localstack_health_check_slkhdfsg.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,39 +5,36 @@ services:
 
   localstack:
     image: localstack/localstack
+    container_name: localstack
     ports:
-      - "4566:4566"
+      - 4566:4566
     environment:
       - SERVICES=s3
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
 
   db:
     image: postgres:12.5
     restart: always
+    container_name: postgres
     ports:
       - 5432:5432
     environment:
       POSTGRES_PASSWORD: example
 
-    depends_on: [localstack]
-
   civiform:
     image: civiform
     restart: always
-    container_name: play
+    container_name: civiform
     links:
       - "db:database"
+      - "localstack"
     ports:
       - 9000:9000
     environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_SESSION_TOKEN
-      - AWS_S3_REGION=us-west-2
-      - AWS_S3_BUCKET_NAME=civiform-local-s3
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-test}
+      - AWS_S3_REGION=${AWS_S3_REGION:-us-west-2}
+      - AWS_S3_BUCKET_NAME=${AWS_S3_BUCKET_NAME:-civiform-local-s3}
       - IDCS_CLIENT_ID
       - IDCS_SECRET
       - ADFS_CLIENT_ID
@@ -48,7 +45,5 @@ services:
       - ~/.coursier:/root/.coursier
       - ~/.sbt:/root/.sbt
       - ~/.ivy:/root/.ivy2
-
-    depends_on: [localstack]
 
     command: ~run

--- a/universal-application-tool-0.0.1/conf/logback.xml
+++ b/universal-application-tool-0.0.1/conf/logback.xml
@@ -28,6 +28,7 @@
   <logger name="application" level="DEBUG" />
   <logger name="loggingfilter" level="INFO" />
   <logger name="controllers" level="INFO" />
+  <logger name="s3client" level="INFO" />
   <logger name="io.ebean" level="INFO" />
 
 


### PR DESCRIPTION
### Description
- Use `curl` instead of `wget` as `curl` is more platform-portable
- Set AWS keys to `test` if not provided for localstack to function correctly
- Minor cleanup of docker-compose file

### Checklist
- [ ] Extended the README / documentation, if necessary
