### PR TITLE
Enable debugging in bin/run-dev.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - "db:database"
     ports:
       - 9000:9000
+      - 9999:9999
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -45,4 +46,4 @@ services:
       - ~/.sbt:/root/.sbt
       - ~/.ivy:/root/.ivy2
 
-    command: ~run
+    command: -jvm-debug "*:9999" ~run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "db:database"
     ports:
       - 9000:9000
-      - 9999:9999
+      - 8457:8457
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -46,4 +46,4 @@ services:
       - ~/.sbt:/root/.sbt
       - ~/.ivy:/root/.ivy2
 
-    command: -jvm-debug "*:9999" ~run
+    command: -jvm-debug "*:8457" ~run


### PR DESCRIPTION
### Description
Turns on listening for the debug port, but continues if no one connects to debug.  Instructions for setting up the debugger are at https://github.com/seattle-uat/civiform/wiki/Java-Debugging.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)