### PR TITLE
Allow an applicant to set their preferred language

### DIFF
--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -1,4 +1,4 @@
-import { startSession, logout, loginAsGuest, loginAsAdmin, ApplicantQuestions, AdminQuestions, AdminPrograms, endSession } from './support'
+import { startSession, logout, loginAsGuest, loginAsAdmin, selectApplicantLanguage, ApplicantQuestions, AdminQuestions, AdminPrograms, endSession } from './support'
 
 describe('normal application flow', () => {
   it('all major steps', async () => {
@@ -21,6 +21,7 @@ describe('normal application flow', () => {
 
     await logout(page);
     await loginAsGuest(page);
+    await selectApplicantLanguage(page, 'English');
 
     await applicantQuestions.applyProgram(programName);
 

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -1,4 +1,4 @@
-import { startSession, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsGuest, ApplicantQuestions } from './support'
+import { startSession, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsGuest, selectApplicantLanguage, ApplicantQuestions } from './support'
 
 describe('normal application flow', () => {
   it('all major steps', async () => {
@@ -40,6 +40,7 @@ describe('normal application flow', () => {
 
     await logout(page);
     await loginAsGuest(page);
+    await selectApplicantLanguage(page, 'English');
 
     const applicantQuestions = new ApplicantQuestions(page);
 

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -35,6 +35,11 @@ export const loginAsGuest = async (page: Page) => {
   await page.click('#guest');
 }
 
+export const selectApplicantLanguage = async (page: Page, language: string) => {
+  await page.selectOption('select', { label: language });
+  await page.click('button');
+}
+
 export const dropTables = async (page: Page) => {
   await page.goto(BASE_URL + '/dev/seed');
   await page.click("#clear");

--- a/universal-application-tool-0.0.1/app/controllers/HomeController.java
+++ b/universal-application-tool-0.0.1/app/controllers/HomeController.java
@@ -15,6 +15,7 @@ import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
+import services.applicant.ApplicantData;
 import views.LoginForm;
 import views.html.index;
 
@@ -57,11 +58,21 @@ public class HomeController extends Controller {
       return profile
           .getApplicant()
           .thenApplyAsync(
-              applicant ->
-                  redirect(
+              applicant -> {
+                // If the applicant has not yet set their preferred language, redirect to
+                // the information controller to ask for preferred language.
+                ApplicantData data = applicant.getApplicantData();
+                if (data.hasPreferredLocale()) {
+                  return redirect(
                           controllers.applicant.routes.ApplicantProgramsController.index(
                               applicant.id))
-                      .withLang(applicant.getApplicantData().preferredLocale(), messagesApi),
+                      .withLang(data.preferredLocale(), messagesApi);
+                } else {
+                  return redirect(
+                      controllers.applicant.routes.ApplicantInformationController.edit(
+                          applicant.id));
+                }
+              },
               httpExecutionContext.current());
     }
   }

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantInformationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantInformationController.java
@@ -1,5 +1,7 @@
 package controllers.applicant;
 
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
 import auth.ProfileUtils;
 import controllers.CiviFormController;
 import forms.ApplicantInformationForm;
@@ -15,11 +17,16 @@ import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
+import play.mvc.Results;
 import repository.ApplicantRepository;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantNotFoundException;
 import views.applicant.ApplicantInformationView;
 
+/**
+ * Provides methods for editing and updating an applicant's information, such as their preferred
+ * language.
+ */
 public final class ApplicantInformationController extends CiviFormController {
 
   private final HttpExecutionContext httpExecutionContext;
@@ -62,7 +69,9 @@ public final class ApplicantInformationController extends CiviFormController {
 
   public CompletionStage<Result> update(Http.Request request, long applicantId) {
     Form<ApplicantInformationForm> form = formFactory.form(ApplicantInformationForm.class);
-    // TODO: catch form binding error and give bad request
+    if (form.hasErrors()) {
+      return supplyAsync(Results::badRequest);
+    }
     ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
 
     return checkApplicantAuthorization(profileUtils, request, applicantId)

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantInformationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantInformationController.java
@@ -84,6 +84,7 @@ public final class ApplicantInformationController extends CiviFormController {
                 Applicant applicant = maybeApplicant.get();
                 ApplicantData data = applicant.getApplicantData();
                 data.setPreferredLocale(infoForm.getLocale());
+                // Update the applicant, then pass the updated applicant to the next stage.
                 return repository
                     .updateApplicant(applicant)
                     .thenApplyAsync(v -> applicant, httpExecutionContext.current());

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantInformationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantInformationController.java
@@ -1,0 +1,90 @@
+package controllers.applicant;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+import auth.ProfileUtils;
+import controllers.CiviFormController;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+
+import forms.ApplicantInformationForm;
+import models.Applicant;
+import play.data.Form;
+import play.data.FormFactory;
+import play.libs.concurrent.HttpExecutionContext;
+import play.mvc.Http;
+import play.mvc.Result;
+import repository.ApplicantRepository;
+import services.applicant.ApplicantData;
+import views.applicant.ApplicantInformationView;
+
+public final class ApplicantInformationController extends CiviFormController {
+
+  private final HttpExecutionContext httpExecutionContext;
+  private final ApplicantInformationView informationView;
+  private final ApplicantRepository repository;
+  private final FormFactory formFactory;
+  private final ProfileUtils profileUtils;
+
+  @Inject
+  public ApplicantInformationController(
+          HttpExecutionContext httpExecutionContext,
+      ApplicantInformationView informationView,
+      ApplicantRepository repository,
+      FormFactory formFactory,
+      ProfileUtils profileUtils) {
+    this.httpExecutionContext = httpExecutionContext;
+    this.informationView = informationView;
+    this.repository = repository;
+    this.formFactory = formFactory;
+    this.profileUtils = profileUtils;
+  }
+
+  public CompletionStage<Result> edit(Http.Request request, long applicantId) {
+    return checkApplicantAuthorization(profileUtils, request, applicantId)
+        .thenApplyAsync(v -> ok(informationView.render(request, applicantId)), httpExecutionContext.current())
+        .exceptionally(
+            ex -> {
+              if (ex instanceof CompletionException) {
+                if (ex.getCause() instanceof SecurityException) {
+                  return unauthorized();
+                }
+              }
+              throw new RuntimeException(ex);
+            });
+  }
+
+  public CompletionStage<Result> update(Http.Request request, long applicantId) {
+    return checkApplicantAuthorization(profileUtils, request, applicantId)
+        .thenApplyAsync(v -> repository.lookupApplicant(applicantId), httpExecutionContext.current())
+        .thenApplyAsync(maybeApplicant -> {
+          // Set preferred locale.
+          Optional<Applicant> applicant = maybeApplicant.toCompletableFuture().join();
+          Form<ApplicantInformationForm> form = formFactory.form(ApplicantInformationForm.class);
+          ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
+
+          if (applicant.isPresent()) {
+            ApplicantData data = applicant.get().getApplicantData();
+            data.setPreferredLocale(infoForm.getLocale());
+            return repository.updateApplicant(applicant.get());
+          } else {
+            throw new RuntimeException("Current applicant does not exist");
+          }
+        }, httpExecutionContext.current())
+        .thenComposeAsync(
+            v -> supplyAsync(
+                () -> redirect(routes.ApplicantProgramsController.index(applicantId))), httpExecutionContext.current())
+        .exceptionally(
+            ex -> {
+              if (ex instanceof CompletionException) {
+                if (ex.getCause() instanceof SecurityException) {
+                  return unauthorized();
+                }
+              }
+              throw new RuntimeException(ex);
+            });
+  }
+}

--- a/universal-application-tool-0.0.1/app/forms/ApplicantInformationForm.java
+++ b/universal-application-tool-0.0.1/app/forms/ApplicantInformationForm.java
@@ -1,0 +1,20 @@
+package forms;
+
+import java.util.Locale;
+
+public class ApplicantInformationForm {
+  private Locale locale;
+
+  public ApplicantInformationForm() {
+    // The default language for CiviForm is US English.
+    locale = Locale.US;
+  }
+
+  public Locale getLocale() {
+    return this.locale;
+  }
+
+  public void setLocale(String languageTag) {
+    this.locale = Locale.forLanguageTag(languageTag);
+  }
+}

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -60,7 +60,10 @@ public class Applicant extends BaseModel {
   @PrePersist
   @PreUpdate
   public void synchronizeObject() {
-    this.preferredLocale = getApplicantData().preferredLocale().toLanguageTag();
+    this.preferredLocale =
+        getApplicantData().hasPreferredLocale()
+            ? getApplicantData().preferredLocale().toLanguageTag()
+            : null;
     this.object = objectAsJsonString();
   }
 

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -6,6 +6,7 @@ import io.ebean.annotation.WhenCreated;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -47,7 +48,8 @@ public class Applicant extends BaseModel {
         // Default to English until the applicant specifies their preferred language.
         this.applicantData = new ApplicantData(object);
       } else {
-        this.applicantData = new ApplicantData(Locale.forLanguageTag(preferredLocale), object);
+        this.applicantData =
+            new ApplicantData(Optional.of(Locale.forLanguageTag(preferredLocale)), object);
       }
     } else if (this.applicantData == null) {
       this.applicantData = new ApplicantData();

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -25,7 +25,7 @@ public class ApplicantData {
   private static final Locale DEFAULT_LOCALE = Locale.US;
   private static final TypeRef<ImmutableList<Long>> IMMUTABLE_LIST_LONG_TYPE = new TypeRef<>() {};
 
-  private Locale preferredLocale;
+  private Optional<Locale> preferredLocale;
   private final DocumentContext jsonData;
 
   public ApplicantData() {
@@ -33,20 +33,26 @@ public class ApplicantData {
   }
 
   public ApplicantData(String jsonData) {
-    this(DEFAULT_LOCALE, jsonData);
+    this(Optional.empty(), jsonData);
   }
 
-  public ApplicantData(Locale preferredLocale, String jsonData) {
+  public ApplicantData(Optional<Locale> preferredLocale, String jsonData) {
     this.preferredLocale = preferredLocale;
     this.jsonData = JsonPathProvider.getJsonPath().parse(checkNotNull(jsonData));
   }
 
+  /** Returns true if this applicant has set their preferred locale, and false otherwise. */
+  public boolean hasPreferredLocale() {
+    return this.preferredLocale.isPresent();
+  }
+
+  /** Returns this applicant's preferred locale if it is set, or the default locale if not set. */
   public Locale preferredLocale() {
-    return this.preferredLocale;
+    return this.preferredLocale.orElse(DEFAULT_LOCALE);
   }
 
   public void setPreferredLocale(Locale locale) {
-    this.preferredLocale = locale;
+    this.preferredLocale = Optional.of(locale);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
@@ -1,0 +1,62 @@
+package views.applicant;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.form;
+import static j2html.TagCreator.p;
+
+import com.google.common.collect.ImmutableList;
+import controllers.applicant.routes;
+import j2html.tags.ContainerTag;
+import java.util.AbstractMap;
+import java.util.Locale;
+import javax.inject.Inject;
+import play.i18n.Lang;
+import play.i18n.Langs;
+import play.mvc.Http;
+import play.twirl.api.Content;
+import views.BaseHtmlView;
+import views.components.SelectWithLabel;
+
+public class ApplicantInformationView extends BaseHtmlView {
+
+  private final ApplicantLayout layout;
+  private final ImmutableList<Locale> supportedLanguages;
+
+  @Inject
+  public ApplicantInformationView(ApplicantLayout layout, Langs langs) {
+    this.layout = layout;
+    this.supportedLanguages =
+        langs.availables().stream().map(Lang::toLocale).collect(toImmutableList());
+  }
+
+  public Content render(Http.Request request, long applicantId) {
+    String formAction = routes.ApplicantProgramsController.index(applicantId).url();
+    return layout.render(
+        form()
+            .withAction(formAction)
+            .withMethod(Http.HttpVerbs.POST)
+            .with(makeCsrfTokenInputTag(request))
+            .with(selectLanguageDropdown())
+            .with(submitButton("Submit")));
+  }
+
+  private ContainerTag selectLanguageDropdown() {
+    SelectWithLabel languageSelect = new SelectWithLabel();
+    languageSelect.setId("select-language");
+
+    // An option consists of the language (localized to that language - for example, this would
+    // display 'Español' for es-US), and the value is the ISO code.
+    languageSelect.setOptions(
+        this.supportedLanguages.stream()
+            .map(
+                locale ->
+                    new AbstractMap.SimpleEntry<>(
+                        locale.getDisplayLanguage(locale), locale.toLanguageTag()))
+            .collect(toImmutableList()));
+
+    return div()
+        .with(p("Please select your preferred language from the following: "))
+        .with(languageSelect.getContainer());
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
@@ -47,18 +47,19 @@ public class ApplicantInformationView extends BaseHtmlView {
   }
 
   private ContainerTag selectLanguageDropdown() {
-    SelectWithLabel languageSelect = new SelectWithLabel();
-    languageSelect.setId("select-language");
-    languageSelect.setFieldName("locale");
-
-    // An option consists of the language (localized to that language - for example, this would
-    // display 'Español' for es-US), and the value is the ISO code.
-    languageSelect.setOptions(
-        this.supportedLanguages.stream()
-            .map(
-                locale ->
-                    new AbstractMap.SimpleEntry<>(formatLabel(locale), locale.toLanguageTag()))
-            .collect(toImmutableList()));
+    SelectWithLabel languageSelect =
+        new SelectWithLabel()
+            .setId("select-language")
+            .setFieldName("locale")
+            .setOptions(
+                // An option consists of the language (localized to that language - for example,
+                // this would display 'Español' for es-US), and the value is the ISO code.
+                this.supportedLanguages.stream()
+                    .map(
+                        locale ->
+                            new AbstractMap.SimpleEntry<>(
+                                formatLabel(locale), locale.toLanguageTag()))
+                    .collect(toImmutableList()));
 
     return div()
         .with(p("Please select your preferred language from the following: "))
@@ -67,7 +68,7 @@ public class ApplicantInformationView extends BaseHtmlView {
 
   /**
    * The dropdown option label should be the language name localized to that language - for example,
-   * "español" for "es-US"). We capitalize the first letter, since some locales do not capitalize
+   * "español" for "es-US". We capitalize the first letter, since some locales do not capitalize
    * languages.
    */
   private String formatLabel(Locale locale) {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
@@ -31,7 +31,7 @@ public class ApplicantInformationView extends BaseHtmlView {
   }
 
   public Content render(Http.Request request, long applicantId) {
-    String formAction = routes.ApplicantProgramsController.index(applicantId).url();
+    String formAction = routes.ApplicantInformationController.update(applicantId).url();
     return layout.render(
         form()
             .withAction(formAction)
@@ -44,6 +44,7 @@ public class ApplicantInformationView extends BaseHtmlView {
   private ContainerTag selectLanguageDropdown() {
     SelectWithLabel languageSelect = new SelectWithLabel();
     languageSelect.setId("select-language");
+    languageSelect.setFieldName("locale");
 
     // An option consists of the language (localized to that language - for example, this would
     // display 'Español' for es-US), and the value is the ISO code.

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
@@ -18,6 +18,11 @@ import play.twirl.api.Content;
 import views.BaseHtmlView;
 import views.components.SelectWithLabel;
 
+/**
+ * Provides a form for selecting an applicant's preferred language. Note that we cannot use Play's
+ * {@link play.i18n.Messages}, since the applicant has no language set yet. Instead, we use English
+ * since this is the CiviForm default language.
+ */
 public class ApplicantInformationView extends BaseHtmlView {
 
   private final ApplicantLayout layout;

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
@@ -57,12 +57,21 @@ public class ApplicantInformationView extends BaseHtmlView {
         this.supportedLanguages.stream()
             .map(
                 locale ->
-                    new AbstractMap.SimpleEntry<>(
-                        locale.getDisplayLanguage(locale), locale.toLanguageTag()))
+                    new AbstractMap.SimpleEntry<>(formatLabel(locale), locale.toLanguageTag()))
             .collect(toImmutableList()));
 
     return div()
         .with(p("Please select your preferred language from the following: "))
         .with(languageSelect.getContainer());
+  }
+
+  /**
+   * The dropdown option label should be the language name localized to that language - for example,
+   * "español" for "es-US"). We capitalize the first letter, since some locales do not capitalize
+   * languages.
+   */
+  private String formatLabel(Locale locale) {
+    String language = locale.getDisplayLanguage(locale);
+    return language.substring(0, 1).toUpperCase(locale) + language.substring(1);
   }
 }

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -49,6 +49,8 @@ POST    /demo                       controllers.J2HtmlDemoController.create(requ
 GET     /assets/*file               controllers.Assets.versioned(file)
 
 # Methods for applicants
+GET     /applicants/:applicantId/edit                                       controllers.applicant.ApplicantInformationController.edit(request: Request, applicantId: Long)
+POST    /applicants/:applicantId                                            controllers.applicant.ApplicantInformationController.update(request: Request, applicantId: Long)
 GET     /applicants/:applicantId/programs                                   controllers.applicant.ApplicantProgramsController.index(request: Request, applicantId: Long)
 GET     /applicants/:applicantId/programs/:programId/edit                   controllers.applicant.ApplicantProgramsController.edit(request: Request, applicantId: Long, programId: Long)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit   controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, applicantId: Long, programId: Long, blockId: String)

--- a/universal-application-tool-0.0.1/test/app/SecurityBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/SecurityBrowserTest.java
@@ -76,13 +76,13 @@ public class SecurityBrowserTest extends BaseBrowserTest {
   }
 
   @Test
-  public void homePage_whenLoggedInAsApplicant_redirectsToApplicantProgramList() {
+  public void homePage_whenLoggedInAsApplicantForFirstTime_redirectsToLanguageForm() {
     loginAsGuest();
     long applicantId = getApplicantId();
 
     goToRootUrl();
 
-    assertUrlEquals(controllers.applicant.routes.ApplicantProgramsController.index(applicantId));
+    assertUrlEquals(controllers.applicant.routes.ApplicantInformationController.edit(applicantId));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -1,0 +1,56 @@
+package controllers.applicant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.api.test.CSRFTokenHelper.addCSRFToken;
+import static play.mvc.Http.Status.UNAUTHORIZED;
+import static play.test.Helpers.contentAsString;
+import static play.test.Helpers.fakeRequest;
+
+import models.Applicant;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Result;
+
+public class ApplicantInformationControllerTest extends WithMockedApplicantProfiles {
+
+  private Applicant currentApplicant;
+  private ApplicantInformationController controller;
+
+  @Before
+  public void setup() {
+    resourceCreator().clearDatabase();
+    controller = instanceOf(ApplicantInformationController.class);
+    currentApplicant = createApplicantWithMockedProfile();
+  }
+
+  @Test
+  public void edit_differentApplicant_returnsUnauthorizedResult() {
+    Result result =
+        controller
+            .edit(fakeRequest().build(), currentApplicant.id + 1)
+            .toCompletableFuture()
+            .join();
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void update_differentApplicant_returnsUnauthorizedResult() {
+    Result result =
+        controller
+            .update(fakeRequest().build(), currentApplicant.id + 1)
+            .toCompletableFuture()
+            .join();
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void edit_usesHumanReadableLanguagesInsteadOfIsoTags() {
+    Result result =
+        controller
+            .edit(addCSRFToken(fakeRequest()).build(), currentApplicant.id)
+            .toCompletableFuture()
+            .join();
+    assertThat(contentAsString(result)).contains("English");
+    assertThat(contentAsString(result)).contains("español");
+  }
+}

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -59,7 +59,7 @@ public class ApplicantInformationControllerTest extends WithMockedApplicantProfi
             .toCompletableFuture()
             .join();
     assertThat(contentAsString(result)).contains("English");
-    assertThat(contentAsString(result)).contains("español");
+    assertThat(contentAsString(result)).contains("Español");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -2,24 +2,32 @@ package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
+import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
+import static play.test.Helpers.stubMessagesApi;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
+import play.mvc.Http;
 import play.mvc.Result;
+import repository.ApplicantRepository;
 
 public class ApplicantInformationControllerTest extends WithMockedApplicantProfiles {
 
   private Applicant currentApplicant;
+  private ApplicantRepository applicantRepository;
   private ApplicantInformationController controller;
 
   @Before
   public void setup() {
     resourceCreator().clearDatabase();
     controller = instanceOf(ApplicantInformationController.class);
+    applicantRepository = instanceOf(ApplicantRepository.class);
     currentApplicant = createApplicantWithMockedProfile();
   }
 
@@ -52,5 +60,42 @@ public class ApplicantInformationControllerTest extends WithMockedApplicantProfi
             .join();
     assertThat(contentAsString(result)).contains("English");
     assertThat(contentAsString(result)).contains("español");
+  }
+
+  @Test
+  public void update_redirectsToProgramIndex_withNonEnglishLocale() {
+    Http.Request request =
+        addCSRFToken(
+                fakeRequest(routes.ApplicantInformationController.update(currentApplicant.id))
+                    .bodyForm(ImmutableMap.of("locale", "es-US")))
+            .build();
+
+    Result result = controller.update(request, currentApplicant.id).toCompletableFuture().join();
+
+    currentApplicant =
+        applicantRepository.lookupApplicant(currentApplicant.id).toCompletableFuture().join().get();
+    assertThat(currentApplicant.getApplicantData().preferredLocale())
+        .isEqualTo(Locale.forLanguageTag("es-US"));
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.cookie("PLAY_LANG").get().value()).isEqualTo("es-US");
+  }
+
+  @Test
+  public void update_ignoresExistingLangCookie() {
+    Http.Request request =
+        addCSRFToken(
+                fakeRequest(routes.ApplicantInformationController.update(currentApplicant.id))
+                    .bodyForm(ImmutableMap.of("locale", "es-US")))
+            .langCookie(Locale.US, stubMessagesApi())
+            .build();
+
+    Result result = controller.update(request, currentApplicant.id).toCompletableFuture().join();
+
+    currentApplicant =
+        applicantRepository.lookupApplicant(currentApplicant.id).toCompletableFuture().join().get();
+    assertThat(currentApplicant.getApplicantData().preferredLocale())
+        .isEqualTo(Locale.forLanguageTag("es-US"));
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.cookie("PLAY_LANG").get().value()).isEqualTo("es-US");
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -1,10 +1,7 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
-import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
@@ -15,59 +12,28 @@ import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
 
-import auth.ProfileFactory;
-import auth.ProfileUtils;
-import auth.UatProfile;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
-import models.Account;
 import models.Applicant;
 import models.Program;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
-import play.inject.Injector;
-import play.inject.guice.GuiceApplicationBuilder;
-import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
-import support.ResourceCreator;
-import support.TestConstants;
 import support.TestQuestionBank;
 
-public class ApplicantProgramBlocksControllerTest {
-
-  private static final ProfileUtils MOCK_UTILS = Mockito.mock(ProfileUtils.class);
-
-  private static Injector injector;
-  private static ResourceCreator resourceCreator;
-  private static ProfileFactory profileFactory;
+public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantProfiles {
 
   private ApplicantProgramBlocksController subject;
   private Program program;
   private Applicant applicant;
 
-  @BeforeClass
-  public static void setupInjector() {
-    injector =
-        new GuiceApplicationBuilder()
-            .configure(TestConstants.TEST_DATABASE_CONFIG)
-            .overrides(bind(ProfileUtils.class).toInstance(MOCK_UTILS))
-            .build()
-            .injector();
-    resourceCreator = new ResourceCreator(injector);
-    profileFactory = injector.instanceOf(ProfileFactory.class);
-  }
-
   @Before
   public void setUpWithFreshApplicant() {
-    resourceCreator.clearDatabase();
-    subject = injector.instanceOf(ApplicantProgramBlocksController.class);
+    resourceCreator().clearDatabase();
+    subject = instanceOf(ApplicantProgramBlocksController.class);
     program =
         ProgramBuilder.newProgram()
             .withBlock()
@@ -293,23 +259,5 @@ public class ApplicantProgramBlocksControllerTest {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Guardar y continuar");
-  }
-
-  private Applicant createApplicantWithMockedProfile() {
-    Applicant applicant = resourceCreator.insertApplicant();
-    Account account = resourceCreator.insertAccount();
-
-    account.setApplicants(ImmutableList.of(applicant));
-    account.save();
-    applicant.setAccount(account);
-    applicant.save();
-
-    UatProfile profile = profileFactory.wrap(applicant);
-    mockProfile(profile);
-    return applicant;
-  }
-
-  private void mockProfile(UatProfile profile) {
-    when(MOCK_UTILS.currentUserProfile(any(Http.Request.class))).thenReturn(Optional.of(profile));
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -1,9 +1,6 @@
 package controllers.applicant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.OK;
@@ -12,58 +9,28 @@ import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
 
-import auth.ProfileFactory;
-import auth.ProfileUtils;
-import auth.UatProfile;
-import com.google.common.collect.ImmutableList;
 import java.util.Locale;
-import java.util.Optional;
-import models.Account;
 import models.Applicant;
 import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mockito;
-import play.inject.Injector;
-import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http;
 import play.mvc.Result;
 import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
-import support.ResourceCreator;
-import support.TestConstants;
 import support.TestQuestionBank;
 
-public class ApplicantProgramsControllerTest {
-
-  private static final ProfileUtils MOCK_UTILS = Mockito.mock(ProfileUtils.class);
-
-  private static Injector injector;
-  private static ResourceCreator resourceCreator;
-  private static ProfileFactory profileFactory;
+public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles {
 
   private Applicant currentApplicant;
   private ApplicantProgramsController controller;
 
-  @BeforeClass
-  public static void setupInjector() {
-    injector =
-        new GuiceApplicationBuilder()
-            .configure(TestConstants.TEST_DATABASE_CONFIG)
-            .overrides(bind(ProfileUtils.class).toInstance(MOCK_UTILS))
-            .build()
-            .injector();
-    resourceCreator = new ResourceCreator(injector);
-    profileFactory = injector.instanceOf(ProfileFactory.class);
-  }
-
   @Before
   public void setUp() {
-    resourceCreator.clearDatabase();
-    controller = injector.instanceOf(ApplicantProgramsController.class);
+    resourceCreator().clearDatabase();
+    controller = instanceOf(ApplicantProgramsController.class);
     currentApplicant = createApplicantWithMockedProfile();
   }
 
@@ -90,9 +57,9 @@ public class ApplicantProgramsControllerTest {
 
   @Test
   public void index_withPrograms_returnsOnlyRelevantPrograms() {
-    resourceCreator.insertProgram("one", LifecycleStage.ACTIVE);
-    resourceCreator.insertProgram("two", LifecycleStage.ACTIVE);
-    resourceCreator.insertProgram("three", LifecycleStage.DRAFT);
+    resourceCreator().insertProgram("one", LifecycleStage.ACTIVE);
+    resourceCreator().insertProgram("two", LifecycleStage.ACTIVE);
+    resourceCreator().insertProgram("three", LifecycleStage.DRAFT);
 
     Result result =
         controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
@@ -105,7 +72,7 @@ public class ApplicantProgramsControllerTest {
 
   @Test
   public void index_withProgram_includesApplyButtonWithRedirect() {
-    Program program = resourceCreator.insertProgram("program", LifecycleStage.ACTIVE);
+    Program program = resourceCreator().insertProgram("program", LifecycleStage.ACTIVE);
 
     Result result =
         controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
@@ -129,9 +96,11 @@ public class ApplicantProgramsControllerTest {
 
   @Test
   public void index_missingTranslationForProgram_defaultsToEnglish() {
-    resourceCreator.insertProgram(
-        Locale.forLanguageTag("es-US"), "A different language!", LifecycleStage.ACTIVE);
-    resourceCreator.insertProgram("English program", LifecycleStage.ACTIVE); // Missing translation
+    resourceCreator()
+        .insertProgram(
+            Locale.forLanguageTag("es-US"), "A different language!", LifecycleStage.ACTIVE);
+    resourceCreator()
+        .insertProgram("English program", LifecycleStage.ACTIVE); // Missing translation
 
     // Set the PLAY_LANG cookie
     Http.Request request =
@@ -222,7 +191,7 @@ public class ApplicantProgramsControllerTest {
   //  end of program submission.
   @Ignore
   public void edit_whenNoMoreIncompleteBlocks_redirectsToListOfPrograms() {
-    Program program = resourceCreator.insertProgram("My Program");
+    Program program = resourceCreator().insertProgram("My Program");
 
     Result result =
         controller
@@ -233,23 +202,5 @@ public class ApplicantProgramsControllerTest {
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
         .hasValue(routes.ApplicantProgramsController.index(currentApplicant.id).url());
-  }
-
-  private Applicant createApplicantWithMockedProfile() {
-    Applicant applicant = resourceCreator.insertApplicant();
-    Account account = resourceCreator.insertAccount();
-
-    account.setApplicants(ImmutableList.of(applicant));
-    account.save();
-    applicant.setAccount(account);
-    applicant.save();
-
-    UatProfile profile = profileFactory.wrap(applicant);
-    mockProfile(profile);
-    return applicant;
-  }
-
-  private void mockProfile(UatProfile profile) {
-    when(MOCK_UTILS.currentUserProfile(any(Http.Request.class))).thenReturn(Optional.of(profile));
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
@@ -1,0 +1,67 @@
+package controllers.applicant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static play.inject.Bindings.bind;
+
+import auth.ProfileFactory;
+import auth.ProfileUtils;
+import auth.UatProfile;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import models.Account;
+import models.Applicant;
+import org.junit.BeforeClass;
+import org.mockito.Mockito;
+import play.inject.Injector;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.mvc.Http;
+import support.ResourceCreator;
+import support.TestConstants;
+
+public class WithMockedApplicantProfiles {
+
+  private static final ProfileUtils MOCK_UTILS = Mockito.mock(ProfileUtils.class);
+
+  private static Injector injector;
+  private static ResourceCreator resourceCreator;
+  private static ProfileFactory profileFactory;
+
+  @BeforeClass
+  public static void setupInjector() {
+    injector =
+        new GuiceApplicationBuilder()
+            .configure(TestConstants.TEST_DATABASE_CONFIG)
+            .overrides(bind(ProfileUtils.class).toInstance(MOCK_UTILS))
+            .build()
+            .injector();
+    resourceCreator = new ResourceCreator(injector);
+    profileFactory = injector.instanceOf(ProfileFactory.class);
+  }
+
+  protected <T> T instanceOf(Class<T> clazz) {
+    return injector.instanceOf(clazz);
+  }
+
+  protected ResourceCreator resourceCreator() {
+    return resourceCreator;
+  }
+
+  protected Applicant createApplicantWithMockedProfile() {
+    Applicant applicant = resourceCreator.insertApplicant();
+    Account account = resourceCreator.insertAccount();
+
+    account.setApplicants(ImmutableList.of(applicant));
+    account.save();
+    applicant.setAccount(account);
+    applicant.save();
+
+    UatProfile profile = profileFactory.wrap(applicant);
+    mockProfile(profile);
+    return applicant;
+  }
+
+  private void mockProfile(UatProfile profile) {
+    when(MOCK_UTILS.currentUserProfile(any(Http.Request.class))).thenReturn(Optional.of(profile));
+  }
+}

--- a/universal-application-tool-0.0.1/test/models/ApplicantTest.java
+++ b/universal-application-tool-0.0.1/test/models/ApplicantTest.java
@@ -55,6 +55,16 @@ public class ApplicantTest extends WithPostgresContainer {
   }
 
   @Test
+  public void missingPreferredLocale_doesNotSetLocaleOnApplicantData() {
+    Applicant applicant = new Applicant();
+    applicant.save();
+
+    applicant = repo.lookupApplicant(applicant.id).toCompletableFuture().join().get();
+
+    assertThat(applicant.getApplicantData().hasPreferredLocale()).isFalse();
+  }
+
+  @Test
   public void createsOnlyOneApplicantData() {
     Applicant applicant = new Applicant();
 

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -28,6 +28,21 @@ public class ApplicantDataTest {
   }
 
   @Test
+  public void hasPreferredLocale_onlyReturnsTrueIfPreferredLocaleIsSet() {
+    ApplicantData data = new ApplicantData();
+    assertThat(data.hasPreferredLocale()).isFalse();
+
+    data = new ApplicantData("{\"applicant\":{}}");
+    assertThat(data.hasPreferredLocale()).isFalse();
+
+    data = new ApplicantData(Optional.empty(), "{\"applicant\":{}}");
+    assertThat(data.hasPreferredLocale()).isFalse();
+
+    data = new ApplicantData(Optional.of(Locale.FRENCH), "{\"applicant\":{}}");
+    assertThat(data.hasPreferredLocale()).isTrue();
+  }
+
+  @Test
   public void overwriteDataAtSamePath_succeeds() {
     ApplicantData data = new ApplicantData();
     Path path = Path.create("applicant.target");


### PR DESCRIPTION
### Description
Add an information form to get an applicant's preferred language the first time they log in. After they select their preferred language, we set the `PLAY_LANG` cookie so all requests are localized

This also refactors the applicant controller tests to extend a `WithMockedApplicantProfiles` class, so that the controller tests can share code to pass the authorization check for applicants

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #787 

![Screen Shot 2021-04-20 at 9 26 06 AM](https://user-images.githubusercontent.com/8559046/115432002-c8d01080-a1ba-11eb-888d-2db7c95d4e82.png)
