### PR TITLE
Change how path conflicts are caught, and add repeater id and path to question invariants.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -68,14 +68,14 @@ public class QuestionController extends CiviFormController {
   }
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public CompletionStage<Result> show(Request request, Long id) {
+  public CompletionStage<Result> show(long id) {
     return service
         .getReadOnlyQuestionService()
         .thenApplyAsync(
             readOnlyService -> {
               try {
                 QuestionDefinition definition = readOnlyService.getQuestionDefinition(id);
-                return ok(editView.renderViewQuestionForm(request, definition));
+                return ok(editView.renderViewQuestionForm(definition));
               } catch (QuestionNotFoundException e) {
                 return badRequest(e.toString());
               }

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -144,17 +144,18 @@ public class QuestionRepository {
   }
 
   /**
-   * Maybe find a {@link Question} that conflicts with {@link QuestionDefinition}. A conflict exists
-   * if they are different questions (i.e. different IDs) in the same version representing the same
-   * path.
+   * Maybe find a {@link Question} whose path conflicts with {@link QuestionDefinition}.
+   *
+   * <p>This is intended to be used for new question definitions, since updates will collide with
+   * themselves and previous versions, and new versions of an old question will conflict with the
+   * old question.
    */
-  public Optional<Question> findPathConflictingQuestion(QuestionDefinition questionDefinition) {
+  public Optional<Question> findPathConflictingQuestion(QuestionDefinition newQuestionDefinition) {
     return ebeanServer
         .find(Question.class)
         .where()
-        .eq("path", questionDefinition.getPath().toString())
-        .eq("version", questionDefinition.getVersion())
-        .ne("id", questionDefinition.isPersisted() ? questionDefinition.getId() : 0L)
+        .eq("path", newQuestionDefinition.getPath().toString())
+        .setMaxRows(1)
         .findOneOrEmpty();
   }
 

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -14,9 +14,11 @@ import models.LifecycleStage;
 import models.Program;
 import models.Question;
 import play.db.ebean.EbeanConfig;
+import services.Path;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionType;
 
 public class QuestionRepository {
 
@@ -149,14 +151,56 @@ public class QuestionRepository {
    * <p>This is intended to be used for new question definitions, since updates will collide with
    * themselves and previous versions, and new versions of an old question will conflict with the
    * old question.
+   *
+   * <p>A new question definition's path conflicts with a stored question if it is NOT a {@link
+   * QuestionType#REPEATER}, and starts with, or is started with, the stored question's path.
    */
   public Optional<Question> findPathConflictingQuestion(QuestionDefinition newQuestionDefinition) {
-    return ebeanServer
+    PathConflictDetector pathConflictDetector =
+        new PathConflictDetector(newQuestionDefinition.getPath());
+    ebeanServer
         .find(Question.class)
-        .where()
-        .eq("path", newQuestionDefinition.getPath().toString())
-        .setMaxRows(1)
-        .findOneOrEmpty();
+        .findEachWhile(question -> !pathConflictDetector.hasConflict(question));
+    return pathConflictDetector.getConflictedQuestion();
+  }
+
+  private static class PathConflictDetector {
+    private Optional<Question> conflictedQuestion = Optional.empty();
+    private final Path newPath;
+
+    private PathConflictDetector(Path newPath) {
+      this.newPath = checkNotNull(newPath);
+    }
+
+    private Optional<Question> getConflictedQuestion() {
+      return conflictedQuestion;
+    }
+
+    private boolean hasConflict(Question question) {
+      Path other = Path.create(question.getPath());
+
+      // Conflict exists if paths are exactly the same
+      if (newPath.equals(other)) {
+        conflictedQuestion = Optional.of(question);
+        return true;
+      }
+
+      // Conflict exists if an existing path starts with this new path
+      if (other.startsWith(newPath)) {
+        conflictedQuestion = Optional.of(question);
+        return true;
+      }
+
+      // Conflict exists if this new path starts with an existing path for a non-repeater question,
+      // but not for repeater questions, since that is a very common pattern.
+      QuestionType otherType = question.getQuestionDefinition().getQuestionType();
+      if (!otherType.equals(QuestionType.REPEATER) && newPath.startsWith(other)) {
+        conflictedQuestion = Optional.of(question);
+        return true;
+      }
+
+      return false;
+    }
   }
 
   public CompletionStage<Optional<Question>> lookupQuestionByPath(String path) {

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -14,7 +14,6 @@ import models.LifecycleStage;
 import models.Program;
 import models.Question;
 import play.db.ebean.EbeanConfig;
-import services.Path;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
@@ -146,17 +145,17 @@ public class QuestionRepository {
 
   /**
    * Maybe find a {@link Question} that conflicts with {@link QuestionDefinition}. A conflict exists
-   * if they are different questions (i.e. different IDs), represent the same path, but have
-   * different names.
+   * if they are different questions (i.e. different IDs) in the same version representing the same
+   * path.
    */
   public Optional<Question> findPathConflictingQuestion(QuestionDefinition questionDefinition) {
     return ebeanServer
-            .find(Question.class)
-            .where()
-            .eq("path", questionDefinition.getPath().toString())
-            .ne("name", questionDefinition.getName())
-            .ne("id", questionDefinition.isPersisted() ? questionDefinition.getId() : 0L)
-            .findOneOrEmpty();
+        .find(Question.class)
+        .where()
+        .eq("path", questionDefinition.getPath().toString())
+        .eq("version", questionDefinition.getVersion())
+        .ne("id", questionDefinition.isPersisted() ? questionDefinition.getId() : 0L)
+        .findOneOrEmpty();
   }
 
   public CompletionStage<Optional<Question>> lookupQuestionByPath(String path) {

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -212,7 +212,7 @@ public abstract class Path {
   private String stripArraySuffix(String segment, boolean strict) {
     Matcher matcher = ARRAY_INDEX_REGEX.matcher(segment);
     if (matcher.matches()) {
-      return new StringBuilder(keyName())
+      return new StringBuilder(segment)
           .replace(matcher.start(ARRAY_SUFFIX_GROUP), matcher.end(ARRAY_SUFFIX_GROUP), "")
           .toString();
     }

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -198,7 +198,7 @@ public abstract class Path {
    * <p>For paths to non-array elements, {@code IllegalStateException} is thrown.
    */
   private String keyNameWithoutArrayIndex() {
-    return stripArraySuffix(keyName(), true);
+    return stripArraySuffix(keyName(), /* strict= */ true);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -227,6 +227,6 @@ public abstract class Path {
 
   /** Non-strict version of {@link #stripArraySuffix(String, boolean)} */
   private String stripArraySuffix(String segment) {
-    return stripArraySuffix(segment, false);
+    return stripArraySuffix(segment, /* strict= */ false);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -167,19 +167,66 @@ public abstract class Path {
   }
 
   /**
+   * Returns true if this path starts with the other path, ignoring array index suffixes. that is,
+   * "a.b[].c[].d" starts with "a.b.c".
+   */
+  public boolean startsWith(Path other) {
+    ImmutableList<String> thisSegments =
+        segments().stream().map(this::stripArraySuffix).collect(ImmutableList.toImmutableList());
+    ImmutableList<String> otherSegments =
+        other.segments().stream()
+            .map(this::stripArraySuffix)
+            .collect(ImmutableList.toImmutableList());
+
+    // This can't start with something that is longer than it.
+    if (otherSegments.size() > thisSegments.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < otherSegments.size(); i++) {
+      if (!thisSegments.get(i).equals(otherSegments.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Returns the path's key name without an array index suffix. e.g. {@code a.b[1].c[3]} returns
    * "c".
    *
    * <p>For paths to non-array elements, {@code IllegalStateException} is thrown.
    */
   private String keyNameWithoutArrayIndex() {
-    Matcher matcher = ARRAY_INDEX_REGEX.matcher(keyName());
+    return stripArraySuffix(keyName(), true);
+  }
+
+  /**
+   * Returns the path segment without an {@link #ARRAY_SUFFIX}.
+   *
+   * @param segment a path segment to strip of {@link #ARRAY_SUFFIX}
+   * @param strict if true, throws an {@link IllegalArgumentException} if segment does not have
+   *     anything to strip
+   * @return segment, without an {@link #ARRAY_SUFFIX}
+   */
+  private String stripArraySuffix(String segment, boolean strict) {
+    Matcher matcher = ARRAY_INDEX_REGEX.matcher(segment);
     if (matcher.matches()) {
       return new StringBuilder(keyName())
           .replace(matcher.start(ARRAY_SUFFIX_GROUP), matcher.end(ARRAY_SUFFIX_GROUP), "")
           .toString();
     }
-    throw new IllegalStateException(
-        String.format("This path %s does not reference an array element.", this));
+
+    if (strict) {
+      throw new IllegalStateException(
+          String.format("This path %s does not reference an array element.", this));
+    }
+
+    return segment;
+  }
+
+  /** Non-strict version of {@link #stripArraySuffix(String, boolean)} */
+  private String stripArraySuffix(String segment) {
+    return stripArraySuffix(segment, false);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -107,15 +107,14 @@ public final class QuestionServiceImpl implements QuestionService {
     if (!errors.isEmpty()) {
       return errors;
     }
-    Path newPath = newDefinition.getPath();
     Optional<Question> maybeConflict =
-        questionRepository.findConflictingQuestion(newPath).toCompletableFuture().join();
+        questionRepository.findPathConflictingQuestion(newDefinition);
     if (maybeConflict.isPresent()) {
-      Question question = maybeConflict.get();
+      Question conflict = maybeConflict.get();
       return ImmutableSet.of(
           CiviFormError.of(
               String.format(
-                  "path '%s' conflicts with question: %s", newPath.path(), question.getPath())));
+                  "path '%s' conflicts with question: %s", newDefinition.getPath(), conflict.getPath())));
     }
     return ImmutableSet.of();
   }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -72,13 +72,13 @@ public final class QuestionServiceImpl implements QuestionService {
           String.format("question with id %d does not exist", questionDefinition.getId()));
     }
     Question question = maybeQuestion.get();
-    ImmutableSet<CiviFormError> invariantErrors =
-        validateQuestionInvariants(question.getQuestionDefinition(), questionDefinition);
+    ImmutableSet<CiviFormError> immutableMemberErrors =
+        validateQuestionImmutableMembers(question.getQuestionDefinition(), questionDefinition);
 
     ImmutableSet<CiviFormError> errors =
         ImmutableSet.<CiviFormError>builder()
             .addAll(validationErrors)
-            .addAll(invariantErrors)
+            .addAll(immutableMemberErrors)
             .build();
     if (!errors.isEmpty()) {
       return ErrorAnd.error(errors);
@@ -125,11 +125,11 @@ public final class QuestionServiceImpl implements QuestionService {
   }
 
   /**
-   * Validates that a question's updates do not change its invariants.
+   * Validates that a question's updates do not change its immutable members.
    *
-   * <p>Question invariants are: name, repeater id, path, and type.
+   * <p>Question immutable members are: name, repeater id, path, and type.
    */
-  private ImmutableSet<CiviFormError> validateQuestionInvariants(
+  private ImmutableSet<CiviFormError> validateQuestionImmutableMembers(
       QuestionDefinition questionDefinition, QuestionDefinition toUpdate) {
     ImmutableSet.Builder<CiviFormError> errors = new ImmutableSet.Builder<>();
 

--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
@@ -56,7 +56,10 @@ public interface ReadOnlyQuestionService {
    */
   QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException;
 
-  /** Checks whether a specific path is valid. */
+  /**
+   * Checks whether a specific path is valid. A path is valid in this context if it represents a
+   * real path to a value.
+   */
   boolean isValid(Path path);
 
   /**

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -102,7 +102,7 @@ public final class QuestionEditView extends BaseHtmlView {
     return layout.renderFull(mainContent);
   }
 
-  public Content renderViewQuestionForm(Request request, QuestionDefinition question) {
+  public Content renderViewQuestionForm(QuestionDefinition question) {
     QuestionType questionType = question.getQuestionType();
     QuestionForm questionForm = getQuestionFormForType(questionType, question);
     String title = String.format("View %s question", questionType.toString().toLowerCase());

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -32,7 +32,7 @@ GET     /admin/questions             controllers.admin.QuestionController.index(
 # Should have a `type` query param, like: /admin/questions/new?type=name. Defaults to text.
 GET     /admin/questions/new         controllers.admin.QuestionController.newOne(request: Request, type: String ?= "text")
 GET     /admin/questions/:id/edit    controllers.admin.QuestionController.edit(request: Request, id: Long)
-GET     /admin/questions/:id         controllers.admin.QuestionController.show(request: Request, id: Long)
+GET     /admin/questions/:id         controllers.admin.QuestionController.show(id: Long)
 POST    /admin/questions/:id         controllers.admin.QuestionController.update(request: Request, id: Long, type: String)
 POST    /admin/questions             controllers.admin.QuestionController.create(request: Request, type: String)
 

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -20,8 +20,10 @@ import play.test.Helpers;
 import repository.WithPostgresContainer;
 import services.Path;
 import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
+import support.TestQuestionBank;
 import views.html.helper.CSRF;
 
 public class QuestionControllerTest extends WithPostgresContainer {
@@ -183,18 +185,22 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_redirectsOnSuccess() {
-    Question question = resourceCreator().insertQuestion("my.path.name");
+    QuestionDefinition nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
-        .put("questionName", "name")
-        .put("questionDescription", "desc")
-        .put("questionParentPath", "my.path")
-        .put("questionType", "TEXT")
-        .put("questionText", "question text updated!")
-        .put("questionHelpText", ":-)");
+        .put("questionName", nameQuestion.getName())
+        .put("questionDescription", "a new description")
+        .put("questionParentPath", nameQuestion.getPath().parentPath().toString())
+        .put("questionType", nameQuestion.getQuestionType().name())
+        .put("questionText", "question text updated")
+        .put("questionHelpText", "a new help text");
     RequestBuilder requestBuilder = addCSRFToken(Helpers.fakeRequest().bodyForm(formData.build()));
 
-    Result result = controller.update(requestBuilder.build(), question.id, "text");
+    Result result =
+        controller.update(
+            requestBuilder.build(),
+            nameQuestion.getId(),
+            nameQuestion.getQuestionType().toString());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.QuestionController.index().url());

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -154,7 +154,10 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
                             applicant.id, program.id, "1"))
                     .bodyForm(
                         ImmutableMap.of(
-                            "applicant.name.first", "FirstName", "applicant.name.last", "")))
+                            "applicant.applicant_name.first",
+                            "FirstName",
+                            "applicant.applicant_name.last",
+                            "")))
             .build();
 
     Result result =
@@ -178,7 +181,10 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
             .bodyForm(
                 ImmutableMap.of(
-                    "applicant.name.first", "FirstName", "applicant.name.last", "LastName"))
+                    "applicant.applicant_name.first",
+                    "FirstName",
+                    "applicant.applicant_name.last",
+                    "LastName"))
             .build();
 
     Result result =
@@ -202,7 +208,10 @@ public class ApplicantProgramBlocksControllerTest extends WithPostgresContainer 
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
             .bodyForm(
                 ImmutableMap.of(
-                    "applicant.name.first", "FirstName", "applicant.name.last", "LastName"))
+                    "applicant.applicant_name.first",
+                    "FirstName",
+                    "applicant.applicant_name.last",
+                    "LastName"))
             .build();
 
     Result result =

--- a/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
@@ -60,25 +60,32 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   }
 
   @Test
-  public void findPathConflictingQuestion_noConflicts_ok() {
-    TestQuestionBank.applicantAddress();
-    Optional<Question> maybeConflict =
-        repo.findPathConflictingQuestion(TestQuestionBank.applicantName().getQuestionDefinition());
+  public void findPathConflictingQuestion_noConflicts_ok() throws Exception {
+    QuestionDefinition applicantAddress =
+        TestQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition newQuestionDefinition =
+        new QuestionDefinitionBuilder(applicantAddress)
+            .clearId()
+            .setName("a brand new question")
+            .setPath(Path.create("applicant.a_brand_new_question"))
+            .build();
+
+    Optional<Question> maybeConflict = repo.findPathConflictingQuestion(newQuestionDefinition);
 
     assertThat(maybeConflict).isEmpty();
   }
 
   @Test
-  public void findPathConflictingQuestion_sameQuestion_ok() {
+  public void findPathConflictingQuestion_sameQuestion_hasConflict() {
     Question applicantAddress = TestQuestionBank.applicantAddress();
     Optional<Question> maybeConflict =
         repo.findPathConflictingQuestion(applicantAddress.getQuestionDefinition());
 
-    assertThat(maybeConflict).isEmpty();
+    assertThat(maybeConflict).contains(applicantAddress);
   }
 
   @Test
-  public void findPathConflictingQuestion_differentVersion_ok() throws Exception {
+  public void findPathConflictingQuestion_differentVersion_hasConflict() throws Exception {
     Question applicantName = TestQuestionBank.applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
@@ -88,11 +95,11 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
     Optional<Question> maybeConflict = repo.findPathConflictingQuestion(questionDefinition);
 
-    assertThat(maybeConflict).isEmpty();
+    assertThat(maybeConflict).contains(applicantName);
   }
 
   @Test
-  public void findPathConflictingQuestion_hasConflicts() throws Exception {
+  public void findPathConflictingQuestion_samePath_hasConflicts() throws Exception {
     Question applicantName = TestQuestionBank.applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).clearId().build();

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -155,4 +155,32 @@ public class PathTest {
     Path expected = Path.create("one.two.three");
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  public void startsWith_isTrue() {
+    assertThat(Path.create("a.b.c").startsWith(Path.create("a.b"))).isTrue();
+  }
+
+  @Test
+  public void startsWith_ignoresArrays_isTrue() {
+    assertThat(Path.create("a.b[].c[].d[]").startsWith(Path.create("a.b.c"))).isTrue();
+    assertThat(Path.create("a.b[].c[].d[]").startsWith(Path.create("a.b.c.d"))).isTrue();
+  }
+
+  @Test
+  public void startsWith_otherStartsWithThis_isFalse() {
+    Path path = Path.create("a.b.c");
+    Path other = Path.create("a.b.c.d");
+
+    assertThat(path.startsWith(other)).isFalse();
+    assertThat(other.startsWith(path)).isTrue();
+  }
+
+  @Test
+  public void startsWith_stringStartsWithButPathSegmentsDont_isFalse() {
+    Path path = Path.create("a.b.c_d");
+    Path other = Path.create("a.b.c");
+
+    assertThat(path.startsWith(other)).isFalse();
+  }
 }

--- a/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
@@ -43,13 +43,13 @@ public class CsvExporterTest extends WithPostgresContainer {
         .addColumn(
             Column.builder()
                 .setHeader("first name")
-                .setJsonPath(Path.create("$.applicant.name.first"))
+                .setJsonPath(Path.create("$.applicant.applicant_name.first"))
                 .setColumnType(ColumnType.APPLICANT)
                 .build())
         .addColumn(
             Column.builder()
                 .setHeader("last name")
-                .setJsonPath(Path.create("$.applicant.name.last"))
+                .setJsonPath(Path.create("$.applicant.applicant_name.last"))
                 .setColumnType(ColumnType.APPLICANT)
                 .build())
         .addColumn(
@@ -83,8 +83,12 @@ public class CsvExporterTest extends WithPostgresContainer {
   @Before
   public void createFakeApplicants() {
     Applicant fakeApplicantOne = new Applicant();
-    fakeApplicantOne.getApplicantData().putString(Path.create("applicant.name.first"), "Alice");
-    fakeApplicantOne.getApplicantData().putString(Path.create("applicant.name.last"), "Appleton");
+    fakeApplicantOne
+        .getApplicantData()
+        .putString(Path.create("applicant.applicant_name.first"), "Alice");
+    fakeApplicantOne
+        .getApplicantData()
+        .putString(Path.create("applicant.applicant_name.last"), "Appleton");
     fakeApplicantOne
         .getApplicantData()
         .putString(
@@ -95,17 +99,25 @@ public class CsvExporterTest extends WithPostgresContainer {
     fakeApplicantOne
         .getApplicantData()
         .putString(Path.create("applicant.multiselect.selection[1]"), "world");
-    fakeApplicantOne.getApplicantData().putString(Path.create("applicant.color.text"), "fuchsia");
+    fakeApplicantOne
+        .getApplicantData()
+        .putString(Path.create("applicant.applicant_favorite_color.text"), "fuchsia");
     fakeApplicantOne.save();
 
     Applicant fakeApplicantTwo = new Applicant();
-    fakeApplicantTwo.getApplicantData().putString(Path.create("applicant.name.first"), "Bob");
-    fakeApplicantTwo.getApplicantData().putString(Path.create("applicant.name.last"), "Baker");
+    fakeApplicantTwo
+        .getApplicantData()
+        .putString(Path.create("applicant.applicant_name.first"), "Bob");
+    fakeApplicantTwo
+        .getApplicantData()
+        .putString(Path.create("applicant.applicant_name.last"), "Baker");
     fakeApplicantTwo.getApplicantData().putString(Path.create("applicant.column"), "");
     fakeApplicantTwo
         .getApplicantData()
         .putString(Path.create("applicant.multiselect.selection[0]"), "hello");
-    fakeApplicantTwo.getApplicantData().putString(Path.create("applicant.color.text"), "maroon");
+    fakeApplicantTwo
+        .getApplicantData()
+        .putString(Path.create("applicant.applicant_favorite_color.text"), "maroon");
     fakeApplicantTwo.save();
     this.fakeApplicants = ImmutableList.of(fakeApplicantOne, fakeApplicantTwo);
   }

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -27,20 +27,21 @@ public class BlockDefinitionTest {
   @Test
   public void getScalarType() throws Exception {
     BlockDefinition block = makeBlockDefinitionWithQuestions();
-    assertThat(block.getScalarType(Path.create("applicant.name.first")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_name.first")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.name.middle")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_name.middle")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.name.last"))).hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.address.street")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_name.last")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.address.city")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_address.street")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.address.state")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_address.city")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.address.zip")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_address.state")))
         .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.color.text")))
+    assertThat(block.getScalarType(Path.create("applicant.applicant_address.zip")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.applicant_favorite_color.text")))
         .hasValue(ScalarType.STRING);
     assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
   }
@@ -50,14 +51,14 @@ public class BlockDefinitionTest {
     BlockDefinition block = makeBlockDefinitionWithQuestions();
     ImmutableList<Path> paths =
         ImmutableList.of(
-            Path.create("applicant.name.first"),
-            Path.create("applicant.name.middle"),
-            Path.create("applicant.name.last"),
-            Path.create("applicant.address.street"),
-            Path.create("applicant.address.city"),
-            Path.create("applicant.address.state"),
-            Path.create("applicant.address.zip"),
-            Path.create("applicant.color.text"));
+            Path.create("applicant.applicant_name.first"),
+            Path.create("applicant.applicant_name.middle"),
+            Path.create("applicant.applicant_name.last"),
+            Path.create("applicant.applicant_address.street"),
+            Path.create("applicant.applicant_address.city"),
+            Path.create("applicant.applicant_address.state"),
+            Path.create("applicant.applicant_address.zip"),
+            Path.create("applicant.applicant_favorite_color.text"));
 
     assertThat(block.hasPaths(paths)).isTrue();
 

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
@@ -84,7 +84,7 @@ public class ReadOnlyQuestionServiceImplTest {
   @Test
   public void getPathScalars_forQuestion() throws InvalidPathException {
     ImmutableMap<Path, ScalarType> result =
-        service.getPathScalars(Path.create("applicant.address"));
+        service.getPathScalars(Path.create("applicant.applicant_address"));
     ImmutableMap<Path, ScalarType> expected = addressQuestion.getScalars();
     assertThat(result).isEqualTo(expected);
   }
@@ -92,9 +92,9 @@ public class ReadOnlyQuestionServiceImplTest {
   @Test
   public void getPathScalars_forScalar() throws InvalidPathException {
     ImmutableMap<Path, ScalarType> result =
-        service.getPathScalars(Path.create("applicant.address.city"));
+        service.getPathScalars(Path.create("applicant.applicant_address.city"));
     ImmutableMap<Path, ScalarType> expected =
-        ImmutableMap.of(Path.create("applicant.address.city"), ScalarType.STRING);
+        ImmutableMap.of(Path.create("applicant.applicant_address.city"), ScalarType.STRING);
     assertThat(result).isEqualTo(expected);
   }
 
@@ -112,12 +112,14 @@ public class ReadOnlyQuestionServiceImplTest {
 
   @Test
   public void getPathType_forQuestion() {
-    assertThat(service.getPathType(Path.create("applicant.color"))).isEqualTo(PathType.QUESTION);
+    assertThat(service.getPathType(Path.create("applicant.applicant_favorite_color")))
+        .isEqualTo(PathType.QUESTION);
   }
 
   @Test
   public void getPathType_forScalar() {
-    assertThat(service.getPathType(Path.create("applicant.name.first"))).isEqualTo(PathType.SCALAR);
+    assertThat(service.getPathType(Path.create("applicant.applicant_name.first")))
+        .isEqualTo(PathType.SCALAR);
   }
 
   @Test
@@ -133,16 +135,16 @@ public class ReadOnlyQuestionServiceImplTest {
 
   @Test
   public void isValid_returnsFalseWhenEmpty() {
-    assertThat(emptyService.isValid(Path.create("invalidPath"))).isFalse();
+    assertThat(emptyService.isValid(Path.empty())).isFalse();
   }
 
   @Test
   public void isValid_returnsTrueForQuestion() {
-    assertThat(service.isValid(Path.create("applicant.name"))).isTrue();
+    assertThat(service.isValid(Path.create("applicant.applicant_name"))).isTrue();
   }
 
   @Test
   public void isValid_returnsTrueForScalar() {
-    assertThat(service.isValid(Path.create("applicant.name.first"))).isTrue();
+    assertThat(service.isValid(Path.create("applicant.applicant_name.first"))).isTrue();
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -64,6 +64,12 @@ public class TestQuestionBank {
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
   }
 
+  public static Question applicantHouseholdMemberName() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME,
+        TestQuestionBank::applicantHouseholdMemberName);
+  }
+
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
         new NameQuestionDefinition(
@@ -121,6 +127,22 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private static Question applicantHouseholdMemberName(QuestionEnum ignore) {
+    Question householdMembers = applicantHouseholdMembers();
+    QuestionDefinition definition =
+        new NameQuestionDefinition(
+            VERSION,
+            "household members name",
+            Path.create("applicant.applicant_household_members[].name"),
+            Optional.of(householdMembers.id),
+            "The applicant's household member's name",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "what is the household member's name?"),
+            ImmutableMap.of(Locale.US, "help text"));
+
+    return maybeSave(definition);
+  }
+
   private static Question maybeSave(QuestionDefinition questionDefinition) {
     Question question = new Question(questionDefinition);
     try {
@@ -141,6 +163,7 @@ public class TestQuestionBank {
     APPLICANT_NAME,
     APPLICANT_ADDRESS,
     APPLICANT_FAVORITE_COLOR,
-    APPLICANT_HOUSEHOLD_MEMBERS
+    APPLICANT_HOUSEHOLD_MEMBERS,
+    APPLICANT_HOUSEHOLD_MEMBER_NAME
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -69,7 +69,7 @@ public class TestQuestionBank {
         new NameQuestionDefinition(
             VERSION,
             "applicant name",
-            Path.create("applicant.name"),
+            Path.create("applicant.applicant_name"),
             Optional.empty(),
             "name of applicant",
             LifecycleStage.ACTIVE,
@@ -83,7 +83,7 @@ public class TestQuestionBank {
         new AddressQuestionDefinition(
             VERSION,
             "applicant address",
-            Path.create("applicant.address"),
+            Path.create("applicant.applicant_address"),
             Optional.empty(),
             "address of applicant",
             LifecycleStage.ACTIVE,
@@ -97,7 +97,7 @@ public class TestQuestionBank {
         new TextQuestionDefinition(
             VERSION,
             "applicant favorite color",
-            Path.create("applicant.color"),
+            Path.create("applicant.applicant_favorite_color"),
             Optional.empty(),
             "favorite color of applicant",
             LifecycleStage.ACTIVE,
@@ -111,7 +111,7 @@ public class TestQuestionBank {
         new RepeaterQuestionDefinition(
             VERSION,
             "applicant household members",
-            Path.create("applicant.household_members[]"),
+            Path.create("applicant.applicant_household_members[]"),
             Optional.empty(),
             "The applicant's household members",
             LifecycleStage.ACTIVE,


### PR DESCRIPTION
### Description
The `String.startsWith` cannot be used with repeated questions.

Question invariants are now: name, path, repeater id, and question type.

Updated the `TestQuestionBank` paths to what they should be based on their names.

Also got rid of an unused `Request` argument.

### Checklist

### Issue(s)
