### PR TITLE
Used TestQuestionBank in Test.services where possible

### DIFF
--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -118,7 +118,8 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void stageAndUpdateIfValid_rawUpdatesContainMultiSelectAnswers_isOk() throws Exception {
-    QuestionDefinition multiSelectQuestion = TestQuestionBank.applicantPets().getQuestionDefinition();
+    QuestionDefinition multiSelectQuestion =
+        TestQuestionBank.applicantPets().getQuestionDefinition();
     createProgram(multiSelectQuestion);
 
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -32,7 +32,6 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
 
   private ApplicantServiceImpl subject;
   private ProgramService programService;
-  private QuestionDefinition questionDefinition;
   private ProgramDefinition programDefinition;
   private ApplicantRepository applicantRepository;
 
@@ -41,8 +40,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     subject = instanceOf(ApplicantServiceImpl.class);
     programService = instanceOf(ProgramServiceImpl.class);
     applicantRepository = instanceOf(ApplicantRepository.class);
-    questionDefinition = TestQuestionBank.applicantName().getQuestionDefinition();
-    createProgram(questionDefinition);
+    createProgram(TestQuestionBank.applicantName().getQuestionDefinition());
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/export/PdfMapAssistantTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/PdfMapAssistantTest.java
@@ -3,20 +3,16 @@ package services.export;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
-import models.LifecycleStage;
 import models.Question;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDField;
 import org.apache.pdfbox.pdmodel.interactive.form.PDListBox;
 import org.junit.Test;
-import services.Path;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
-import services.question.types.QuestionType;
 import support.TestQuestionBank;
 
 public class PdfMapAssistantTest {

--- a/universal-application-tool-0.0.1/test/services/export/PdfMapAssistantTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/PdfMapAssistantTest.java
@@ -17,8 +17,10 @@ import support.TestQuestionBank;
 
 public class PdfMapAssistantTest {
   public Question makeFakeQuestionWithName(String name) throws UnsupportedQuestionTypeException {
-    QuestionDefinition definition = TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
-    QuestionDefinition questionDefinition = new QuestionDefinitionBuilder(definition).setName(name).build();
+    QuestionDefinition definition =
+        TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+    QuestionDefinition questionDefinition =
+        new QuestionDefinitionBuilder(definition).setName(name).build();
     return new Question(questionDefinition);
   }
 

--- a/universal-application-tool-0.0.1/test/services/export/PdfMapAssistantTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/PdfMapAssistantTest.java
@@ -17,19 +17,12 @@ import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
+import support.TestQuestionBank;
 
 public class PdfMapAssistantTest {
   public Question makeFakeQuestionWithName(String name) throws UnsupportedQuestionTypeException {
-    QuestionDefinition questionDefinition =
-        new QuestionDefinitionBuilder()
-            .setName(name)
-            .setDescription("fake question")
-            .setQuestionText(ImmutableMap.of())
-            .setQuestionHelpText(ImmutableMap.of())
-            .setQuestionType(QuestionType.TEXT)
-            .setLifecycleStage(LifecycleStage.ACTIVE)
-            .setPath(Path.create("$.applicant.fake.path"))
-            .build();
+    QuestionDefinition definition = TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+    QuestionDefinition questionDefinition = new QuestionDefinitionBuilder(definition).setName(name).build();
     return new Question(questionDefinition);
   }
 

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -71,6 +71,11 @@ public class TestQuestionBank {
             QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
   }
 
+  public static Question applicantSatisfaction() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
+  }
+
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
@@ -168,6 +173,22 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private static Question applicantSatisfaction(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new RadioButtonQuestionDefinition(
+                    VERSION,
+                    "Applicant Satisfaction",
+                    Path.create("applicant.satisfaction"),
+                    Optional.empty(),
+                    "The applicant's overall satisfaction with something",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your satisfaction with enrollment?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    ImmutableListMultimap.of(Locale.US, "dissatisfied", Locale.US, "neutral", Locale.US, "satisfied")
+            );
+    return maybeSave(definition);
+  }
+
   private static Question maybeSave(QuestionDefinition questionDefinition) {
     Question question = new Question(questionDefinition);
     try {
@@ -190,6 +211,7 @@ public class TestQuestionBank {
     APPLICANT_FAVORITE_COLOR,
     APPLICANT_HOUSEHOLD_MEMBERS,
     APPLICANT_PETS,
-    APPLICANT_PRONOUNS
+    APPLICANT_PRONOUNS,
+    APPLICANT_SATISFACTION
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -1,5 +1,6 @@
 package support;
 
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Map;
@@ -12,11 +13,7 @@ import models.Question;
 import services.Path;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.AddressQuestionDefinition;
-import services.question.types.NameQuestionDefinition;
-import services.question.types.QuestionDefinition;
-import services.question.types.RepeaterQuestionDefinition;
-import services.question.types.TextQuestionDefinition;
+import services.question.types.*;
 
 /**
  * A cached {@link Question} bank for testing.
@@ -64,6 +61,11 @@ public class TestQuestionBank {
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
   }
 
+  public static Question applicantPets() {
+      return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_PETS, TestQuestionBank::applicantPets);
+  }
+
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
@@ -106,6 +108,22 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private static Question applicantPets(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new CheckboxQuestionDefinition(
+                    VERSION,
+                    "checkbox",
+                    Path.create("applicant.checkbox"),
+                    Optional.empty(),
+                    "description",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "question?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    ImmutableListMultimap.of(Locale.US, "cat", Locale.US, "dog")
+            );
+    return maybeSave(definition);
+  }
+
   private static Question applicantHouseholdMembers(QuestionEnum ignore) {
     QuestionDefinition definition =
         new RepeaterQuestionDefinition(
@@ -141,6 +159,7 @@ public class TestQuestionBank {
     APPLICANT_NAME,
     APPLICANT_ADDRESS,
     APPLICANT_FAVORITE_COLOR,
-    APPLICANT_HOUSEHOLD_MEMBERS
+    APPLICANT_HOUSEHOLD_MEMBERS,
+    APPLICANT_PETS
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -76,6 +76,11 @@ public class TestQuestionBank {
             QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
   }
 
+  public static Question applicantAge() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
+  }
+
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
@@ -189,6 +194,21 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private static Question applicantAge(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new NumberQuestionDefinition(
+                    VERSION,
+                    "Applicant Age",
+                    Path.create("applicant.age"),
+                    Optional.empty(),
+                    "The age of the applicant",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your age?"),
+                    ImmutableMap.of(Locale.US, "help text")
+            );
+    return maybeSave(definition);
+  }
+
   private static Question maybeSave(QuestionDefinition questionDefinition) {
     Question question = new Question(questionDefinition);
     try {
@@ -212,6 +232,7 @@ public class TestQuestionBank {
     APPLICANT_HOUSEHOLD_MEMBERS,
     APPLICANT_PETS,
     APPLICANT_PRONOUNS,
-    APPLICANT_SATISFACTION
+    APPLICANT_SATISFACTION,
+    APPLICANT_AGE
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -13,7 +13,15 @@ import models.Question;
 import services.Path;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.*;
+import services.question.types.AddressQuestionDefinition;
+import services.question.types.CheckboxQuestionDefinition;
+import services.question.types.DropdownQuestionDefinition;
+import services.question.types.NameQuestionDefinition;
+import services.question.types.NumberQuestionDefinition;
+import services.question.types.QuestionDefinition;
+import services.question.types.RadioButtonQuestionDefinition;
+import services.question.types.RepeaterQuestionDefinition;
+import services.question.types.TextQuestionDefinition;
 
 /**
  * A cached {@link Question} bank for testing.

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -51,22 +51,22 @@ public class TestQuestionBank {
 
   public static Question applicantAddress() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_ADDRESS, TestQuestionBank::applicantAddress);
+        QuestionEnum.APPLICANT_ADDRESS, TestQuestionBank::applicantAddress);
   }
 
   public static Question applicantAge() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
+        QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
   }
 
   public static Question applicantFavoriteColor() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_FAVORITE_COLOR, TestQuestionBank::applicantFavoriteColor);
+        QuestionEnum.APPLICANT_FAVORITE_COLOR, TestQuestionBank::applicantFavoriteColor);
   }
 
   public static Question applicantHouseholdMembers() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
   }
 
   public static Question applicantName() {
@@ -75,18 +75,18 @@ public class TestQuestionBank {
   }
 
   public static Question applicantPets() {
-      return questionCache.computeIfAbsent(
+    return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_PETS, TestQuestionBank::applicantPets);
   }
 
   public static Question applicantPronouns() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
+        QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
   }
 
   public static Question applicantSatisfaction() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
+        QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
   }
 
   private static Question applicantAddress(QuestionEnum ignore) {
@@ -105,16 +105,15 @@ public class TestQuestionBank {
 
   private static Question applicantAge(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new NumberQuestionDefinition(
-                    VERSION,
-                    "Applicant Age",
-                    Path.create("applicant.age"),
-                    Optional.empty(),
-                    "The age of the applicant",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your age?"),
-                    ImmutableMap.of(Locale.US, "help text")
-            );
+        new NumberQuestionDefinition(
+            VERSION,
+            "Applicant Age",
+            Path.create("applicant.age"),
+            Optional.empty(),
+            "The age of the applicant",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "What is your age?"),
+            ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
@@ -149,71 +148,69 @@ public class TestQuestionBank {
 
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new NameQuestionDefinition(
-                    VERSION,
-                    "applicant name",
-                    Path.create("applicant.name"),
-                    Optional.empty(),
-                    "name of applicant",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "what is your name?"),
-                    ImmutableMap.of(Locale.US, "help text"));
+        new NameQuestionDefinition(
+            VERSION,
+            "applicant name",
+            Path.create("applicant.name"),
+            Optional.empty(),
+            "name of applicant",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "what is your name?"),
+            ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
   private static Question applicantPets(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new CheckboxQuestionDefinition(
-                    VERSION,
-                    "checkbox",
-                    Path.create("applicant.checkbox"),
-                    Optional.empty(),
-                    "description",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "question?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    ImmutableListMultimap.of(Locale.US, "cat", Locale.US, "dog")
-            );
+        new CheckboxQuestionDefinition(
+            VERSION,
+            "checkbox",
+            Path.create("applicant.checkbox"),
+            Optional.empty(),
+            "description",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "question?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            ImmutableListMultimap.of(Locale.US, "cat", Locale.US, "dog"));
     return maybeSave(definition);
   }
 
   private static Question applicantPronouns(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new DropdownQuestionDefinition(
-                    VERSION,
-                    "applicant preferred pronouns",
-                    Path.create("applicant.preferred.pronouns"),
-                    Optional.empty(),
-                    "Allows the applicant to select a preferred pronoun",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    ImmutableListMultimap.of(
-                            Locale.US,
-                            "He / him",
-                            Locale.US,
-                            "She / her",
-                            Locale.FRANCE,
-                            "Il / lui",
-                            Locale.FRANCE,
-                            "Elle / elle")
-            );
+        new DropdownQuestionDefinition(
+            VERSION,
+            "applicant preferred pronouns",
+            Path.create("applicant.preferred.pronouns"),
+            Optional.empty(),
+            "Allows the applicant to select a preferred pronoun",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            ImmutableListMultimap.of(
+                Locale.US,
+                "He / him",
+                Locale.US,
+                "She / her",
+                Locale.FRANCE,
+                "Il / lui",
+                Locale.FRANCE,
+                "Elle / elle"));
     return maybeSave(definition);
   }
 
   private static Question applicantSatisfaction(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new RadioButtonQuestionDefinition(
-                    VERSION,
-                    "Applicant Satisfaction",
-                    Path.create("applicant.satisfaction"),
-                    Optional.empty(),
-                    "The applicant's overall satisfaction with something",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your satisfaction with enrollment?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    ImmutableListMultimap.of(Locale.US, "dissatisfied", Locale.US, "neutral", Locale.US, "satisfied")
-            );
+        new RadioButtonQuestionDefinition(
+            VERSION,
+            "Applicant Satisfaction",
+            Path.create("applicant.satisfaction"),
+            Optional.empty(),
+            "The applicant's overall satisfaction with something",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "What is your satisfaction with enrollment?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            ImmutableListMultimap.of(
+                Locale.US, "dissatisfied", Locale.US, "neutral", Locale.US, "satisfied"));
     return maybeSave(definition);
   }
 

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -66,6 +66,11 @@ public class TestQuestionBank {
         QuestionEnum.APPLICANT_PETS, TestQuestionBank::applicantPets);
   }
 
+  public static Question applicantPronouns() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
+  }
+
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
@@ -108,6 +113,21 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private static Question applicantHouseholdMembers(QuestionEnum ignore) {
+    QuestionDefinition definition =
+        new RepeaterQuestionDefinition(
+            VERSION,
+            "applicant household members",
+            Path.create("applicant.household_members[]"),
+            Optional.empty(),
+            "The applicant's household members",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "Who are your household members?"),
+            ImmutableMap.of(Locale.US, "help text"));
+
+    return maybeSave(definition);
+  }
+
   private static Question applicantPets(QuestionEnum ignore) {
     QuestionDefinition definition =
             new CheckboxQuestionDefinition(
@@ -124,18 +144,27 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private static Question applicantHouseholdMembers(QuestionEnum ignore) {
+  private static Question applicantPronouns(QuestionEnum ignore) {
     QuestionDefinition definition =
-        new RepeaterQuestionDefinition(
-            VERSION,
-            "applicant household members",
-            Path.create("applicant.household_members[]"),
-            Optional.empty(),
-            "The applicant's household members",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "Who are your household members?"),
-            ImmutableMap.of(Locale.US, "help text"));
-
+            new DropdownQuestionDefinition(
+                    VERSION,
+                    "applicant preferred pronouns",
+                    Path.create("applicant.preferred.pronouns"),
+                    Optional.empty(),
+                    "Allows the applicant to select a preferred pronoun",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    ImmutableListMultimap.of(
+                            Locale.US,
+                            "He / him",
+                            Locale.US,
+                            "She / her",
+                            Locale.FRANCE,
+                            "Il / lui",
+                            Locale.FRANCE,
+                            "Elle / elle")
+            );
     return maybeSave(definition);
   }
 
@@ -160,6 +189,7 @@ public class TestQuestionBank {
     APPLICANT_ADDRESS,
     APPLICANT_FAVORITE_COLOR,
     APPLICANT_HOUSEHOLD_MEMBERS,
-    APPLICANT_PETS
+    APPLICANT_PETS,
+    APPLICANT_PRONOUNS
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -41,24 +41,29 @@ public class TestQuestionBank {
     nextId.set(1L);
   }
 
-  public static Question applicantName() {
-    return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
-  }
-
   public static Question applicantAddress() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_ADDRESS, TestQuestionBank::applicantAddress);
+            QuestionEnum.APPLICANT_ADDRESS, TestQuestionBank::applicantAddress);
+  }
+
+  public static Question applicantAge() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
   }
 
   public static Question applicantFavoriteColor() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_FAVORITE_COLOR, TestQuestionBank::applicantFavoriteColor);
+            QuestionEnum.APPLICANT_FAVORITE_COLOR, TestQuestionBank::applicantFavoriteColor);
   }
 
   public static Question applicantHouseholdMembers() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
+            QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
+  }
+
+  public static Question applicantName() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
   }
 
   public static Question applicantPets() {
@@ -76,25 +81,6 @@ public class TestQuestionBank {
             QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
   }
 
-  public static Question applicantAge() {
-    return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
-  }
-
-  private static Question applicantName(QuestionEnum ignore) {
-    QuestionDefinition definition =
-        new NameQuestionDefinition(
-            VERSION,
-            "applicant name",
-            Path.create("applicant.name"),
-            Optional.empty(),
-            "name of applicant",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "what is your name?"),
-            ImmutableMap.of(Locale.US, "help text"));
-    return maybeSave(definition);
-  }
-
   private static Question applicantAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
@@ -106,6 +92,21 @@ public class TestQuestionBank {
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "what is your address?"),
             ImmutableMap.of(Locale.US, "help text"));
+    return maybeSave(definition);
+  }
+
+  private static Question applicantAge(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new NumberQuestionDefinition(
+                    VERSION,
+                    "Applicant Age",
+                    Path.create("applicant.age"),
+                    Optional.empty(),
+                    "The age of the applicant",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your age?"),
+                    ImmutableMap.of(Locale.US, "help text")
+            );
     return maybeSave(definition);
   }
 
@@ -135,6 +136,20 @@ public class TestQuestionBank {
             ImmutableMap.of(Locale.US, "Who are your household members?"),
             ImmutableMap.of(Locale.US, "help text"));
 
+    return maybeSave(definition);
+  }
+
+  private static Question applicantName(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new NameQuestionDefinition(
+                    VERSION,
+                    "applicant name",
+                    Path.create("applicant.name"),
+                    Optional.empty(),
+                    "name of applicant",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "what is your name?"),
+                    ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
@@ -194,21 +209,6 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private static Question applicantAge(QuestionEnum ignore) {
-    QuestionDefinition definition =
-            new NumberQuestionDefinition(
-                    VERSION,
-                    "Applicant Age",
-                    Path.create("applicant.age"),
-                    Optional.empty(),
-                    "The age of the applicant",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your age?"),
-                    ImmutableMap.of(Locale.US, "help text")
-            );
-    return maybeSave(definition);
-  }
-
   private static Question maybeSave(QuestionDefinition questionDefinition) {
     Question question = new Question(questionDefinition);
     try {
@@ -226,13 +226,13 @@ public class TestQuestionBank {
   }
 
   private enum QuestionEnum {
-    APPLICANT_NAME,
     APPLICANT_ADDRESS,
+    APPLICANT_AGE,
     APPLICANT_FAVORITE_COLOR,
     APPLICANT_HOUSEHOLD_MEMBERS,
+    APPLICANT_NAME,
     APPLICANT_PETS,
     APPLICANT_PRONOUNS,
-    APPLICANT_SATISFACTION,
-    APPLICANT_AGE
+    APPLICANT_SATISFACTION
   }
 }


### PR DESCRIPTION
### Description
Added new questions to the `TestQuestionDefinitionBank`:
* `applicantPets` a `CheckboxQuestionDefinition`
* `applicantAge` a `NumberQuestionDefinition`
* `applicantPronouns` a `DropdownQuestionDefinition`
* `applicantSatisfaction` a `RadioButtonQuestionDefinition`

Cleaned up unused imports in all modified files

Replaced `QuestionService.create` where appropriate

Shortened `QuestionDefinitionBuilder` in `PdfMapAssistantTest`

I also found `createProgram()` and `createQuestions()` redundant in `ApplicantServiceImplTest` so I removed them and added the methods they called into `setup()`


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Progress towards #484 