### PR TITLE
Use the new Path.join method to append to a path. (#638)

### DIFF
--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -88,12 +88,7 @@ public abstract class Path {
     return Path.create(segments().subList(0, segments().size() - 1));
   }
 
-  /**
-   * Append a path to the path.
-   *
-   * <p>TODO(#638): refactor things that use `toBuilder().append(seg).build()` with {@link
-   * #join(String)};
-   */
+  /** Append a path to the path. */
   public Path join(String path) {
     Path other = Path.create(path);
     return Path.create(
@@ -179,30 +174,5 @@ public abstract class Path {
     }
     throw new IllegalStateException(
         String.format("This path %s does not reference an array element.", this));
-  }
-
-  public abstract Builder toBuilder();
-
-  public static Builder builder() {
-    return new AutoValue_Path.Builder();
-  }
-
-  @AutoValue.Builder
-  public abstract static class Builder {
-
-    abstract Builder setSegments(ImmutableList<String> segments);
-
-    public abstract ImmutableList.Builder<String> segmentsBuilder();
-
-    public abstract Path build();
-
-    public Builder setPath(String path) {
-      return setSegments(ImmutableList.copyOf(JSON_SPLITTER.splitToList(path)));
-    }
-
-    public Builder append(String segment) {
-      segmentsBuilder().add(segment.trim());
-      return this;
-    }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -315,7 +315,7 @@ public class ApplicantData {
     ImmutableList.Builder<Path> pathsRemoved = new ImmutableList.Builder<>();
     for (Map.Entry<?, ?> entry : other.entrySet()) {
       String key = entry.getKey().toString();
-      Path path = rootKey.toBuilder().append(key).build();
+      Path path = rootKey.join(key);
       if (hasPath(path)) {
         if (entry.getValue() instanceof Map) {
           // Recurse into maps.

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -210,11 +210,7 @@ public class ApplicantServiceImpl implements ApplicantService {
   }
 
   private void writeMetadataForPath(Path path, ApplicantData data, long programId) {
-    data.putLong(
-        path.toBuilder().append(QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY).build(),
-        programId);
-    data.putLong(
-        path.toBuilder().append(QuestionDefinition.METADATA_UPDATE_TIME_KEY).build(),
-        clock.millis());
+    data.putLong(path.join(QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY), programId);
+    data.putLong(path.join(QuestionDefinition.METADATA_UPDATE_TIME_KEY), clock.millis());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/AddressQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/AddressQuestionDefinition.java
@@ -107,7 +107,7 @@ public class AddressQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getStreetPath() {
-    return getPath().toBuilder().append("street").build();
+    return getPath().join("street");
   }
 
   public ScalarType getStreetType() {
@@ -115,7 +115,7 @@ public class AddressQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getCityPath() {
-    return getPath().toBuilder().append("city").build();
+    return getPath().join("city");
   }
 
   public ScalarType getCityType() {
@@ -123,7 +123,7 @@ public class AddressQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getStatePath() {
-    return getPath().toBuilder().append("state").build();
+    return getPath().join("state");
   }
 
   public ScalarType getStateType() {
@@ -131,7 +131,7 @@ public class AddressQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getZipPath() {
-    return getPath().toBuilder().append("zip").build();
+    return getPath().join("zip");
   }
 
   public ScalarType getZipType() {

--- a/universal-application-tool-0.0.1/app/services/question/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/MultiOptionQuestionDefinition.java
@@ -76,7 +76,7 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getSelectionPath() {
-    return getPath().toBuilder().append("selection").build();
+    return getPath().join("selection");
   }
 
   public abstract ScalarType getSelectionType();

--- a/universal-application-tool-0.0.1/app/services/question/NameQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/NameQuestionDefinition.java
@@ -109,7 +109,7 @@ public class NameQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getFirstNamePath() {
-    return getPath().toBuilder().append("first").build();
+    return getPath().join("first");
   }
 
   public ScalarType getFirstNameType() {
@@ -117,7 +117,7 @@ public class NameQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getMiddleNamePath() {
-    return getPath().toBuilder().append("middle").build();
+    return getPath().join("middle");
   }
 
   public ScalarType getMiddleNameType() {
@@ -125,7 +125,7 @@ public class NameQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getLastNamePath() {
-    return getPath().toBuilder().append("last").build();
+    return getPath().join("last");
   }
 
   public ScalarType getLastNameType() {

--- a/universal-application-tool-0.0.1/app/services/question/NumberQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/NumberQuestionDefinition.java
@@ -139,7 +139,7 @@ public class NumberQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getNumberPath() {
-    return getPath().toBuilder().append("number").build();
+    return getPath().join("number");
   }
 
   public ScalarType getNumberType() {

--- a/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
@@ -185,7 +185,7 @@ public abstract class QuestionDefinition {
   public abstract QuestionType getQuestionType();
 
   public Path getLastUpdatedTimePath() {
-    return getPath().toBuilder().append(METADATA_UPDATE_TIME_KEY).build();
+    return getPath().join(METADATA_UPDATE_TIME_KEY);
   }
 
   public ScalarType getLastUpdatedTimeType() {
@@ -193,7 +193,7 @@ public abstract class QuestionDefinition {
   }
 
   public Path getProgramIdPath() {
-    return getPath().toBuilder().append(METADATA_UPDATE_PROGRAM_ID_KEY).build();
+    return getPath().join(METADATA_UPDATE_PROGRAM_ID_KEY);
   }
 
   public ScalarType getProgramIdType() {

--- a/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
@@ -138,7 +138,7 @@ public class TextQuestionDefinition extends QuestionDefinition {
   }
 
   public Path getTextPath() {
-    return getPath().toBuilder().append("text").build();
+    return getPath().join("text");
   }
 
   public ScalarType getTextType() {

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -117,9 +117,7 @@ public class ApplicantProgramsControllerTest extends WithPostgresContainer {
             .withQuestion(TestQuestionBank.applicantAddress())
             .build();
     // Answer the color question
-    applicant
-        .getApplicantData()
-        .putString(colorQuestion.getPath().toBuilder().append("text").build(), "forest green");
+    applicant.getApplicantData().putString(colorQuestion.getPath().join("text"), "forest green");
     applicant.getApplicantData().putLong(colorQuestion.getLastUpdatedTimePath(), 12345L);
     applicant.getApplicantData().putLong(colorQuestion.getProgramIdPath(), 456L);
     applicant.save();

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -124,21 +124,6 @@ public class PathTest {
   }
 
   @Test
-  public void pathBuilder() {
-    Path path = Path.builder().setPath("applicant.my.path").build();
-    assertThat(path.path()).isEqualTo("applicant.my.path");
-
-    path = path.toBuilder().append("another").build();
-    assertThat(path.path()).isEqualTo("applicant.my.path.another");
-
-    path = path.toBuilder().append("part").build();
-    assertThat(path.path()).isEqualTo("applicant.my.path.another.part");
-
-    path = path.toBuilder().setPath("something.new").build();
-    assertThat(path.path()).isEqualTo("something.new");
-  }
-
-  @Test
   public void pathJoin() {
     Path path = Path.create("applicant.my.path");
     assertThat(path.path()).isEqualTo("applicant.my.path");

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -176,26 +176,24 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
   }
 
   private void answerNameQuestion(long programId) {
-    applicantData.putString(nameQuestion.getPath().toBuilder().append("first").build(), "Alice");
-    applicantData.putString(nameQuestion.getPath().toBuilder().append("middle").build(), "Middle");
-    applicantData.putString(nameQuestion.getPath().toBuilder().append("last").build(), "Last");
+    applicantData.putString(nameQuestion.getPath().join("first"), "Alice");
+    applicantData.putString(nameQuestion.getPath().join("middle"), "Middle");
+    applicantData.putString(nameQuestion.getPath().join("last"), "Last");
     applicantData.putLong(nameQuestion.getProgramIdPath(), programId);
     applicantData.putLong(nameQuestion.getLastUpdatedTimePath(), 12345L);
   }
 
   private void answerColorQuestion(long programId) {
-    applicantData.putString(colorQuestion.getPath().toBuilder().append("text").build(), "mauve");
+    applicantData.putString(colorQuestion.getPath().join("text"), "mauve");
     applicantData.putLong(colorQuestion.getProgramIdPath(), programId);
     applicantData.putLong(colorQuestion.getLastUpdatedTimePath(), 12345L);
   }
 
   private void answerAddressQuestion(long programId) {
-    applicantData.putString(
-        addressQuestion.getPath().toBuilder().append("street").build(), "123 Rhode St.");
-    applicantData.putString(
-        addressQuestion.getPath().toBuilder().append("city").build(), "Seattle");
-    applicantData.putString(addressQuestion.getPath().toBuilder().append("state").build(), "WA");
-    applicantData.putString(addressQuestion.getPath().toBuilder().append("zip").build(), "12345");
+    applicantData.putString(addressQuestion.getPath().join("street"), "123 Rhode St.");
+    applicantData.putString(addressQuestion.getPath().join("city"), "Seattle");
+    applicantData.putString(addressQuestion.getPath().join("state"), "WA");
+    applicantData.putString(addressQuestion.getPath().join("zip"), "12345");
     applicantData.putLong(addressQuestion.getProgramIdPath(), programId);
     applicantData.putLong(addressQuestion.getLastUpdatedTimePath(), 12345L);
   }


### PR DESCRIPTION
### Description
Please explain the changes you made here:

* Replaced `path.toBuilder().append(XYZ).build()` with `path.join(XYZ)`.
* All builder append usages were inside `ApplicantServiceImpl`.
* Added `pathJoin()` unit test to `PathTest`.
* Verified passing unit tests for `PathTest` & `ApplicantServiceImplTest`.
* Removed todo documentation above `Path.join()`.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Fixes #638.
