### PR TITLE
[BUGFIX-817] Set checkbox input value to true.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -113,12 +113,6 @@ public class QuestionConfig {
             .setLabelText("Disallow post office boxes")
             .setValue("true")
             .setChecked(addressQuestionForm.getDisallowPoBox())
-            .getContainer(),
-        FieldWithLabel.checkbox()
-            .setId("address-question-include-none-checkbox")
-            .setFieldName("noAddress")
-            .setLabelText("Include \"No address\" option")
-            .setValue("true")
             .getContainer());
     return this;
   }

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -111,12 +111,14 @@ public class QuestionConfig {
             .setId("address-question-disallow-po-box-checkbox")
             .setFieldName("disallowPoBox")
             .setLabelText("Disallow post office boxes")
+            .setValue("true")
             .setChecked(addressQuestionForm.getDisallowPoBox())
             .getContainer(),
         FieldWithLabel.checkbox()
             .setId("address-question-include-none-checkbox")
             .setFieldName("noAddress")
             .setLabelText("Include \"No address\" option")
+            .setValue("true")
             .getContainer());
     return this;
   }


### PR DESCRIPTION
### Description
The checkbox input needs value=true.

### Screenshots
From /dev/seed, an address question without pobox checkbox checked
![pobox-false](https://user-images.githubusercontent.com/12072571/115087985-21a25f00-9ec4-11eb-818b-e7d412d9ade1.PNG)


From /dev/seed, an address question with pobox checkbox checked
![pobox-true](https://user-images.githubusercontent.com/12072571/115087990-22d38c00-9ec4-11eb-9eb3-75a06027a837.PNG)


### Issue(s)
Fixes #817 