### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ RUNNING_PID
 node_modules
 bundle.js
 tailwind.css
+yarn.lock


### PR DESCRIPTION
### Description
Adds `yarn.lock` to our `.gitignore`
