### PR TITLE
Add another place where we find the correct string via locale lookup.

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -166,6 +166,14 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
           .map(option -> option.localize(locale))
           .collect(toImmutableList());
     } else {
+      // As in QuestionDefinition - we need to fetch "en_US" from "en".
+      for (Locale supportedLocale : supportedLocales) {
+        if (supportedLocale.getLanguage().equals(locale.getLanguage())) {
+          return this.options.stream()
+                  .map(option -> option.localize(supportedLocale))
+                  .collect(toImmutableList());
+        }
+      }
       throw new TranslationNotFoundException(getPath().toString(), locale);
     }
   }

--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -170,8 +170,8 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
       for (Locale supportedLocale : supportedLocales) {
         if (supportedLocale.getLanguage().equals(locale.getLanguage())) {
           return this.options.stream()
-                  .map(option -> option.localize(supportedLocale))
-                  .collect(toImmutableList());
+              .map(option -> option.localize(supportedLocale))
+              .collect(toImmutableList());
         }
       }
       throw new TranslationNotFoundException(getPath().toString(), locale);

--- a/universal-application-tool-0.0.1/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -56,7 +56,7 @@ public class MultiOptionQuestionDefinitionTest {
             .build();
 
     MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
-    Throwable thrown = catchThrowable(() -> multiOption.getOptionsForLocale(Locale.CANADA));
+    Throwable thrown = catchThrowable(() -> multiOption.getOptionsForLocale(Locale.CANADA_FRENCH));
 
     assertThat(thrown).isInstanceOf(TranslationNotFoundException.class);
     assertThat(thrown).hasMessageContaining("ca");


### PR DESCRIPTION
### Description
Another instance of the error fixed in #827.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
