### PR TITLE
Remove app build in prober cron

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
-      - name: Build test app container
-        run: docker build -t civiform ./
       - name: Build browser testing container
         run: bin/build-browser-tests
       - name: Run prober test


### PR DESCRIPTION
### Description
No need to build app, prober is run against staging.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

