### PR TITLE
Cleaned up Read Only Question Service (#651)

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
@@ -36,28 +36,6 @@ public interface ReadOnlyQuestionService {
   PathType getPathType(Path path);
 
   /**
-   * Gets the question definition for a given String path.
-   *
-   * <p>If the path is to a QUESTION, it will return that.
-   *
-   * <p>If the path is to a SCALAR, it will return the parent QuestionDefinition for that Scalar.
-   *
-   * <p>If the path is invalid it will throw an InvalidPathException.
-   */
-  QuestionDefinition getQuestionDefinition(String path) throws InvalidPathException;
-
-  /**
-   * Gets the question definition for a given {@link Path}.
-   *
-   * <p>If the path is to a QUESTION, it will return that.
-   *
-   * <p>If the path is to a SCALAR, it will return the parent QuestionDefinition for that Scalar.
-   *
-   * <p>If the path is invalid it will throw an InvalidPathException.
-   */
-  QuestionDefinition getQuestionDefinition(Path path) throws InvalidPathException;
-
-  /**
    * Gets the question definition for a ID.
    *
    * @throws QuestionNotFoundException if the question for the ID does not exist.

--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionServiceImpl.java
@@ -14,7 +14,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
   private final ImmutableMap<Path, ScalarType> scalars;
   private final ImmutableMap<Long, QuestionDefinition> questionsById;
   private final ImmutableMap<Path, QuestionDefinition> questionsByPath;
-  private final ImmutableMap<Path, QuestionDefinition> scalarParents;
 
   private Locale preferredLocale = Locale.US;
 
@@ -23,7 +22,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
     ImmutableMap.Builder<Long, QuestionDefinition> questionIdMap = ImmutableMap.builder();
     ImmutableMap.Builder<Path, QuestionDefinition> questionPathMap = ImmutableMap.builder();
     ImmutableMap.Builder<Path, ScalarType> scalarMap = ImmutableMap.builder();
-    ImmutableMap.Builder<Path, QuestionDefinition> scalarParentsMap = ImmutableMap.builder();
     for (ImmutableList<QuestionDefinition> qds :
         questions.stream()
             .collect(new GroupByKeyCollector<>(QuestionDefinition::getName))
@@ -38,7 +36,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
             .forEach(
                 entry -> {
                   scalarMap.put(entry.getKey(), entry.getValue());
-                  scalarParentsMap.put(entry.getKey(), qd);
                 });
       }
     }
@@ -48,7 +45,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
     questionsById = questionIdMap.build();
     questionsByPath = questionPathMap.build();
     scalars = scalarMap.build();
-    scalarParents = scalarParentsMap.build();
   }
 
   @Override
@@ -84,25 +80,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
       return PathType.SCALAR;
     }
     return PathType.NONE;
-  }
-
-  @Override
-  public QuestionDefinition getQuestionDefinition(String stringPath) throws InvalidPathException {
-    return getQuestionDefinition(Path.create(stringPath));
-  }
-
-  @Override
-  public QuestionDefinition getQuestionDefinition(Path path) throws InvalidPathException {
-    PathType pathType = this.getPathType(path);
-    switch (pathType) {
-      case QUESTION:
-        return questionsByPath.get(path);
-      case SCALAR:
-        return scalarParents.get(path);
-      case NONE:
-      default:
-        throw new InvalidPathException(path);
-    }
   }
 
   @Override

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
@@ -130,23 +130,6 @@ public class ReadOnlyQuestionServiceImplTest {
   }
 
   @Test
-  public void getQuestionDefinition_forInvalidPath() {
-    assertThatThrownBy(() -> service.getQuestionDefinition(invalidPath))
-        .isInstanceOf(InvalidPathException.class)
-        .hasMessage("Path not found: " + invalidPath);
-  }
-
-  @Test
-  public void getQuestionDefinition_forQuestion() throws InvalidPathException {
-    assertThat(service.getQuestionDefinition("applicant.address")).isEqualTo(addressQuestion);
-  }
-
-  @Test
-  public void getQuestionDefinition_forScalar() throws InvalidPathException {
-    assertThat(service.getQuestionDefinition("applicant.name.first")).isEqualTo(nameQuestion);
-  }
-
-  @Test
   public void getQuestionDefinition_byId() throws QuestionNotFoundException {
     assertThat(service.getQuestionDefinition(123L)).isEqualTo(nameQuestion);
   }


### PR DESCRIPTION
Cleaned up Read Only Question Service (#651)

### Description
For `ReadOnlyQuestionService.getQuestionDefinition` I removed:
* 3 test cases
* 2 methods from interface and implementation

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Notes
Before reviewing the changes, if desired I believe the `ReadOnlyQuestionService` can be further cleaned up as a few more functions are only used in test cases or just the implementation itself:
* `getAllScalars()`
* `getPathScalars()`
* `getPathType()`
* `isValid()`
* `setPreferredLocale(Locale)`
* `getPreferredLocale()`

### Issue(s)
Fixes #651
