### PR TITLE
Separate ECS task roles between staging and prod

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -6,6 +6,11 @@ Mappings:
       image: public.ecr.aws/t1q6b4h2/universal-application-tool:prod
     staging:
       image: public.ecr.aws/t1q6b4h2/universal-application-tool:latest
+  S3TaskRoles:
+    prod:
+      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
+    staging:
+      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRoleStaging
 Parameters:
   Environment:
     Type: String
@@ -91,7 +96,7 @@ Resources:
     Properties:
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
+      TaskRoleArn: !FindInMap [S3TaskRoles, !Ref Environment, role]
       ExecutionRoleArn: arn:aws:iam::405662711265:role/ecs-task-role
       NetworkMode: awsvpc
       Cpu: 1024

--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -6,16 +6,14 @@ Mappings:
       image: public.ecr.aws/t1q6b4h2/universal-application-tool:prod
     staging:
       image: public.ecr.aws/t1q6b4h2/universal-application-tool:latest
-  S3TaskRoles:
-    prod:
-      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
-    staging:
-      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRoleStaging
 Parameters:
   Environment:
     Type: String
     AllowedValues: ["staging", "prod"]
     Description: "Staging or prod environment"
+  S3TaskRole:
+    Description: The task role for the containers.
+    Type: String
   DBAddress:
     Description: The address at which the database can be reached.
     Type: String
@@ -96,7 +94,7 @@ Resources:
     Properties:
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !FindInMap [S3TaskRoles, !Ref Environment, role]
+      TaskRoleArn: !Ref S3TaskRole
       ExecutionRoleArn: arn:aws:iam::405662711265:role/ecs-task-role
       NetworkMode: awsvpc
       Cpu: 1024

--- a/infra/filestorage.yaml
+++ b/infra/filestorage.yaml
@@ -1,11 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'We have a S3 bucket encrypted with "Customer master keys" (CMKs). The bucket is limited access to from within our VPC. This means the console does not have access to it, either.'
-Mappings:
-  S3TaskRoles:
-    prod:
-      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
-    staging:
-      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRoleStaging
 Parameters:
   S3VPCEndpoint:
     Description: The vpc endpoint from which CiviForm connects to S3.
@@ -14,6 +8,9 @@ Parameters:
     Type: String
     AllowedValues: ["staging", "prod"]
     Description: "Staging or prod environment"
+  S3TaskRole:
+    Description: The user allowed to access S3.
+    Type: String
 Resources:
   key:
     Type: AWS::KMS::Key
@@ -39,7 +36,7 @@ Resources:
         - Sid: Enable CiviForm Server Permissions
           Effect: Allow
           Principal:
-            AWS: !FindInMap [S3TaskRoles, !Ref Environment, role]
+            AWS: !Ref S3TaskRole
           Action:
             - kms:Encrypt
             - kms:Decrypt
@@ -86,7 +83,7 @@ Resources:
                 - !Ref bucket
                 - /*
             NotPrincipal:
-              AWS: !FindInMap [S3TaskRoles, !Ref Environment, role]
+              AWS: !Ref S3TaskRole
             Condition:
               StringNotEquals:
                 'aws:sourceVpce': !Ref 'S3VPCEndpoint'
@@ -101,7 +98,7 @@ Resources:
                 - !Ref bucket
                 - /*
             Principal:
-              AWS: !FindInMap [S3TaskRoles, !Ref Environment, role]
+              AWS: !Ref S3TaskRole
 Outputs:
   bucketname:
     Description: The location of the bucket for secure uploads.

--- a/infra/filestorage.yaml
+++ b/infra/filestorage.yaml
@@ -1,5 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'We have a S3 bucket encrypted with "Customer master keys" (CMKs). The bucket is limited access to from within our VPC. This means the console does not have access to it, either.'
+Mappings:
+  S3TaskRoles:
+    prod:
+      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
+    staging:
+      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRoleStaging
 Parameters:
   S3VPCEndpoint:
     Description: The vpc endpoint from which CiviForm connects to S3.
@@ -33,7 +39,7 @@ Resources:
         - Sid: Enable CiviForm Server Permissions
           Effect: Allow
           Principal:
-            AWS: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
+            AWS: !FindInMap [S3TaskRoles, !Ref Environment, role]
           Action:
             - kms:Encrypt
             - kms:Decrypt
@@ -80,7 +86,7 @@ Resources:
                 - !Ref bucket
                 - /*
             NotPrincipal:
-              AWS: 'arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole'
+              AWS: !FindInMap [S3TaskRoles, !Ref Environment, role]
             Condition:
               StringNotEquals:
                 'aws:sourceVpce': !Ref 'S3VPCEndpoint'
@@ -95,7 +101,7 @@ Resources:
                 - !Ref bucket
                 - /*
             Principal:
-              AWS: 'arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole'
+              AWS: !FindInMap [S3TaskRoles, !Ref Environment, role]
 Outputs:
   bucketname:
     Description: The location of the bucket for secure uploads.

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -8,6 +8,11 @@ Mappings:
     staging:
       Domain: staging.seattle.civiform.com
       HostedZone: Z02860647AHUYUQTEAPO
+  S3TaskRoles:
+    prod:
+      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRole
+    staging:
+      role: arn:aws:iam::405662711265:role/AmazonECSTaskS3BucketRoleStaging
 Parameters:
   Timestamp:
     Description: Current timestamp in seconds.
@@ -37,6 +42,7 @@ Resources:
       Parameters:
         S3VPCEndpoint: !GetAtt 'VPC.Outputs.S3Endpoint'
         Environment: !Ref Environment
+        S3TaskRole: !FindInMap [S3TaskRoles, !Ref Environment, role]
   Secrets:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -90,6 +96,7 @@ Resources:
         S3BucketName: !GetAtt 'Filestore.Outputs.bucketname'
         DomainName: !FindInMap [DNS, !Ref Environment, Domain]
         Environment: !Ref Environment
+        S3TaskRole: !FindInMap [S3TaskRoles, !Ref Environment, role]
   Monitoring:
     Type: AWS::CloudFormation::Stack
     Condition: CreateProdResources


### PR DESCRIPTION
### Description
Use separate roles for staging and prod so they cannot access each other's resources, specifically S3 buckets.
