### PR TITLE
Add `localizedName` and `localizedDescription` to the admin Program form

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -34,7 +34,7 @@ export class AdminPrograms {
     await this.page.fill('#program-display-name-input', programName);
     await this.page.fill('#program-display-description-textarea', description);
 
-    await this.page.click('text=Create');
+    await this.page.click('text=Save');
 
     await this.expectAdminProgramsPage();
 

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -29,8 +29,10 @@ export class AdminPrograms {
     await this.gotoAdminProgramsPage();
     await this.page.click('#new-program-button');
 
-    await this.page.fill('text=Program name', programName);
-    await this.page.fill('text=Program description', description);
+    await this.page.fill('#program-name-input', programName);
+    await this.page.fill('#program-description-textarea', description);
+    await this.page.fill('#program-display-name-input', programName);
+    await this.page.fill('#program-display-description-textarea', description);
 
     await this.page.click('text=Create');
 

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -66,8 +66,8 @@ public class AdminProgramController extends CiviFormController {
         service.createProgramDefinition(
             program.getAdminName(),
             program.getAdminDescription(),
-            program.getLocalizedName(),
-            program.getLocalizedDescription());
+            program.getLocalizedDisplayName(),
+            program.getLocalizedDisplayDescription());
     if (result.isError()) {
       String errorMessage = joinErrors(result.getErrors());
       return ok(newOneView.render(request, program, errorMessage));
@@ -116,8 +116,8 @@ public class AdminProgramController extends CiviFormController {
               id,
               Locale.US,
               program.getAdminDescription(),
-              program.getLocalizedName(),
-              program.getLocalizedDescription());
+              program.getLocalizedDisplayName(),
+              program.getLocalizedDisplayDescription());
       if (result.isError()) {
         String errorMessage = joinErrors(result.getErrors());
         return ok(editView.render(request, id, program, errorMessage));

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import auth.Authorizers;
 import controllers.CiviFormController;
 import forms.ProgramForm;
+import java.util.Locale;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
@@ -62,7 +63,11 @@ public class AdminProgramController extends CiviFormController {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
-        service.createProgramDefinition(program.getName(), program.getDescription());
+        service.createProgramDefinition(
+            program.getAdminName(),
+            program.getAdminDescription(),
+            program.getLocalizedName(),
+            program.getLocalizedDescription());
     if (result.isError()) {
       String errorMessage = joinErrors(result.getErrors());
       return ok(newOneView.render(request, program, errorMessage));
@@ -107,7 +112,12 @@ public class AdminProgramController extends CiviFormController {
     ProgramForm program = programForm.bindFromRequest(request).get();
     try {
       ErrorAnd<ProgramDefinition, CiviFormError> result =
-          service.updateProgramDefinition(id, program.getName(), program.getDescription());
+          service.updateProgramDefinition(
+              id,
+              Locale.US,
+              program.getAdminDescription(),
+              program.getLocalizedName(),
+              program.getLocalizedDescription());
       if (result.isError()) {
         String errorMessage = joinErrors(result.getErrors());
         return ok(editView.render(request, id, program, errorMessage));

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -205,7 +205,9 @@ public class DatabaseSeedController extends DevController {
   private ProgramDefinition insertProgramWithBlocks(String name) {
     try {
       ProgramDefinition programDefinition =
-          programService.createProgramDefinition(name, "desc").getResult();
+          programService
+              .createProgramDefinition(name, "desc", name, "display description")
+              .getResult();
 
       BlockForm firstBlockForm = new BlockForm();
       firstBlockForm.setName("Block 1");

--- a/universal-application-tool-0.0.1/app/forms/ProgramForm.java
+++ b/universal-application-tool-0.0.1/app/forms/ProgramForm.java
@@ -1,27 +1,49 @@
 package forms;
 
 public class ProgramForm {
-  private String name;
-  private String description;
+  private String adminName;
+  private String adminDescription;
+
+  // TODO: Support multiple locales
+  private String localizedName;
+  private String localizedDescription;
 
   public ProgramForm() {
-    name = "";
-    description = "";
+    adminName = "";
+    adminDescription = "";
+    localizedName = "";
+    localizedDescription = "";
   }
 
-  public String getName() {
-    return name;
+  public String getAdminName() {
+    return adminName;
   }
 
-  public void setName(String name) {
-    this.name = name;
+  public void setAdminName(String adminName) {
+    this.adminName = adminName;
   }
 
-  public String getDescription() {
-    return description;
+  public String getAdminDescription() {
+    return adminDescription;
   }
 
-  public void setDescription(String description) {
-    this.description = description;
+  public void setAdminDescription(String adminDescription) {
+    this.adminDescription = adminDescription;
+  }
+
+  public String getLocalizedName() {
+    return localizedName;
+  }
+
+  public String getLocalizedDescription() {
+    return localizedDescription;
+  }
+
+  public void setLocalizedName(String localizedName) {
+    this.localizedName = localizedName;
+  }
+
+  public void setLocalizedDescription(String localizedDescription) {
+    this.localizedDescription = localizedDescription;
   }
 }

--- a/universal-application-tool-0.0.1/app/forms/ProgramForm.java
+++ b/universal-application-tool-0.0.1/app/forms/ProgramForm.java
@@ -5,14 +5,14 @@ public class ProgramForm {
   private String adminDescription;
 
   // TODO: Support multiple locales
-  private String localizedName;
-  private String localizedDescription;
+  private String localizedDisplayName;
+  private String localizedDisplayDescription;
 
   public ProgramForm() {
     adminName = "";
     adminDescription = "";
-    localizedName = "";
-    localizedDescription = "";
+    localizedDisplayName = "";
+    localizedDisplayDescription = "";
   }
 
   public String getAdminName() {
@@ -31,19 +31,19 @@ public class ProgramForm {
     this.adminDescription = adminDescription;
   }
 
-  public String getLocalizedName() {
-    return localizedName;
+  public String getLocalizedDisplayName() {
+    return localizedDisplayName;
   }
 
-  public String getLocalizedDescription() {
-    return localizedDescription;
+  public String getLocalizedDisplayDescription() {
+    return localizedDisplayDescription;
   }
 
-  public void setLocalizedName(String localizedName) {
-    this.localizedName = localizedName;
+  public void setLocalizedDisplayName(String localizedDisplayName) {
+    this.localizedDisplayName = localizedDisplayName;
   }
 
-  public void setLocalizedDescription(String localizedDescription) {
-    this.localizedDescription = localizedDescription;
+  public void setLocalizedDisplayDescription(String localizedDisplayDescription) {
+    this.localizedDisplayDescription = localizedDisplayDescription;
   }
 }

--- a/universal-application-tool-0.0.1/app/forms/ProgramForm.java
+++ b/universal-application-tool-0.0.1/app/forms/ProgramForm.java
@@ -4,7 +4,8 @@ public class ProgramForm {
   private String adminName;
   private String adminDescription;
 
-  // TODO: Support multiple locales
+  // TODO(https://github.com/seattle-uat/civiform/issues/777): Allow the admin to
+  // set localized strings for applicant-visible name and description.
   private String localizedDisplayName;
   private String localizedDisplayDescription;
 

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -67,14 +67,18 @@ public class Program extends BaseModel {
    * Construct a new Program object with the given program name and description, and with an empty
    * block named Block 1.
    */
-  public Program(String name, String description) {
-    this.name = name;
-    this.description = description;
+  public Program(
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription) {
+    this.name = adminName;
+    this.description = adminDescription;
     // TODO(https://github.com/seattle-uat/civiform/issues/777): Allow the admin to
     // set localized strings for applicant-visible name and description. Default to
-    // using the adming name and description for now.
-    this.localizedName = ImmutableMap.of(Locale.US, name);
-    this.localizedDescription = ImmutableMap.of(Locale.US, description);
+    // using the admin name and description for now.
+    this.localizedName = ImmutableMap.of(Locale.US, defaultDisplayName);
+    this.localizedDescription = ImmutableMap.of(Locale.US, defaultDisplayDescription);
     this.lifecycleStage = LifecycleStage.DRAFT;
     BlockDefinition emptyBlock =
         BlockDefinition.builder()

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -75,8 +75,7 @@ public class Program extends BaseModel {
     this.name = adminName;
     this.description = adminDescription;
     // TODO(https://github.com/seattle-uat/civiform/issues/777): Allow the admin to
-    // set localized strings for applicant-visible name and description. Default to
-    // using the admin name and description for now.
+    // set localized strings for applicant-visible name and description.
     this.localizedName = ImmutableMap.of(Locale.US, defaultDisplayName);
     this.localizedDescription = ImmutableMap.of(Locale.US, defaultDisplayDescription);
     this.lifecycleStage = LifecycleStage.DRAFT;

--- a/universal-application-tool-0.0.1/app/services/LocalizationUtils.java
+++ b/universal-application-tool-0.0.1/app/services/LocalizationUtils.java
@@ -1,0 +1,25 @@
+package services;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class LocalizationUtils {
+
+  /**
+   * By design, {@link ImmutableMap}s do not have a {@code remove} method in their builders. If we
+   * want to update an existing translation, we must copy the map except the existing entry for that
+   * locale, and then create a new map with the new entry.
+   */
+  public static ImmutableMap<Locale, String> overwriteExistingTranslation(
+      ImmutableMap<Locale, String> existing, Locale locale, String value) {
+    ImmutableMap.Builder<Locale, String> builder = ImmutableMap.builder();
+    for (Map.Entry<Locale, String> entry : existing.entrySet()) {
+      if (!entry.getKey().equals(locale)) {
+        builder.put(entry.getKey(), entry.getValue());
+      }
+    }
+    builder.put(locale, value);
+    return builder.build();
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Optional;
 import models.LifecycleStage;
 import models.Program;
+import services.LocalizationUtils;
 import services.question.types.QuestionDefinition;
 
 @AutoValue
@@ -222,13 +223,42 @@ public abstract class ProgramDefinition {
 
     public abstract ProgramDefinition build();
 
+    /**
+     * Add a new localization for the program name. This will fail if a translation for the given
+     * locale already exists.
+     */
     public Builder addLocalizedName(Locale locale, String name) {
       localizedNameBuilder().put(locale, name);
       return this;
     }
 
+    /**
+     * Add a new localization for the program description. This will fail if a translation for the
+     * given locale already exists.
+     */
     public Builder addLocalizedDescription(Locale locale, String name) {
       localizedDescriptionBuilder().put(locale, name);
+      return this;
+    }
+
+    /**
+     * Update an existing localization for the program name. This will overwrite the old name for
+     * that locale.
+     */
+    public Builder updateLocalizedName(
+        ImmutableMap<Locale, String> existing, Locale locale, String name) {
+      setLocalizedName(LocalizationUtils.overwriteExistingTranslation(existing, locale, name));
+      return this;
+    }
+
+    /**
+     * Update an existing localization for the program description. This will overwrite the old
+     * description for that locale.
+     */
+    public Builder updateLocalizedDescription(
+        ImmutableMap<Locale, String> existing, Locale locale, String description) {
+      setLocalizedDescription(
+          LocalizationUtils.overwriteExistingTranslation(existing, locale, description));
       return this;
     }
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -247,7 +247,11 @@ public abstract class ProgramDefinition {
      */
     public Builder updateLocalizedName(
         ImmutableMap<Locale, String> existing, Locale locale, String name) {
-      setLocalizedName(LocalizationUtils.overwriteExistingTranslation(existing, locale, name));
+      if (existing.containsKey(locale)) {
+        setLocalizedName(LocalizationUtils.overwriteExistingTranslation(existing, locale, name));
+      } else {
+        addLocalizedName(locale, name);
+      }
       return this;
     }
 
@@ -257,8 +261,12 @@ public abstract class ProgramDefinition {
      */
     public Builder updateLocalizedDescription(
         ImmutableMap<Locale, String> existing, Locale locale, String description) {
-      setLocalizedDescription(
-          LocalizationUtils.overwriteExistingTranslation(existing, locale, description));
+      if (existing.containsKey(locale)) {
+        setLocalizedDescription(
+            LocalizationUtils.overwriteExistingTranslation(existing, locale, description));
+      } else {
+        addLocalizedDescription(locale, description);
+      }
       return this;
     }
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -2,6 +2,7 @@ package services.program;
 
 import com.google.common.collect.ImmutableList;
 import forms.BlockForm;
+import java.util.Locale;
 import java.util.concurrent.CompletionStage;
 import models.Application;
 import services.CiviFormError;
@@ -54,26 +55,38 @@ public interface ProgramService {
   /**
    * Create a new program with an empty block.
    *
-   * @param name a name for this program
-   * @param description the description of what the program provides
+   * @param adminName a name for this program
+   * @param adminDescription the description of what the program provides
    * @return the {@link ProgramDefinition} that was created if succeeded, or a set of errors if
    *     failed
    */
   ErrorAnd<ProgramDefinition, CiviFormError> createProgramDefinition(
-      String name, String description);
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription);
 
   /**
-   * Update a program's name and description.
+   * Update a program's mutable fields: admin description, display name and description for
+   * applicants.
    *
    * @param programId the ID of the program to update
-   * @param name a name for this program
-   * @param description the description of what the program provides
+   * @param locale the locale for this update - only applies to applicant display name and
+   *     description
+   * @param adminDescription the description of this program - visible only to admins
+   * @param displayName a name for this program
+   * @param displayDescription the description of what the program provides
    * @return the {@link ProgramDefinition} that was updated if succeeded, or a set of errors if
    *     failed
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   ErrorAnd<ProgramDefinition, CiviFormError> updateProgramDefinition(
-      long programId, String name, String description) throws ProgramNotFoundException;
+      long programId,
+      Locale locale,
+      String adminDescription,
+      String displayName,
+      String displayDescription)
+      throws ProgramNotFoundException;
 
   /**
    * Adds a {@link BlockDefinition} to the given program.

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -55,8 +55,11 @@ public interface ProgramService {
   /**
    * Create a new program with an empty block.
    *
-   * @param adminName a name for this program
-   * @param adminDescription the description of what the program provides
+   * @param adminName a name for this program for internal use by admins - this is immutable once
+   *     set
+   * @param adminDescription a description of this program for use by admins
+   * @param defaultDisplayName the name of this program to display to applicants
+   * @param defaultDisplayDescription a description for this program to display to applicants
    * @return the {@link ProgramDefinition} that was created if succeeded, or a set of errors if
    *     failed
    */

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -145,7 +145,7 @@ public class ProgramServiceImpl implements ProgramService {
 
   private ImmutableSet<CiviFormError> validateProgramText(String... text) {
     if (Arrays.stream(text).anyMatch(String::isBlank)) {
-      return ImmutableSet.of(CiviFormError.of("program text cannot be blank"));
+      return ImmutableSet.of(CiviFormError.of("program information cannot be blank"));
     }
     return ImmutableSet.of();
   }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -3,7 +3,6 @@ package services.program;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import forms.BlockForm;
@@ -97,27 +96,43 @@ public class ProgramServiceImpl implements ProgramService {
 
   @Override
   public ErrorAnd<ProgramDefinition, CiviFormError> createProgramDefinition(
-      String name, String description) {
-    ImmutableSet<CiviFormError> errors = validateProgramDefinition(name, description);
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription) {
+
+    ImmutableSet.Builder<CiviFormError> builder = ImmutableSet.builder();
+    builder.addAll(validateProgramDefinition(adminName, adminDescription));
+    builder.addAll(validateProgramDefinition(defaultDisplayName, defaultDisplayDescription));
+
+    ImmutableSet<CiviFormError> errors = builder.build();
     if (!errors.isEmpty()) {
       return ErrorAnd.error(errors);
     }
-    Program program = new Program(name, description);
+
+    Program program =
+        new Program(adminName, adminDescription, defaultDisplayName, defaultDisplayDescription);
     return ErrorAnd.of(programRepository.insertProgramSync(program).getProgramDefinition());
   }
 
   @Override
   public ErrorAnd<ProgramDefinition, CiviFormError> updateProgramDefinition(
-      long programId, String name, String description) throws ProgramNotFoundException {
+      long programId,
+      Locale locale,
+      String adminDescription,
+      String displayName,
+      String displayDescription)
+      throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
-    ImmutableSet<CiviFormError> errors = validateProgramDefinition(name, description);
+    ImmutableSet<CiviFormError> errors = validateProgramDefinition(displayName, displayDescription);
     if (!errors.isEmpty()) {
       return ErrorAnd.error(errors);
     }
     Program program =
         programDefinition.toBuilder()
-            .setLocalizedName(ImmutableMap.of(Locale.US, name))
-            .setLocalizedDescription(ImmutableMap.of(Locale.US, description))
+            .setAdminDescription(adminDescription)
+            .addLocalizedName(locale, displayName)
+            .addLocalizedDescription(locale, displayDescription)
             .build()
             .toProgram();
     return ErrorAnd.of(

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import forms.BlockForm;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -101,11 +102,9 @@ public class ProgramServiceImpl implements ProgramService {
       String defaultDisplayName,
       String defaultDisplayDescription) {
 
-    ImmutableSet.Builder<CiviFormError> builder = ImmutableSet.builder();
-    builder.addAll(validateProgramDefinition(adminName, adminDescription));
-    builder.addAll(validateProgramDefinition(defaultDisplayName, defaultDisplayDescription));
-
-    ImmutableSet<CiviFormError> errors = builder.build();
+    ImmutableSet<CiviFormError> errors =
+        validateProgramText(
+            adminName, adminDescription, defaultDisplayName, defaultDisplayDescription);
     if (!errors.isEmpty()) {
       return ErrorAnd.error(errors);
     }
@@ -124,7 +123,8 @@ public class ProgramServiceImpl implements ProgramService {
       String displayDescription)
       throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
-    ImmutableSet<CiviFormError> errors = validateProgramDefinition(displayName, displayDescription);
+    ImmutableSet<CiviFormError> errors =
+        validateProgramText(adminDescription, displayName, displayDescription);
     if (!errors.isEmpty()) {
       return ErrorAnd.error(errors);
     }
@@ -142,15 +142,11 @@ public class ProgramServiceImpl implements ProgramService {
             .join());
   }
 
-  private ImmutableSet<CiviFormError> validateProgramDefinition(String name, String description) {
-    ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.<CiviFormError>builder();
-    if (name.isBlank()) {
-      errors.add(CiviFormError.of("program name cannot be blank"));
+  private ImmutableSet<CiviFormError> validateProgramText(String... text) {
+    if (Arrays.stream(text).anyMatch(String::isBlank)) {
+      return ImmutableSet.of(CiviFormError.of("program text cannot be blank"));
     }
-    if (description.isBlank()) {
-      errors.add(CiviFormError.of("program description cannot be blank"));
-    }
-    return errors.build();
+    return ImmutableSet.of();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -131,8 +131,9 @@ public class ProgramServiceImpl implements ProgramService {
     Program program =
         programDefinition.toBuilder()
             .setAdminDescription(adminDescription)
-            .addLocalizedName(locale, displayName)
-            .addLocalizedDescription(locale, displayDescription)
+            .updateLocalizedName(programDefinition.localizedName(), locale, displayName)
+            .updateLocalizedDescription(
+                programDefinition.localizedDescription(), locale, displayDescription)
             .build()
             .toProgram();
     return ErrorAnd.of(

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -26,15 +26,15 @@ import views.style.Styles;
  */
 public abstract class BaseHtmlView {
 
-  public Tag renderHeader(String headerText, String... additionalClasses) {
+  public static Tag renderHeader(String headerText, String... additionalClasses) {
     return h1(headerText).withClasses(Styles.M_2, StyleUtils.joinStyles(additionalClasses));
   }
 
-  protected ContainerTag fieldErrors(ImmutableSet<ValidationErrorMessage> errors) {
+  protected static ContainerTag fieldErrors(ImmutableSet<ValidationErrorMessage> errors) {
     return div(each(errors, error -> span(error.message())));
   }
 
-  protected Tag checkboxInputWithLabel(
+  protected static Tag checkboxInputWithLabel(
       String labelText, String inputId, String inputName, String inputValue) {
     return label()
         .with(
@@ -42,23 +42,23 @@ public abstract class BaseHtmlView {
             text(labelText));
   }
 
-  protected Tag button(String textContents) {
+  protected static Tag button(String textContents) {
     return TagCreator.button(text(textContents)).withType("button");
   }
 
-  protected Tag button(String id, String textContents) {
+  protected static Tag button(String id, String textContents) {
     return button(textContents).withId(id);
   }
 
-  protected Tag submitButton(String textContents) {
+  protected static Tag submitButton(String textContents) {
     return TagCreator.button(text(textContents)).withType("submit");
   }
 
-  protected Tag submitButton(String id, String textContents) {
+  protected static Tag submitButton(String id, String textContents) {
     return submitButton(textContents).withId(id);
   }
 
-  protected Tag redirectButton(String id, String text, String redirectUrl) {
+  protected static Tag redirectButton(String id, String text, String redirectUrl) {
     return button(id, text).attr("onclick", String.format("window.location = '%s';", redirectUrl));
   }
 
@@ -66,11 +66,11 @@ public abstract class BaseHtmlView {
    * Generates a hidden HTML input tag containing a signed CSRF token. The token and tag must be
    * present in all UAT forms.
    */
-  protected Tag makeCsrfTokenInputTag(Http.Request request) {
+  protected static Tag makeCsrfTokenInputTag(Http.Request request) {
     return input().isHidden().withValue(getCsrfToken(request)).withName("csrfToken");
   }
 
-  private String getCsrfToken(Http.Request request) {
+  private static String getCsrfToken(Http.Request request) {
     return CSRF.getToken(request.asScala()).value();
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramEditView.java
@@ -1,7 +1,5 @@
 package views.admin.programs;
 
-import static j2html.TagCreator.form;
-
 import com.google.inject.Inject;
 import forms.ProgramForm;
 import j2html.tags.ContainerTag;
@@ -10,7 +8,6 @@ import play.twirl.api.Content;
 import services.program.ProgramDefinition;
 import views.BaseHtmlView;
 import views.admin.AdminLayout;
-import views.components.FieldWithLabel;
 import views.components.LinkElement;
 import views.components.ToastMessage;
 import views.style.Styles;
@@ -25,11 +22,12 @@ public class ProgramEditView extends BaseHtmlView {
 
   public Content render(Request request, ProgramDefinition program) {
     ContainerTag formTag =
-        buildProgramForm(
+        ProgramFormBuilder.buildProgramForm(
                 program.adminName(),
                 program.adminDescription(),
                 program.getNameForDefaultLocale(),
-                program.getDescriptionForDefaultLocale())
+                program.getDescriptionForDefaultLocale(),
+                true)
             .with(makeCsrfTokenInputTag(request))
             .with(buildManageQuestionLink(program.id()))
             .withAction(controllers.admin.routes.AdminProgramController.update(program.id()).url());
@@ -39,61 +37,22 @@ public class ProgramEditView extends BaseHtmlView {
 
   public Content render(Request request, long id, ProgramForm program, String message) {
     ContainerTag formTag =
-        buildProgramForm(
+        ProgramFormBuilder.buildProgramForm(
                 program.getAdminName(),
                 program.getAdminDescription(),
-                program.getLocalizedName(),
-                program.getLocalizedDescription())
+                program.getLocalizedDisplayName(),
+                program.getLocalizedDisplayDescription(),
+                true)
             .with(makeCsrfTokenInputTag(request))
             .with(buildManageQuestionLink(id))
             .withAction(controllers.admin.routes.AdminProgramController.update(id).url());
 
-    if (message.length() > 0) {
+    if (!message.isEmpty()) {
       formTag.with(ToastMessage.error(message).setDismissible(false).getContainerTag());
     }
 
     return layout.render(
         renderHeader(String.format("Edit program: %s", program.getAdminName())), formTag);
-  }
-
-  private ContainerTag buildProgramForm(
-      String adminName, String adminDescription, String displayName, String displayDescription) {
-    ContainerTag formTag = form().withMethod("POST");
-    formTag.with(
-        FieldWithLabel.input()
-            .setId("program-name-input")
-            .setFieldName("adminName")
-            .setLabelText("What do you want to call this program?")
-            .setPlaceholderText(
-                "Give a name for internal identification purposes - this cannot be updated once"
-                    + " set")
-            .setValue(adminName)
-            .getContainer(),
-        FieldWithLabel.textArea()
-            .setId("program-description-textarea")
-            .setFieldName("adminDescription")
-            .setLabelText("Program description")
-            .setPlaceholderText("This description is visible only to system admins")
-            .setValue(adminDescription)
-            .getContainer(),
-        FieldWithLabel.textArea()
-            .setId("program-display-name-textarea")
-            .setFieldName("localizedDisplayName")
-            .setLabelText("Program display name")
-            .setPlaceholderText(
-                "What is the name of this program? This will be shown to applicants")
-            .setValue(displayName)
-            .getContainer(),
-        FieldWithLabel.textArea()
-            .setId("program-description-textarea")
-            .setFieldName("localizedDisplayDescription")
-            .setLabelText("Program display description")
-            .setPlaceholderText(
-                "A short description of this program. This will be shown to applicants")
-            .setValue(displayDescription)
-            .getContainer(),
-        submitButton("Save").withId("program-update-button"));
-    return formTag;
   }
 
   private ContainerTag buildManageQuestionLink(long id) {

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramEditView.java
@@ -25,7 +25,11 @@ public class ProgramEditView extends BaseHtmlView {
 
   public Content render(Request request, ProgramDefinition program) {
     ContainerTag formTag =
-        buildProgramForm(program.adminName(), program.adminDescription())
+        buildProgramForm(
+                program.adminName(),
+                program.adminDescription(),
+                program.getNameForDefaultLocale(),
+                program.getDescriptionForDefaultLocale())
             .with(makeCsrfTokenInputTag(request))
             .with(buildManageQuestionLink(program.id()))
             .withAction(controllers.admin.routes.AdminProgramController.update(program.id()).url());
@@ -35,7 +39,11 @@ public class ProgramEditView extends BaseHtmlView {
 
   public Content render(Request request, long id, ProgramForm program, String message) {
     ContainerTag formTag =
-        buildProgramForm(program.getName(), program.getDescription())
+        buildProgramForm(
+                program.getAdminName(),
+                program.getAdminDescription(),
+                program.getLocalizedName(),
+                program.getLocalizedDescription())
             .with(makeCsrfTokenInputTag(request))
             .with(buildManageQuestionLink(id))
             .withAction(controllers.admin.routes.AdminProgramController.update(id).url());
@@ -45,27 +53,44 @@ public class ProgramEditView extends BaseHtmlView {
     }
 
     return layout.render(
-        renderHeader(String.format("Edit program: %s", program.getName())), formTag);
+        renderHeader(String.format("Edit program: %s", program.getAdminName())), formTag);
   }
 
-  private ContainerTag buildProgramForm(String programName, String programDescription) {
+  private ContainerTag buildProgramForm(
+      String adminName, String adminDescription, String displayName, String displayDescription) {
     ContainerTag formTag = form().withMethod("POST");
     formTag.with(
         FieldWithLabel.input()
             .setId("program-name-input")
-            .setFieldName("name")
+            .setFieldName("adminName")
             .setLabelText("What do you want to call this program?")
             .setPlaceholderText(
                 "Give a name for internal identification purposes - this cannot be updated once"
                     + " set")
-            .setValue(programName)
+            .setValue(adminName)
             .getContainer(),
         FieldWithLabel.textArea()
             .setId("program-description-textarea")
-            .setFieldName("description")
+            .setFieldName("adminDescription")
             .setLabelText("Program description")
             .setPlaceholderText("This description is visible only to system admins")
-            .setValue(programDescription)
+            .setValue(adminDescription)
+            .getContainer(),
+        FieldWithLabel.textArea()
+            .setId("program-display-name-textarea")
+            .setFieldName("localizedDisplayName")
+            .setLabelText("Program display name")
+            .setPlaceholderText(
+                "What is the name of this program? This will be shown to applicants")
+            .setValue(displayName)
+            .getContainer(),
+        FieldWithLabel.textArea()
+            .setId("program-description-textarea")
+            .setFieldName("localizedDisplayDescription")
+            .setLabelText("Program display description")
+            .setPlaceholderText(
+                "A short description of this program. This will be shown to applicants")
+            .setValue(displayDescription)
             .getContainer(),
         submitButton("Save").withId("program-update-button"));
     return formTag;

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
@@ -18,7 +18,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
       String adminDescription,
       String displayName,
       String displayDescription,
-      boolean programExists) {
+      boolean editExistingProgram) {
     ContainerTag formTag = form().withMethod("POST");
     formTag.with(
         h2("Program Information - Administrative Use Only"),
@@ -30,7 +30,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
                 "Give a name for internal identification purposes - this cannot be updated once"
                     + " set")
             .setValue(adminName)
-            .setDisabled(programExists)
+            .setDisabled(editExistingProgram)
             .getContainer(),
         FieldWithLabel.textArea()
             .setId("program-description-textarea")

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
@@ -1,6 +1,7 @@
 package views.admin.programs;
 
 import static j2html.TagCreator.form;
+import static j2html.TagCreator.h2;
 
 import j2html.tags.ContainerTag;
 import views.BaseHtmlView;
@@ -20,6 +21,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
       boolean programExists) {
     ContainerTag formTag = form().withMethod("POST");
     formTag.with(
+        h2("Program Information - Administrative Use Only"),
         FieldWithLabel.input()
             .setId("program-name-input")
             .setFieldName("adminName")
@@ -37,8 +39,9 @@ public class ProgramFormBuilder extends BaseHtmlView {
             .setPlaceholderText("This description is visible only to system admins")
             .setValue(adminDescription)
             .getContainer(),
+        h2("Publicly Visible Program Information"),
         FieldWithLabel.input()
-            .setId("program-display-name-textarea")
+            .setId("program-display-name-input")
             .setFieldName("localizedDisplayName")
             .setLabelText("Program display name")
             .setPlaceholderText(
@@ -46,7 +49,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
             .setValue(displayName)
             .getContainer(),
         FieldWithLabel.textArea()
-            .setId("program-description-textarea")
+            .setId("program-display-description-textarea")
             .setFieldName("localizedDisplayDescription")
             .setLabelText("Program display description")
             .setPlaceholderText(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
@@ -1,0 +1,59 @@
+package views.admin.programs;
+
+import static j2html.TagCreator.form;
+
+import j2html.tags.ContainerTag;
+import views.BaseHtmlView;
+import views.components.FieldWithLabel;
+
+/**
+ * Builds a program form for rendering. If the program was previously created, the {@code adminName}
+ * field is disabled, since it cannot be edited once set.
+ */
+public class ProgramFormBuilder extends BaseHtmlView {
+
+  public static ContainerTag buildProgramForm(
+      String adminName,
+      String adminDescription,
+      String displayName,
+      String displayDescription,
+      boolean programExists) {
+    ContainerTag formTag = form().withMethod("POST");
+    formTag.with(
+        FieldWithLabel.input()
+            .setId("program-name-input")
+            .setFieldName("adminName")
+            .setLabelText("What do you want to call this program?")
+            .setPlaceholderText(
+                "Give a name for internal identification purposes - this cannot be updated once"
+                    + " set")
+            .setValue(adminName)
+            .setDisabled(programExists)
+            .getContainer(),
+        FieldWithLabel.textArea()
+            .setId("program-description-textarea")
+            .setFieldName("adminDescription")
+            .setLabelText("Program description")
+            .setPlaceholderText("This description is visible only to system admins")
+            .setValue(adminDescription)
+            .getContainer(),
+        FieldWithLabel.input()
+            .setId("program-display-name-textarea")
+            .setFieldName("localizedDisplayName")
+            .setLabelText("Program display name")
+            .setPlaceholderText(
+                "What is the name of this program? This will be shown to applicants")
+            .setValue(displayName)
+            .getContainer(),
+        FieldWithLabel.textArea()
+            .setId("program-description-textarea")
+            .setFieldName("localizedDisplayDescription")
+            .setLabelText("Program display description")
+            .setPlaceholderText(
+                "A short description of this program. This will be shown to applicants")
+            .setValue(displayDescription)
+            .getContainer(),
+        submitButton("Save").withId("program-update-button"));
+    return formTag;
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramNewOneView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramNewOneView.java
@@ -2,7 +2,6 @@ package views.admin.programs;
 
 import static j2html.TagCreator.body;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.form;
 
 import com.google.inject.Inject;
 import forms.ProgramForm;
@@ -11,7 +10,6 @@ import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import views.BaseHtmlView;
 import views.admin.AdminLayout;
-import views.components.FieldWithLabel;
 import views.components.ToastMessage;
 
 public final class ProgramNewOneView extends BaseHtmlView {
@@ -23,11 +21,17 @@ public final class ProgramNewOneView extends BaseHtmlView {
   }
 
   public Content render(Request request) {
+    ProgramForm blankForm = new ProgramForm();
     return layout.render(
         body(
             renderHeader("New program"),
             div(
-                buildProgramForm(new ProgramForm())
+                ProgramFormBuilder.buildProgramForm(
+                        blankForm.getAdminName(),
+                        blankForm.getAdminDescription(),
+                        blankForm.getLocalizedDisplayName(),
+                        blankForm.getLocalizedDisplayDescription(),
+                        false)
                     .with(makeCsrfTokenInputTag(request))
                     .withAction(controllers.admin.routes.AdminProgramController.create().url()))));
   }
@@ -37,33 +41,17 @@ public final class ProgramNewOneView extends BaseHtmlView {
         body(
             renderHeader("New program"),
             div(
-                buildProgramForm(programForm)
+                ProgramFormBuilder.buildProgramForm(
+                        programForm.getAdminName(),
+                        programForm.getAdminDescription(),
+                        programForm.getLocalizedDisplayName(),
+                        programForm.getLocalizedDisplayDescription(),
+                        false)
                     .with(makeCsrfTokenInputTag(request))
                     .withAction(controllers.admin.routes.AdminProgramController.create().url())));
     if (message.length() > 0) {
       bodyContent.with(ToastMessage.error(message).setDismissible(false).getContainerTag());
     }
     return layout.render(bodyContent);
-  }
-
-  private ContainerTag buildProgramForm(ProgramForm programForm) {
-    ContainerTag formTag = form().withMethod("POST");
-    formTag.with(
-        FieldWithLabel.input()
-            .setId("program-name-input")
-            .setFieldName("name")
-            .setLabelText("Program name")
-            .setPlaceholderText("The name of the program")
-            .setValue(programForm.getName())
-            .getContainer(),
-        FieldWithLabel.textArea()
-            .setId("program-description-textarea")
-            .setFieldName("description")
-            .setLabelText("Program description")
-            .setPlaceholderText("The description of the program")
-            .setValue(programForm.getDescription())
-            .getContainer(),
-        submitButton("Create").withId("program-create-button"));
-    return formTag;
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
@@ -70,7 +70,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     Result result = controller.create(request);
 
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("program information cannot be blank");
+    assertThat(contentAsString(result)).contains("program admin name cannot be blank");
     assertThat(contentAsString(result)).contains("New program");
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
@@ -175,7 +175,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Edit program");
-    assertThat(contentAsString(result)).contains("program information cannot be blank");
+    assertThat(contentAsString(result)).contains("program admin description cannot be blank");
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
 

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
@@ -70,7 +70,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     Result result = controller.create(request);
 
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("program name cannot be blank");
+    assertThat(contentAsString(result)).contains("program information cannot be blank");
     assertThat(contentAsString(result)).contains("New program");
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
@@ -78,9 +78,18 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
   @Test
   public void create_returnsNewProgramInList() {
     RequestBuilder requestBuilder =
-        Helpers.fakeRequest()
-            .bodyForm(
-                ImmutableMap.of("name", "New Program", "description", "This is a new program"));
+        addCSRFToken(
+            Helpers.fakeRequest()
+                .bodyForm(
+                    ImmutableMap.of(
+                        "adminName",
+                        "New Program",
+                        "adminDescription",
+                        "This is a new program",
+                        "localizedDisplayName",
+                        "display name",
+                        "localizedDisplayDescription",
+                        "display description")));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -96,9 +105,18 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
   public void create_includesNewAndExistingProgramsInList() {
     ProgramBuilder.newProgram("Existing One").build();
     RequestBuilder requestBuilder =
-        Helpers.fakeRequest()
-            .bodyForm(
-                ImmutableMap.of("name", "New Program", "description", "This is a new program"));
+        addCSRFToken(
+            Helpers.fakeRequest()
+                .bodyForm(
+                    ImmutableMap.of(
+                        "adminName",
+                        "New Program",
+                        "adminDescription",
+                        "This is a new program",
+                        "localizedDisplayName",
+                        "display name",
+                        "localizedDisplayDescription",
+                        "display description")));
 
     Result result = controller.create(requestBuilder.build());
 
@@ -157,7 +175,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Edit program");
-    assertThat(contentAsString(result)).contains("program name cannot be blank");
+    assertThat(contentAsString(result)).contains("program information cannot be blank");
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
 

--- a/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
@@ -73,7 +73,7 @@ public class ApplicationRepositoryTest extends WithPostgresContainer {
   }
 
   private Program saveProgram(String name) {
-    Program program = new Program(name, "desc");
+    Program program = new Program(name, "desc", name, "desc");
     program.save();
     return program;
   }

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -57,7 +57,7 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void insertProgramSync() throws TranslationNotFoundException {
-    Program program = new Program("ProgramRepository", "desc");
+    Program program = new Program("ProgramRepository", "desc", "name", "description");
 
     Program withId = repo.insertProgramSync(program);
 

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -62,8 +62,7 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
     Program withId = repo.insertProgramSync(program);
 
     Program found = repo.lookupProgram(withId.id).toCompletableFuture().join().get();
-    assertThat(found.getProgramDefinition().getLocalizedName(Locale.US))
-        .isEqualTo("ProgramRepository");
+    assertThat(found.getProgramDefinition().getLocalizedName(Locale.US)).isEqualTo("name");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -309,7 +309,10 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   }
 
   private void createProgram(QuestionDefinition... questions) throws Exception {
-    programDefinition = programService.createProgramDefinition("test program", "desc").getResult();
+    programDefinition =
+        programService
+            .createProgramDefinition("test program", "desc", "name", "description")
+            .getResult();
     programDefinition =
         programService
             .addBlockToProgram(programDefinition.id(), "test block", "test block description")

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -302,7 +302,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     createProgram(questionDefinition);
   }
 
-  private void createProgram(QuestionDefinition... questions) throws Exception {
+  private void createProgram(QuestionDefinition... questions) {
     programDefinition =
         ProgramBuilder.newProgram("test program", "desc")
             .withBlock()

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -160,4 +160,30 @@ public class ProgramDefinitionTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Multiple entries with same key");
   }
+
+  @Test
+  public void updateNameAndDescription_replacesExistingValue() throws TranslationNotFoundException {
+    ProgramDefinition program =
+        ProgramDefinition.builder()
+            .setId(123L)
+            .setAdminName("Admin name")
+            .setAdminDescription("Admin description")
+            .addLocalizedName(Locale.US, "existing name")
+            .addLocalizedDescription(Locale.US, "existing description")
+            .setLifecycleStage(LifecycleStage.ACTIVE)
+            .build();
+
+    program =
+        program.toBuilder()
+            .updateLocalizedName(program.localizedName(), Locale.US, "new name")
+            .build();
+    assertThat(program.getLocalizedName(Locale.US)).isEqualTo("new name");
+
+    program =
+        program.toBuilder()
+            .updateLocalizedDescription(
+                program.localizedDescription(), Locale.US, "new description")
+            .build();
+    assertThat(program.getLocalizedDescription(Locale.US)).isEqualTo("new description");
+  }
 }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -180,7 +180,11 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
     assertThat(result.getErrors())
-        .containsOnly(CiviFormError.of("program information cannot be blank"));
+        .containsOnly(
+            CiviFormError.of("program admin name cannot be blank"),
+            CiviFormError.of("program admin description cannot be blank"),
+            CiviFormError.of("program display name cannot be blank"),
+            CiviFormError.of("program display description cannot be blank"));
   }
 
   @Test
@@ -235,7 +239,10 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
     assertThat(result.getErrors())
-        .containsOnly(CiviFormError.of("program information cannot be blank"));
+        .containsOnly(
+            CiviFormError.of("program admin description cannot be blank"),
+            CiviFormError.of("program display name cannot be blank"),
+            CiviFormError.of("program display description cannot be blank"));
   }
 
   @Test


### PR DESCRIPTION
### Description
1. The non-block information for a program now contains: `adminName`, `adminDescription`, `localizedName`, and `localizedDescription`
2. When an admin edits a program, the `adminName` is not an editable field - we use this name internally to find versions of programs
3. Up next: actually provide a way for admins to enter localized names and descriptions for supported languages

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#777 

![Screen Shot 2021-04-20 at 4 44 09 PM](https://user-images.githubusercontent.com/8559046/115477044-f38c8a00-a1f7-11eb-8750-679177a6be7d.png)