### PR TITLE
Make empty number value inputs pass validation, unless there is a configured minimum or maximum value

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -29,8 +29,10 @@ public class NumberQuestion implements PresentsErrors {
 
     NumberQuestionDefinition questionDefinition = getQuestionDefinition();
 
-    // If there is no minimum value set, accept a blank answer.
-    if (getNumberValue().isEmpty() && questionDefinition.getMin().isEmpty()) {
+    // If there is no minimum or maximum value configured, accept a blank answer.
+    if (getNumberValue().isEmpty()
+        && questionDefinition.getMin().isEmpty()
+        && questionDefinition.getMax().isEmpty()) {
       return ImmutableSet.of();
     }
 
@@ -46,8 +48,8 @@ public class NumberQuestion implements PresentsErrors {
 
     if (questionDefinition.getMax().isPresent()) {
       long max = questionDefinition.getMax().getAsLong();
-      // If the value is empty, do not consider it to be "greater than the maximum".
-      if (getNumberValue().isPresent() && getNumberValue().get() > max) {
+      // If the value is empty, consider it to be "greater than the maximum".
+      if (getNumberValue().isEmpty() || getNumberValue().get() > max) {
         errors.add(ValidationErrorMessage.numberTooLargeError(max));
       }
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -38,7 +38,7 @@ public class NumberQuestion implements PresentsErrors {
 
     if (questionDefinition.getMin().isPresent()) {
       long min = questionDefinition.getMin().getAsLong();
-      // If the value is empty, consider this to be "less than the minimum".
+      // If the value is empty, consider it to be "less than the minimum".
       if (getNumberValue().isEmpty() || getNumberValue().get() < min) {
         errors.add(ValidationErrorMessage.numberTooSmallError(min));
       }
@@ -46,7 +46,8 @@ public class NumberQuestion implements PresentsErrors {
 
     if (questionDefinition.getMax().isPresent()) {
       long max = questionDefinition.getMax().getAsLong();
-      if (getNumberValue().get() > max) {
+      // If the value is empty, do not consider it to be "greater than the maximum".
+      if (getNumberValue().isPresent() && getNumberValue().get() > max) {
         errors.add(ValidationErrorMessage.numberTooLargeError(max));
       }
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -27,20 +27,26 @@ public class NumberQuestion implements PresentsErrors {
       return ImmutableSet.of();
     }
 
-    NumberQuestionDefinition definition = getQuestionDefinition();
-    long answer = getNumberValue().get();
+    NumberQuestionDefinition questionDefinition = getQuestionDefinition();
+
+    // If there is no minimum value set, accept a blank answer.
+    if (getNumberValue().isEmpty() && questionDefinition.getMin().isEmpty()) {
+      return ImmutableSet.of();
+    }
+
     ImmutableSet.Builder<ValidationErrorMessage> errors = ImmutableSet.builder();
 
-    if (definition.getMin().isPresent()) {
-      long min = definition.getMin().getAsLong();
-      if (answer < min) {
+    if (questionDefinition.getMin().isPresent()) {
+      long min = questionDefinition.getMin().getAsLong();
+      // If the value is empty, consider this to be "less than the minimum".
+      if (getNumberValue().isEmpty() || getNumberValue().get() < min) {
         errors.add(ValidationErrorMessage.numberTooSmallError(min));
       }
     }
 
-    if (definition.getMax().isPresent()) {
-      long max = definition.getMax().getAsLong();
-      if (answer > max) {
+    if (questionDefinition.getMax().isPresent()) {
+      long max = questionDefinition.getMax().getAsLong();
+      if (getNumberValue().get() > max) {
         errors.add(ValidationErrorMessage.numberTooLargeError(max));
       }
     }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -66,12 +66,12 @@ public class NumberQuestionTest {
   public void withEmptyValueAtPath_passesValidation() {
     applicantData.putLong(numberQuestionDefinition.getNumberPath(), "");
     ApplicantQuestion applicantQuestion =
-            new ApplicantQuestion(numberQuestionDefinition, applicantData);
+        new ApplicantQuestion(numberQuestionDefinition, applicantData);
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
     assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(numberQuestion.getNumberValue().get()).isEqualTo(800);
+    assertThat(numberQuestion.getNumberValue()).isEmpty();
   }
 
   @Test
@@ -120,5 +120,33 @@ public class NumberQuestionTest {
     assertThat(numberQuestion.getQuestionErrors())
         .containsOnly(ValidationErrorMessage.create(expectedErrorMessage));
     assertThat(numberQuestion.getNumberValue().get()).isEqualTo(value);
+  }
+
+  @Test
+  public void withMinValue_withEmptyValueAtPath_failsValidation() {
+    NumberQuestionDefinition.NumberValidationPredicates.Builder numberValidationPredicatesBuilder =
+            NumberQuestionDefinition.NumberValidationPredicates.builder();
+    numberValidationPredicatesBuilder.setMin(1);
+    NumberQuestionDefinition minNumberQuestionDefinition =
+            new NumberQuestionDefinition(
+                    1L,
+                    "question name",
+                    Path.create("applicant.my.path.name"),
+                    Optional.empty(),
+                    "description",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "question?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    numberValidationPredicatesBuilder.build());
+
+    applicantData.putLong(minNumberQuestionDefinition.getNumberPath(), "");
+    ApplicantQuestion applicantQuestion =
+            new ApplicantQuestion(minNumberQuestionDefinition, applicantData);
+
+    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+
+    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(numberQuestion.getQuestionErrors())
+            .containsOnly(ValidationErrorMessage.numberTooSmallError(1));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -15,10 +15,7 @@ import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
-import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.NumberQuestionDefinition;
-import services.question.types.QuestionDefinitionBuilder;
-import services.question.types.QuestionType;
 
 @RunWith(JUnitParamsRunner.class)
 public class NumberQuestionTest {
@@ -129,28 +126,56 @@ public class NumberQuestionTest {
   @Test
   public void withMinValue_withEmptyValueAtPath_failsValidation() {
     NumberQuestionDefinition.NumberValidationPredicates.Builder numberValidationPredicatesBuilder =
-            NumberQuestionDefinition.NumberValidationPredicates.builder();
+        NumberQuestionDefinition.NumberValidationPredicates.builder();
     numberValidationPredicatesBuilder.setMin(1);
     NumberQuestionDefinition minNumberQuestionDefinition =
-            new NumberQuestionDefinition(
-                    1L,
-                    "question name",
-                    Path.create("applicant.my.path.name"),
-                    Optional.empty(),
-                    "description",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "question?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    numberValidationPredicatesBuilder.build());
+        new NumberQuestionDefinition(
+            1L,
+            "question name",
+            Path.create("applicant.my.path.name"),
+            Optional.empty(),
+            "description",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "question?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            numberValidationPredicatesBuilder.build());
 
     applicantData.putLong(minNumberQuestionDefinition.getNumberPath(), "");
     ApplicantQuestion applicantQuestion =
-            new ApplicantQuestion(minNumberQuestionDefinition, applicantData);
+        new ApplicantQuestion(minNumberQuestionDefinition, applicantData);
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
     assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(numberQuestion.getQuestionErrors())
-            .containsOnly(ValidationErrorMessage.numberTooSmallError(1));
+        .containsOnly(ValidationErrorMessage.numberTooSmallError(1));
+  }
+
+  @Test
+  public void withMaxValue_withEmptyValueAtPath_failsValidation() {
+    NumberQuestionDefinition.NumberValidationPredicates.Builder numberValidationPredicatesBuilder =
+        NumberQuestionDefinition.NumberValidationPredicates.builder();
+    numberValidationPredicatesBuilder.setMax(1);
+    NumberQuestionDefinition minNumberQuestionDefinition =
+        new NumberQuestionDefinition(
+            1L,
+            "question name",
+            Path.create("applicant.my.path.name"),
+            Optional.empty(),
+            "description",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "question?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            numberValidationPredicatesBuilder.build());
+
+    applicantData.putLong(minNumberQuestionDefinition.getNumberPath(), "");
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(minNumberQuestionDefinition, applicantData);
+
+    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+
+    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(numberQuestion.getQuestionErrors())
+        .containsOnly(ValidationErrorMessage.numberTooLargeError(1));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -15,10 +15,14 @@ import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.NumberQuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionType;
 
 @RunWith(JUnitParamsRunner.class)
 public class NumberQuestionTest {
+
   private static final NumberQuestionDefinition numberQuestionDefinition =
       new NumberQuestionDefinition(
           1L,

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -52,7 +52,7 @@ public class NumberQuestionTest {
   }
 
   @Test
-  public void withEmptyApplicantData() {
+  public void withEmptyApplicantData_passesValidation() {
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(numberQuestionDefinition, applicantData);
 
@@ -63,7 +63,19 @@ public class NumberQuestionTest {
   }
 
   @Test
-  public void withValidApplicantData() {
+  public void withEmptyValueAtPath_passesValidation() {
+    applicantData.putLong(numberQuestionDefinition.getNumberPath(), "");
+    ApplicantQuestion applicantQuestion =
+            new ApplicantQuestion(numberQuestionDefinition, applicantData);
+
+    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+
+    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(numberQuestion.getNumberValue().get()).isEqualTo(800);
+  }
+
+  @Test
+  public void withValidValue_passesValidation() {
     applicantData.putLong(numberQuestionDefinition.getNumberPath(), 800);
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(numberQuestionDefinition, applicantData);
@@ -76,7 +88,7 @@ public class NumberQuestionTest {
 
   @Test
   @Parameters({"50", "75", "100"})
-  public void withMinAndMaxValue_withValidApplicantData_passesValidation(long value) {
+  public void withMinAndMaxValue_withValidValue_passesValidation(long value) {
     applicantData.putLong(minAndMaxNumberQuestionDefinition.getNumberPath(), value);
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(minAndMaxNumberQuestionDefinition, applicantData);
@@ -96,7 +108,7 @@ public class NumberQuestionTest {
     "101,Must be at most 100.",
     "999,Must be at most 100."
   })
-  public void withMinAndMaxValue_withInvalidApplicantData_failsValidation(
+  public void withMinAndMaxValue_withInvalidValue_failsValidation(
       long value, String expectedErrorMessage) {
     applicantData.putLong(minAndMaxNumberQuestionDefinition.getNumberPath(), value);
     ApplicantQuestion applicantQuestion =


### PR DESCRIPTION
### Description
#769 inadvertently created a new bug where an exception is thrown when a user attempts to submit an empty value for questions of type `number`. This PR makes it so that number fields are not required by default. In other words, the field will pass validation on the applicant side if it is left blank.

However, if the admin has configured a minimum or maximum value on the `number` question, we now *do* require a value, and return a `"Must be at least %d"` or `"Must be at most %d"` validation error message if it is left blank.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #409