### PR TITLE
Only use https.

### DIFF
--- a/bin/check-cfn-change
+++ b/bin/check-cfn-change
@@ -29,6 +29,10 @@ if aws cloudformation describe-change-set --region ${REGION}  --change-set-name 
 	sleep 5
 fi
 
+while aws cloudformation describe-change-set --region ${REGION}  --change-set-name auto-changeset-pr-$PR_NUMBER  --stack-name "$STACK" > /dev/null; do
+	sleep 5
+done
+
 aws s3 sync ./infra s3://seattle-civiform-cftmpl/${TIMESTAMP}
 
 aws cloudformation create-change-set --region ${REGION} --include-nested-stacks --stack-name "$STACK" --change-set-name auto-changeset-pr-$PR_NUMBER --template-url  https://seattle-civiform-cftmpl.s3-${REGION}.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}, {\"ParameterKey\": \"Environment\", \"ParameterValue\": \"$ENVIRONMENT\"}]"

--- a/infra/load_balancer.yaml
+++ b/infra/load_balancer.yaml
@@ -54,6 +54,21 @@ Resources:
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2
+  httpredirect:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: "HTTPS"
+            Port: 443
+            Host: "#{host}"
+            Path: "/#{path}"
+            Query: "#{query}"
+            StatusCode: "HTTP_301"
+      LoadBalancerArn: !Ref 'publiclb'
+      Port: 80
+      Protocol: HTTP
   httpslistener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:

--- a/infra/load_balancer.yaml
+++ b/infra/load_balancer.yaml
@@ -54,15 +54,6 @@ Resources:
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2
-  listener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      DefaultActions:
-        - TargetGroupArn: !Ref 'droptraffic'
-          Type: forward
-      LoadBalancerArn: !Ref 'publiclb'
-      Port: 80
-      Protocol: HTTP
   httpslistener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -100,19 +91,6 @@ Resources:
             Values:
               - '*'
       ListenerArn: !Ref 'httpslistener'
-      Priority: 1
-  lbrule:
-    Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref 'lbtarget'
-          Type: forward
-      Conditions:
-        - Field: path-pattern
-          PathPatternConfig:
-            Values:
-              - '*'
-      ListenerArn: !Ref 'listener'
       Priority: 1
   dnsrecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
### Description
Remove the http path on port 80, leaving only https on port 443.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Related to #742.