### PR TITLE
Fix java formatter version to 1.9

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -18,6 +18,7 @@ jobs:
           java-version: '11.0.10'
       - uses: axel-op/googlejavaformat-action@master
         with:
+          version: 1.9
           skipCommit: true
       - name: show diff
         run: git add .; git diff --exit-code HEAD


### PR DESCRIPTION
### Description
The latest version upgraded to 1.10 today and causes inconsistency between our local formatter and github actions.

