### PR TITLE
Scripts that need to be in specific directories are `pushd`ed to the right place.

### DIFF
--- a/bin/build-and-push
+++ b/bin/build-and-push
@@ -1,4 +1,5 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 set -e
 set +x
@@ -14,3 +15,5 @@ ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name 
 ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
 
 aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
+
+popd

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -1,4 +1,5 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 set -e
 set +x
@@ -6,3 +7,5 @@ set +x
 docker build -t civiform-browser-test \
   browser-test \
   -f browser-test/playwright.Dockerfile
+
+popd

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,4 +1,7 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
+
+
 echo "Making sure we're up to date with the latest formatter..."
 if ! docker pull public.ecr.aws/t1q6b4h2/civiform-formatter:latest; then
 	echo "Failed to pull - possibly some stuck credentials.  De-authenticating then retrying..."
@@ -6,8 +9,6 @@ if ! docker pull public.ecr.aws/t1q6b4h2/civiform-formatter:latest; then
 	docker pull public.ecr.aws/t1q6b4h2/civiform-formatter:latest
 fi
 
-if [ $(basename "$PWD") == "universal-application-tool-0.0.1" ]; then
-	docker run --rm -it -v "${PWD}/:/code" public.ecr.aws/t1q6b4h2/civiform-formatter:latest
-else
-	docker run --rm -it -v "${PWD}/universal-application-tool-0.0.1/:/code" public.ecr.aws/t1q6b4h2/civiform-formatter:latest
-fi
+docker run --rm -it -v "$(pwd)/universal-application-tool-0.0.1/:/code" public.ecr.aws/t1q6b4h2/civiform-formatter:latest
+
+popd

--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -2,7 +2,7 @@
 pushd $(git rev-parse --show-toplevel)
 
 # find repo root name (currently civiform), also support any names for backward and forward compatibility
-CIVIFORM_DIR=${PWD##*/}
+CIVIFORM_DIR=$(basename $(pwd))
 
 create_s3_cmd="s3api create-bucket --bucket civiform-local-s3 --region us-west-2"
 

--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -1,7 +1,8 @@
 #!/bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 # find repo root name (currently civiform), also support any names for backward and forward compatibility
-CIVIFORM_DIR=$(pwd | awk -F / '{print $(NF-2)}')
+CIVIFORM_DIR=${PWD##*/}
 
 create_s3_cmd="s3api create-bucket --bucket civiform-local-s3 --region us-west-2"
 
@@ -18,3 +19,5 @@ if ! which aws; then
 fi
 
 aws --endpoint-url=http://localhost:4566 $create_s3_cmd
+
+popd

--- a/bin/localstack/purge-s3
+++ b/bin/localstack/purge-s3
@@ -2,7 +2,7 @@
 pushd $(git rev-parse --show-toplevel)
 
 # find repo root name (currently civiform), also support any names for backward and forward compatibility
-CIVIFORM_DIR=${PWD##*/}
+CIVIFORM_DIR=$(basename $(pwd))
 
 purge_s3_cmd="s3 rm s3://civiform-local-s3/ --recursive"
 

--- a/bin/localstack/purge-s3
+++ b/bin/localstack/purge-s3
@@ -1,7 +1,8 @@
 #!/bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 # find repo root name (currently civiform), also support any names for backward and forward compatibility
-CIVIFORM_DIR=$(pwd | awk -F / '{print $(NF-2)}')
+CIVIFORM_DIR=${PWD##*/}
 
 purge_s3_cmd="s3 rm s3://civiform-local-s3/ --recursive"
 
@@ -18,3 +19,5 @@ if ! which aws; then
 fi
 
 aws --endpoint-url=http://localhost:4566 $purge_s3_cmd
+
+popd

--- a/bin/npm
+++ b/bin/npm
@@ -1,8 +1,7 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
-# find the right dir to mount.  this is a silly trick based on finding the directory this file is in,
-# moving up one dir, and printing the name of that directory.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 # allocate a tty for better test output even though not strictly needed.
-docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $DIR/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 --entrypoint npm civiform $@
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 --entrypoint npm civiform $@
 
+popd

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -1,10 +1,13 @@
 #!/bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 # run bin/pull-image
-$( dirname ${BASH_SOURCE[0]})/pull-image
+bin/pull-image
 
 if [ -f ".secrets" ]; then
   . .secrets
 fi
 
 docker-compose -f browser-test/browser-test-compose.yml up
+
+popd

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -1,7 +1,6 @@
 #!/bin/bash
 pushd $(git rev-parse --show-toplevel)
 
-# run bin/pull-image
 bin/pull-image
 
 if [ -f ".secrets" ]; then

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -1,4 +1,5 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 set -e
 set +x
@@ -11,3 +12,5 @@ docker run --ipc=host --rm -it \
   civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \
   $@
+
+popd

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -1,4 +1,5 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 set -e
 set +x
@@ -9,3 +10,5 @@ docker run \
   --network browser-test_default \
   civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh
+
+popd

--- a/bin/run-browser-tests-local
+++ b/bin/run-browser-tests-local
@@ -1,6 +1,5 @@
 #! /usr/bin/env bash
-
-pushd $(dirname ${BASH_SOURCE[0]})/../browser-test
+pushd $(git rev-parse --show-toplevel)/browser-test
 
 BASE_URL=http://localhost:9999 yarn test $@
 

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -3,7 +3,6 @@ pushd $(git rev-parse --show-toplevel)
 
 set -e
 
-# run bin/pull-image
 bin/pull-image
 
 if [ -f ".secrets" ]; then

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -1,7 +1,10 @@
 #!/bin/bash
+pushd $(git rev-parse --show-toplevel)
+
+set -e
 
 # run bin/pull-image
-$( dirname ${BASH_SOURCE[0]})/pull-image
+bin/pull-image
 
 if [ -f ".secrets" ]; then
     . .secrets
@@ -20,10 +23,12 @@ docker-compose up -d localstack
 
 # wait till localstack running
 # otherwise other services crash
-$( dirname ${BASH_SOURCE[0]})/localstack/wait
+bin/localstack/wait
 
 # ensure local s3 created
-$( dirname ${BASH_SOURCE[0]})/localstack/mk-s3
+bin/localstack/mk-s3
 
 # start everything else
 docker-compose up
+
+popd

--- a/bin/run-test
+++ b/bin/run-test
@@ -1,7 +1,10 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 # run bin/pull-image
-$( dirname ${BASH_SOURCE[0]})/pull-image
+bin/pull-image
 
 # allocate a tty for better test output even though not strictly needed.
-docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 civiform reload test
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 civiform reload test
+
+popd

--- a/bin/run-test
+++ b/bin/run-test
@@ -1,7 +1,6 @@
 #! /bin/bash
 pushd $(git rev-parse --show-toplevel)
 
-# run bin/pull-image
 bin/pull-image
 
 # allocate a tty for better test output even though not strictly needed.

--- a/bin/sbt
+++ b/bin/sbt
@@ -1,10 +1,10 @@
 #! /bin/bash
+pushd $(git rev-parse --show-toplevel)
 
 # run bin/pull-image
-$( dirname ${BASH_SOURCE[0]})/pull-image
+bin/pull-image
 
-# find the right dir to mount.  this is a silly trick based on finding the directory this file is in,
-# moving up one dir, and printing the name of that directory.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 # allocate a tty for better test output even though not strictly needed.
-docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $DIR/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 civiform $@
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 civiform $@
+
+popd

--- a/bin/sbt
+++ b/bin/sbt
@@ -1,7 +1,6 @@
 #! /bin/bash
 pushd $(git rev-parse --show-toplevel)
 
-# run bin/pull-image
 bin/pull-image
 
 # allocate a tty for better test output even though not strictly needed.

--- a/browser-test/bin/fmt
+++ b/browser-test/bin/fmt
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-
-# find absolute path to local browser-test directory
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
+pushd $(git rev-parse --show-toplevel)/browser-test
 
 # find relative path to typescript files
-FILES="$(cd $DIR; find src -name '*.ts' | xargs)"
+FILES="$(find src -name '*.ts' | xargs)"
 
 # build command to run within docker container
 CMD="cd code; tsfmt -r $FILES"
 
-docker run --rm -it -v "${DIR}/:/code" public.ecr.aws/t1q6b4h2/civiform-formatter:latest sh -c "$CMD"
+docker run --rm -it -v "$(pwd):/code" public.ecr.aws/t1q6b4h2/civiform-formatter:latest sh -c "$CMD"
+
+popd


### PR DESCRIPTION
### Description
Scripts that parsed PWD or BASH_SOURCE now use `pushd` with `git rev-parse --show-toplevel` and end with a `popd`.

A `set -e` was added to `bin/run-dev` to error early because that one has been prone to errors.

Tested by running the scripts from `universal-applicantion-tool_0.0.1/app`.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

### Approvals
ALL