### PR TITLE
Do not allow us to automatically apply db DOWNs.

### DIFF
--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -306,9 +306,7 @@ play.evolutions {
   db.default {
     useLocks = true
     autoApply = true
-    # This might break something in the prod database someday.  Let's remove it once we completely agree
-    # never to require any more evolution downs.
-    autoApplyDowns = true
+    autoApplyDowns = false
   }
 }
 


### PR DESCRIPTION
### Description
Like it says in the comment - don't auto apply database downs (so we can't dump the prod db anymore).

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
