### PR TITLE
Add a knob to easily disable localstack/s3

### DIFF
--- a/bin/run-dev
+++ b/bin/run-dev
@@ -7,6 +7,13 @@ if [ -f ".secrets" ]; then
     . .secrets
 fi
 
+if [ "$DISABLE_LOCALSTACK" ]; then
+  echo "localstack is disabled, only starting civiform and db..."
+  docker-compose up db civiform
+  exit $?
+fi
+echo "Starting localstack... set environment variable DISABLE_LOCALSTACK=1 to skip"
+
 # start localstack
 docker-compose up -d localstack
 
@@ -14,7 +21,7 @@ docker-compose up -d localstack
 # otherwise other services crash
 $( dirname ${BASH_SOURCE[0]})/localstack/wait
 
-# Ensure local s3 created
+# ensure local s3 created
 $( dirname ${BASH_SOURCE[0]})/localstack/mk-s3
 
 # start everything else

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -8,8 +8,9 @@ if [ -f ".secrets" ]; then
 fi
 
 if [ "$DISABLE_LOCALSTACK" ]; then
-  echo "localstack is disabled, only starting civiform and db..."
-  docker-compose up db civiform
+  services=$(docker-compose ps --services | grep -v localstack | xargs)
+  echo "localstack is disabled, only starting $services..."
+  docker-compose up $services
   exit $?
 fi
 echo "Starting localstack... set environment variable DISABLE_LOCALSTACK=1 to skip"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     container_name: civiform
     links:
       - "db:database"
+      # comment below line and set environment variable DISABLE_LOCALSTACK=1 if you don't want localstack
       - "localstack"
     ports:
       - 9000:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,6 @@ services:
     container_name: civiform
     links:
       - "db:database"
-      # comment below line and set environment variable DISABLE_LOCALSTACK=1 if you don't want localstack
-      - "localstack"
     ports:
       - 9000:9000
     environment:

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -384,6 +384,7 @@ play.assets {
 # By convention, the default server is named `default`
 ebean.default = "models.*"
 
+aws.enable=true
+aws.local.endpoint="http://localstack:4566"
 aws.s3.region=${?AWS_S3_REGION}
 aws.s3.bucket=${?AWS_S3_BUCKET_NAME}
-aws.local.endpoint="http://localstack:4566"


### PR DESCRIPTION
### Description
Add a few settings to easily disable aws and localstack.

To disable S3 connection from civiform:
- set aws.enable to false in application.conf

To disable localstack from our docker compose
- run `bin/stop-dev`
- set environment variable 
  ```shell
  export DISABLE_LOCALSTACK=1
  ```