### PR TITLE
Fix a synchronization bug in test question bank

### DIFF
--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -65,6 +65,8 @@ public class TestQuestionBank {
   }
 
   public static Question applicantHouseholdMemberName() {
+    // Make sure the next call will have the question ready
+    applicantHouseholdMembers();
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME,
         TestQuestionBank::applicantHouseholdMemberName);


### PR DESCRIPTION
### Description
`computeIfAbsent` can only update one key at a time. Make sure we create the question we need before we call `computeIfAbsent`
