### PR TITLE
Don't test number value against min or max if it's empty

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -40,16 +40,16 @@ public class NumberQuestion implements PresentsErrors {
 
     if (questionDefinition.getMin().isPresent()) {
       long min = questionDefinition.getMin().getAsLong();
-      // If the value is empty, consider it to be "less than the minimum".
-      if (getNumberValue().isEmpty() || getNumberValue().get() < min) {
+      // If value is empty, don't test against min.
+      if (getNumberValue().isPresent() && getNumberValue().get() < min) {
         errors.add(ValidationErrorMessage.numberTooSmallError(min));
       }
     }
 
     if (questionDefinition.getMax().isPresent()) {
       long max = questionDefinition.getMax().getAsLong();
-      // If the value is empty, consider it to be "greater than the maximum".
-      if (getNumberValue().isEmpty() || getNumberValue().get() > max) {
+      // If value is empty, don't test against max.
+      if (getNumberValue().isPresent() && getNumberValue().get() > max) {
         errors.add(ValidationErrorMessage.numberTooLargeError(max));
       }
     }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -132,7 +132,6 @@ public class NumberQuestionTest {
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
     assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(numberQuestion.getQuestionErrors())
-        .containsOnly(ValidationErrorMessage.numberTooSmallError(1));
+    assertThat(numberQuestion.hasQuestionErrors()).isFalse();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -124,58 +124,15 @@ public class NumberQuestionTest {
   }
 
   @Test
-  public void withMinValue_withEmptyValueAtPath_failsValidation() {
-    NumberQuestionDefinition.NumberValidationPredicates.Builder numberValidationPredicatesBuilder =
-        NumberQuestionDefinition.NumberValidationPredicates.builder();
-    numberValidationPredicatesBuilder.setMin(1);
-    NumberQuestionDefinition minNumberQuestionDefinition =
-        new NumberQuestionDefinition(
-            1L,
-            "question name",
-            Path.create("applicant.my.path.name"),
-            Optional.empty(),
-            "description",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "question?"),
-            ImmutableMap.of(Locale.US, "help text"),
-            numberValidationPredicatesBuilder.build());
-
-    applicantData.putLong(minNumberQuestionDefinition.getNumberPath(), "");
+  public void withMinAndMaxValue_withEmptyValueAtPath_passesValidation() {
+    applicantData.putLong(minAndMaxNumberQuestionDefinition.getNumberPath(), "");
     ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(minNumberQuestionDefinition, applicantData);
+        new ApplicantQuestion(minAndMaxNumberQuestionDefinition, applicantData);
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
     assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(numberQuestion.getQuestionErrors())
         .containsOnly(ValidationErrorMessage.numberTooSmallError(1));
-  }
-
-  @Test
-  public void withMaxValue_withEmptyValueAtPath_failsValidation() {
-    NumberQuestionDefinition.NumberValidationPredicates.Builder numberValidationPredicatesBuilder =
-        NumberQuestionDefinition.NumberValidationPredicates.builder();
-    numberValidationPredicatesBuilder.setMax(1);
-    NumberQuestionDefinition minNumberQuestionDefinition =
-        new NumberQuestionDefinition(
-            1L,
-            "question name",
-            Path.create("applicant.my.path.name"),
-            Optional.empty(),
-            "description",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "question?"),
-            ImmutableMap.of(Locale.US, "help text"),
-            numberValidationPredicatesBuilder.build());
-
-    applicantData.putLong(minNumberQuestionDefinition.getNumberPath(), "");
-    ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(minNumberQuestionDefinition, applicantData);
-
-    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
-
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(numberQuestion.getQuestionErrors())
-        .containsOnly(ValidationErrorMessage.numberTooLargeError(1));
   }
 }


### PR DESCRIPTION
### Description
We should not consider a number question that is answered with an empty value to be invalid if there is a min and/or max set.

This is because a question's required-ness is set at the program definition level, rather than at the question level.

Required questions at the program definition level is not yet implemented.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

