### PR TITLE
New TestBankQuestion Questions

### DIFF
--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -110,20 +110,6 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private static Question applicantName(QuestionEnum ignore) {
-    QuestionDefinition definition =
-        new NameQuestionDefinition(
-            VERSION,
-            "applicant name",
-            Path.create("applicant.applicant_name"),
-            Optional.empty(),
-            "name of applicant",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "what is your name?"),
-            ImmutableMap.of(Locale.US, "help text"));
-    return maybeSave(definition);
-  }
-
   private static Question applicantAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
@@ -180,6 +166,20 @@ public class TestQuestionBank {
             ImmutableMap.of(Locale.US, "what is the household member's name?"),
             ImmutableMap.of(Locale.US, "help text"));
 
+    return maybeSave(definition);
+  }
+
+  private static Question applicantName(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new NameQuestionDefinition(
+                    VERSION,
+                    "applicant name",
+                    Path.create("applicant.applicant_name"),
+                    Optional.empty(),
+                    "name of applicant",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "what is your name?"),
+                    ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -52,7 +52,7 @@ public class TestQuestionBank {
 
   public static Question applicantAge() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
+        QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
   }
 
   public static Question applicantAddress() {
@@ -78,35 +78,35 @@ public class TestQuestionBank {
 
   public static Question applicantName() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
+        QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
   }
 
   public static Question applicantPets() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_PETS, TestQuestionBank::applicantPets);
+        QuestionEnum.APPLICANT_PETS, TestQuestionBank::applicantPets);
   }
 
   public static Question applicantPronouns() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
+        QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
   }
 
   public static Question applicantSatisfaction() {
     return questionCache.computeIfAbsent(
-            QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
+        QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
   }
 
   private static Question applicantAge(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new NumberQuestionDefinition(
-                    VERSION,
-                    "Applicant Age",
-                    Path.create("applicant.age"),
-                    Optional.empty(),
-                    "The age of the applicant",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your age?"),
-                    ImmutableMap.of(Locale.US, "help text"));
+        new NumberQuestionDefinition(
+            VERSION,
+            "Applicant Age",
+            Path.create("applicant.age"),
+            Optional.empty(),
+            "The age of the applicant",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "What is your age?"),
+            ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
@@ -185,55 +185,55 @@ public class TestQuestionBank {
 
   private static Question applicantPets(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new CheckboxQuestionDefinition(
-                    VERSION,
-                    "checkbox",
-                    Path.create("applicant.checkbox"),
-                    Optional.empty(),
-                    "description",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "question?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    ImmutableList.of(
-                            QuestionOption.create(1L, ImmutableMap.of(Locale.US, "cat")),
-                            QuestionOption.create(2L, ImmutableMap.of(Locale.US, "dog"))));
+        new CheckboxQuestionDefinition(
+            VERSION,
+            "checkbox",
+            Path.create("applicant.checkbox"),
+            Optional.empty(),
+            "description",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "question?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            ImmutableList.of(
+                QuestionOption.create(1L, ImmutableMap.of(Locale.US, "cat")),
+                QuestionOption.create(2L, ImmutableMap.of(Locale.US, "dog"))));
     return maybeSave(definition);
   }
 
   private static Question applicantPronouns(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new DropdownQuestionDefinition(
-                    VERSION,
-                    "applicant preferred pronouns",
-                    Path.create("applicant.preferred.pronouns"),
-                    Optional.empty(),
-                    "Allows the applicant to select a preferred pronoun",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    ImmutableList.of(
-                            QuestionOption.create(1L, ImmutableMap.of(Locale.US, "He / him")),
-                            QuestionOption.create(2L, ImmutableMap.of(Locale.US, "He / him")),
-                            QuestionOption.create(3L, ImmutableMap.of(Locale.FRANCE, "Il / lui")),
-                            QuestionOption.create(4L, ImmutableMap.of(Locale.FRANCE, "Elle / elle"))));
+        new DropdownQuestionDefinition(
+            VERSION,
+            "applicant preferred pronouns",
+            Path.create("applicant.preferred.pronouns"),
+            Optional.empty(),
+            "Allows the applicant to select a preferred pronoun",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            ImmutableList.of(
+                QuestionOption.create(1L, ImmutableMap.of(Locale.US, "He / him")),
+                QuestionOption.create(2L, ImmutableMap.of(Locale.US, "He / him")),
+                QuestionOption.create(3L, ImmutableMap.of(Locale.FRANCE, "Il / lui")),
+                QuestionOption.create(4L, ImmutableMap.of(Locale.FRANCE, "Elle / elle"))));
     return maybeSave(definition);
   }
 
   private static Question applicantSatisfaction(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new RadioButtonQuestionDefinition(
-                    VERSION,
-                    "Applicant Satisfaction",
-                    Path.create("applicant.satisfaction"),
-                    Optional.empty(),
-                    "The applicant's overall satisfaction with something",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "What is your satisfaction with enrollment?"),
-                    ImmutableMap.of(Locale.US, "help text"),
-                    ImmutableList.of(
-                            QuestionOption.create(1L, ImmutableMap.of(Locale.US, "dissatisfied")),
-                            QuestionOption.create(2L, ImmutableMap.of(Locale.US, "neutral")),
-                            QuestionOption.create(3L, ImmutableMap.of(Locale.US, "satisfied"))));
+        new RadioButtonQuestionDefinition(
+            VERSION,
+            "Applicant Satisfaction",
+            Path.create("applicant.satisfaction"),
+            Optional.empty(),
+            "The applicant's overall satisfaction with something",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "What is your satisfaction with enrollment?"),
+            ImmutableMap.of(Locale.US, "help text"),
+            ImmutableList.of(
+                QuestionOption.create(1L, ImmutableMap.of(Locale.US, "dissatisfied")),
+                QuestionOption.create(2L, ImmutableMap.of(Locale.US, "neutral")),
+                QuestionOption.create(3L, ImmutableMap.of(Locale.US, "satisfied"))));
     return maybeSave(definition);
   }
 
@@ -257,8 +257,8 @@ public class TestQuestionBank {
     APPLICANT_ADDRESS,
     APPLICANT_AGE,
     APPLICANT_FAVORITE_COLOR,
-    APPLICANT_HOUSEHOLD_MEMBERS,
     APPLICANT_HOUSEHOLD_MEMBER_NAME,
+    APPLICANT_HOUSEHOLD_MEMBERS,
     APPLICANT_NAME,
     APPLICANT_PETS,
     APPLICANT_PRONOUNS,

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -171,15 +171,15 @@ public class TestQuestionBank {
 
   private static Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new NameQuestionDefinition(
-                    VERSION,
-                    "applicant name",
-                    Path.create("applicant.applicant_name"),
-                    Optional.empty(),
-                    "name of applicant",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "what is your name?"),
-                    ImmutableMap.of(Locale.US, "help text"));
+        new NameQuestionDefinition(
+            VERSION,
+            "applicant name",
+            Path.create("applicant.applicant_name"),
+            Optional.empty(),
+            "name of applicant",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "what is your name?"),
+            ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
@@ -212,10 +212,14 @@ public class TestQuestionBank {
             ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
             ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
-                QuestionOption.create(1L, ImmutableMap.of(Locale.US, "He / him")),
-                QuestionOption.create(2L, ImmutableMap.of(Locale.US, "He / him")),
-                QuestionOption.create(3L, ImmutableMap.of(Locale.FRANCE, "Il / lui")),
-                QuestionOption.create(4L, ImmutableMap.of(Locale.FRANCE, "Elle / elle"))));
+                QuestionOption.create(
+                    1L, ImmutableMap.of(Locale.US, "He / him", Locale.FRANCE, "Il / lui")),
+                QuestionOption.create(
+                    2L, ImmutableMap.of(Locale.US, "She / her", Locale.FRANCE, "Elle / elle")),
+                QuestionOption.create(
+                    2L,
+                    ImmutableMap.of(
+                        Locale.US, "They / them", Locale.FRANCE, "(elles ils) / eux"))));
     return maybeSave(definition);
   }
 

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -1,7 +1,6 @@
 package support;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Map;

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -1,5 +1,7 @@
 package support;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Map;
@@ -10,11 +12,16 @@ import javax.persistence.PersistenceException;
 import models.LifecycleStage;
 import models.Question;
 import services.Path;
+import services.question.QuestionOption;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.AddressQuestionDefinition;
+import services.question.types.CheckboxQuestionDefinition;
+import services.question.types.DropdownQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
+import services.question.types.NumberQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.RadioButtonQuestionDefinition;
 import services.question.types.RepeaterQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
@@ -44,9 +51,9 @@ public class TestQuestionBank {
     nextId.set(1L);
   }
 
-  public static Question applicantName() {
+  public static Question applicantAge() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
+            QuestionEnum.APPLICANT_AGE, TestQuestionBank::applicantAge);
   }
 
   public static Question applicantAddress() {
@@ -68,6 +75,40 @@ public class TestQuestionBank {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME,
         TestQuestionBank::applicantHouseholdMemberName);
+  }
+
+  public static Question applicantName() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
+  }
+
+  public static Question applicantPets() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_PETS, TestQuestionBank::applicantPets);
+  }
+
+  public static Question applicantPronouns() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_PRONOUNS, TestQuestionBank::applicantPronouns);
+  }
+
+  public static Question applicantSatisfaction() {
+    return questionCache.computeIfAbsent(
+            QuestionEnum.APPLICANT_SATISFACTION, TestQuestionBank::applicantSatisfaction);
+  }
+
+  private static Question applicantAge(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new NumberQuestionDefinition(
+                    VERSION,
+                    "Applicant Age",
+                    Path.create("applicant.age"),
+                    Optional.empty(),
+                    "The age of the applicant",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your age?"),
+                    ImmutableMap.of(Locale.US, "help text"));
+    return maybeSave(definition);
   }
 
   private static Question applicantName(QuestionEnum ignore) {
@@ -143,6 +184,60 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  private static Question applicantPets(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new CheckboxQuestionDefinition(
+                    VERSION,
+                    "checkbox",
+                    Path.create("applicant.checkbox"),
+                    Optional.empty(),
+                    "description",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "question?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    ImmutableList.of(
+                            QuestionOption.create(1L, ImmutableMap.of(Locale.US, "cat")),
+                            QuestionOption.create(2L, ImmutableMap.of(Locale.US, "dog"))));
+    return maybeSave(definition);
+  }
+
+  private static Question applicantPronouns(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new DropdownQuestionDefinition(
+                    VERSION,
+                    "applicant preferred pronouns",
+                    Path.create("applicant.preferred.pronouns"),
+                    Optional.empty(),
+                    "Allows the applicant to select a preferred pronoun",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your preferred pronoun?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    ImmutableList.of(
+                            QuestionOption.create(1L, ImmutableMap.of(Locale.US, "He / him")),
+                            QuestionOption.create(2L, ImmutableMap.of(Locale.US, "He / him")),
+                            QuestionOption.create(3L, ImmutableMap.of(Locale.FRANCE, "Il / lui")),
+                            QuestionOption.create(4L, ImmutableMap.of(Locale.FRANCE, "Elle / elle"))));
+    return maybeSave(definition);
+  }
+
+  private static Question applicantSatisfaction(QuestionEnum ignore) {
+    QuestionDefinition definition =
+            new RadioButtonQuestionDefinition(
+                    VERSION,
+                    "Applicant Satisfaction",
+                    Path.create("applicant.satisfaction"),
+                    Optional.empty(),
+                    "The applicant's overall satisfaction with something",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "What is your satisfaction with enrollment?"),
+                    ImmutableMap.of(Locale.US, "help text"),
+                    ImmutableList.of(
+                            QuestionOption.create(1L, ImmutableMap.of(Locale.US, "dissatisfied")),
+                            QuestionOption.create(2L, ImmutableMap.of(Locale.US, "neutral")),
+                            QuestionOption.create(3L, ImmutableMap.of(Locale.US, "satisfied"))));
+    return maybeSave(definition);
+  }
+
   private static Question maybeSave(QuestionDefinition questionDefinition) {
     Question question = new Question(questionDefinition);
     try {
@@ -160,10 +255,14 @@ public class TestQuestionBank {
   }
 
   private enum QuestionEnum {
-    APPLICANT_NAME,
     APPLICANT_ADDRESS,
+    APPLICANT_AGE,
     APPLICANT_FAVORITE_COLOR,
     APPLICANT_HOUSEHOLD_MEMBERS,
-    APPLICANT_HOUSEHOLD_MEMBER_NAME
+    APPLICANT_HOUSEHOLD_MEMBER_NAME,
+    APPLICANT_NAME,
+    APPLICANT_PETS,
+    APPLICANT_PRONOUNS,
+    APPLICANT_SATISFACTION
   }
 }


### PR DESCRIPTION
### Description
Hi, after the last few commits to main I found I had to rewrite some of the tests to use `ImmutableMap` instead of `ImmutableMapList`.  To help myself be more productive I wanted to create smaller PR's so I wouldn't run into these type of rebase conflicts.

In this PR I've added the following to `TestQuestionBank`:
* `applicantAge()` a `NumberQuestionDefinition`
* `applicantPets()` a `CheckboxQuestionDefinition`
* `applicantPronouns()` a `DropdownQuestionDefinition`
* `applicantSatisfaction()` a `RadioButtonQuestionDefinition`

I also alphabetized the methods.  These methods will be used when replacing some of the `QuestionBuilder` methods with pre-seeded `TestQuestionBank` questions.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary