### PR TITLE
Ensure that deploy-prod and deploy-staging update things correctly.

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -18,13 +18,6 @@ jobs:
         run: bin/build-browser-tests
       - name: Run prober test
         run: bin/run-prober
-      # Note: this isn't quite right.  This doesn't promote
-      # to prod so much as deploy-current-head to prod.
-      # In the event that staging is running an out-of-date version,
-      # we might accidentally deploy the wrong thing.
-      # We need to fix this before going to real production - this
-      # is a disaster waiting to happen - but it's unlikely any
-      # individual day, and we'll fix it soon.
       - name: Promote to prod.
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}

--- a/bin/deploy-prod
+++ b/bin/deploy-prod
@@ -6,11 +6,19 @@ export AWS_DEFAULT_REGION=us-west-2
 REGION=us-west-2
 
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
-docker build -f prod.Dockerfile -t universal-application-tool --cache-from public.ecr.aws/t1q6b4h2/universal-application-tool:latest .
-docker tag universal-application-tool:latest public.ecr.aws/t1q6b4h2/universal-application-tool:prod
+docker pull public.ecr.aws/t1q6b4h2/universal-application-tool:latest
+docker tag public.ecr.aws/t1q6b4h2/universal-application-tool:latest public.ecr.aws/t1q6b4h2/universal-application-tool:prod
 docker push public.ecr.aws/t1q6b4h2/universal-application-tool:prod
 
 TIMESTAMP=$(date +%s)
 
 aws s3 sync ./infra s3://seattle-civiform-cftmpl/${TIMESTAMP}
 aws cloudformation update-stack --region ${REGION} --stack-name civiform --template-url  https://seattle-civiform-cftmpl.s3-${REGION}.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}, {\"ParameterKey\": \"Environment\", \"ParameterValue\": \"prod\"}]"
+
+aws cloudformation wait stack-update-complete --stack-name civiform
+
+ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSService") | .OutputValue')
+ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
+
+aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
+

--- a/bin/deploy-staging
+++ b/bin/deploy-staging
@@ -14,3 +14,10 @@ TIMESTAMP=$(date +%s)
 
 aws s3 sync ./infra s3://seattle-civiform-cftmpl/${TIMESTAMP}
 aws cloudformation update-stack --region ${REGION} --stack-name civiform-staging --template-url  https://seattle-civiform-cftmpl.s3-${REGION}.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}, {\"ParameterKey\": \"Environment\", \"ParameterValue\": \"staging\"}]"
+
+aws cloudformation wait stack-update-complete --stack-name civiform-staging
+
+ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform-staging | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSService") | .OutputValue')
+ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform-staging | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
+
+aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment


### PR DESCRIPTION
### Description

Deploy-prod marks latest as prod, rather than building from scratch.  Both deploy-prod and deploy-staging now include hupping the containers, which does not happen reliably in cloudformation.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)