### PR TITLE
Bug fix: Update TestQuestionBank to use non-static methods

### DIFF
--- a/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
+++ b/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
@@ -37,10 +37,10 @@ public class UatProfileTest extends WithPostgresContainer {
   @Test
   public void checkAuthorization_passesForOneOfSeveralIdsInAccount() {
     // We need to save these first so that the IDs are populated.
-    Applicant one = resourceCreator.insertApplicant();
-    Applicant two = resourceCreator.insertApplicant();
-    Applicant three = resourceCreator.insertApplicant();
-    Account account = resourceCreator.insertAccount();
+    Applicant one = resourceCreator().insertApplicant();
+    Applicant two = resourceCreator().insertApplicant();
+    Applicant three = resourceCreator().insertApplicant();
+    Account account = resourceCreator().insertAccount();
 
     // Set the accounts on applicants and the applicants on the account. Saving required!
     one.setAccount(account);

--- a/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
+++ b/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
@@ -37,10 +37,10 @@ public class UatProfileTest extends WithPostgresContainer {
   @Test
   public void checkAuthorization_passesForOneOfSeveralIdsInAccount() {
     // We need to save these first so that the IDs are populated.
-    Applicant one = resourceCreator().insertApplicant();
-    Applicant two = resourceCreator().insertApplicant();
-    Applicant three = resourceCreator().insertApplicant();
-    Account account = resourceCreator().insertAccount();
+    Applicant one = resourceCreator.insertApplicant();
+    Applicant two = resourceCreator.insertApplicant();
+    Applicant three = resourceCreator.insertApplicant();
+    Account account = resourceCreator.insertAccount();
 
     // Set the accounts on applicants and the applicants on the account. Saving required!
     one.setAccount(account);

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -24,7 +24,6 @@ import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import support.ProgramBuilder;
-import support.TestQuestionBank;
 
 public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
 
@@ -98,7 +97,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
   public void edit_withProgram_OK()
       throws UnsupportedQuestionTypeException, InvalidUpdateException {
     Program program = ProgramBuilder.newProgram().build();
-    Question appName = TestQuestionBank.applicantName();
+    Question appName = testQuestionBank().applicantName();
     appName.save();
     Request request = addCSRFToken(fakeRequest()).build();
     Result result = controller.edit(request, program.id, 1L);

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -97,7 +97,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
   public void edit_withProgram_OK()
       throws UnsupportedQuestionTypeException, InvalidUpdateException {
     Program program = ProgramBuilder.newProgram().build();
-    Question appName = testQuestionBank().applicantName();
+    Question appName = testQuestionBank.applicantName();
     appName.save();
     Request request = addCSRFToken(fakeRequest()).build();
     Result result = controller.edit(request, program.id, 1L);

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -17,7 +17,6 @@ import play.mvc.Result;
 import play.test.Helpers;
 import repository.WithPostgresContainer;
 import services.question.types.QuestionDefinition;
-import support.TestQuestionBank;
 import views.html.helper.CSRF;
 
 public class QuestionControllerTest extends WithPostgresContainer {
@@ -47,7 +46,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void create_repeatedQuestion_redirectsOnSuccess() {
-    Question repeaterQuestion = TestQuestionBank.applicantHouseholdMembers();
+    Question repeaterQuestion = testQuestionBank().applicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "name")
@@ -106,7 +105,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void edit_returnsPopulatedForm() {
-    Question question = TestQuestionBank.applicantName();
+    Question question = testQuestionBank().applicantName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .edit(request, question.id)
@@ -124,7 +123,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void edit_repeatedQuestion_hasFormattedRepeaterName() {
-    Question repeatedQuestion = TestQuestionBank.applicantHouseholdMemberName();
+    Question repeatedQuestion = testQuestionBank().applicantHouseholdMemberName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .edit(request, repeatedQuestion.id)
@@ -143,8 +142,8 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void index_returnsQuestions() {
-    TestQuestionBank.applicantAddress();
-    TestQuestionBank.applicantName();
+    testQuestionBank().applicantAddress();
+    testQuestionBank().applicantName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .index(request)
@@ -213,7 +212,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_redirectsOnSuccess() {
-    QuestionDefinition nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", nameQuestion.getName())
@@ -236,7 +235,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWithErrorMessageAndPopulatedFields() {
-    Question question = TestQuestionBank.applicantFavoriteColor();
+    Question question = testQuestionBank().applicantFavoriteColor();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "favorite_color")
@@ -255,7 +254,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWithInvalidQuestionType() {
-    Question question = TestQuestionBank.applicantHouseholdMembers();
+    Question question = testQuestionBank().applicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionType", "INVALID_TYPE").put("questionText", "question text updated!");
     RequestBuilder requestBuilder = Helpers.fakeRequest().bodyForm(formData.build());

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -46,7 +46,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void create_repeatedQuestion_redirectsOnSuccess() {
-    Question repeaterQuestion = testQuestionBank().applicantHouseholdMembers();
+    Question repeaterQuestion = testQuestionBank.applicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "name")
@@ -105,7 +105,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void edit_returnsPopulatedForm() {
-    Question question = testQuestionBank().applicantName();
+    Question question = testQuestionBank.applicantName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .edit(request, question.id)
@@ -123,7 +123,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void edit_repeatedQuestion_hasFormattedRepeaterName() {
-    Question repeatedQuestion = testQuestionBank().applicantHouseholdMemberName();
+    Question repeatedQuestion = testQuestionBank.applicantHouseholdMemberName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .edit(request, repeatedQuestion.id)
@@ -142,8 +142,8 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void index_returnsQuestions() {
-    testQuestionBank().applicantAddress();
-    testQuestionBank().applicantName();
+    testQuestionBank.applicantAddress();
+    testQuestionBank.applicantName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .index(request)
@@ -212,7 +212,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_redirectsOnSuccess() {
-    QuestionDefinition nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", nameQuestion.getName())
@@ -235,7 +235,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWithErrorMessageAndPopulatedFields() {
-    Question question = testQuestionBank().applicantFavoriteColor();
+    Question question = testQuestionBank.applicantFavoriteColor();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
         .put("questionName", "favorite_color")
@@ -254,7 +254,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWithInvalidQuestionType() {
-    Question question = testQuestionBank().applicantHouseholdMembers();
+    Question question = testQuestionBank.applicantHouseholdMembers();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionType", "INVALID_TYPE").put("questionText", "question text updated!");
     RequestBuilder requestBuilder = Helpers.fakeRequest().bodyForm(formData.build());

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -25,7 +25,7 @@ public class ApplicantInformationControllerTest extends WithMockedApplicantProfi
 
   @Before
   public void setup() {
-    resourceCreator().clearDatabase();
+    clearDatabase();
     controller = instanceOf(ApplicantInformationController.class);
     applicantRepository = instanceOf(ApplicantRepository.class);
     currentApplicant = createApplicantWithMockedProfile();

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -22,7 +22,6 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
-import support.TestQuestionBank;
 
 public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantProfiles {
 
@@ -32,12 +31,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
 
   @Before
   public void setUpWithFreshApplicant() {
-    resourceCreator().clearDatabase();
+    clearDatabase();
+
     subject = instanceOf(ApplicantProgramBlocksController.class);
     program =
         ProgramBuilder.newProgram()
             .withBlock()
-            .withQuestion(TestQuestionBank.applicantName())
+            .withQuestion(testQuestionBank().applicantName())
             .build();
     applicant = createApplicantWithMockedProfile();
   }
@@ -192,9 +192,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
     program =
         ProgramBuilder.newProgram()
             .withBlock("block 1")
-            .withQuestion(TestQuestionBank.applicantName())
+            .withQuestion(testQuestionBank().applicantName())
             .withBlock("block 2")
-            .withQuestion(TestQuestionBank.applicantAddress())
+            .withQuestion(testQuestionBank().applicantAddress())
             .build();
     Request request =
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
@@ -220,7 +220,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
     program =
         ProgramBuilder.newProgram()
             .withBlock("block 1")
-            .withQuestion(TestQuestionBank.applicantName())
+            .withQuestion(testQuestionBank().applicantName())
             .build();
 
     Request request =

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -20,7 +20,6 @@ import play.mvc.Http;
 import play.mvc.Result;
 import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
-import support.TestQuestionBank;
 
 public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles {
 
@@ -29,7 +28,7 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
 
   @Before
   public void setUp() {
-    resourceCreator().clearDatabase();
+    clearDatabase();
     controller = instanceOf(ApplicantProgramsController.class);
     currentApplicant = createApplicantWithMockedProfile();
   }
@@ -37,17 +36,17 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void index_differentApplicant_returnsUnauthorizedResult() {
     Result result =
-        controller
-            .index(fakeRequest().build(), currentApplicant.id + 1)
-            .toCompletableFuture()
-            .join();
+            controller
+                    .index(fakeRequest().build(), currentApplicant.id + 1)
+                    .toCompletableFuture()
+                    .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
   public void index_withNoPrograms_returnsEmptyResult() {
     Result result =
-        controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
+            controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
@@ -62,7 +61,7 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
     resourceCreator().insertProgram("three", LifecycleStage.DRAFT);
 
     Result result =
-        controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
+            controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("one");
@@ -75,18 +74,18 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
     Program program = resourceCreator().insertProgram("program", LifecycleStage.ACTIVE);
 
     Result result =
-        controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
+            controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .contains(routes.ApplicantProgramsController.edit(currentApplicant.id, program.id).url());
+            .contains(routes.ApplicantProgramsController.edit(currentApplicant.id, program.id).url());
   }
 
   @Test
   public void index_usesMessagesForUserPreferredLocale() {
     // Set the PLAY_LANG cookie
     Http.Request request =
-        fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
+            fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
 
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -97,14 +96,14 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void index_missingTranslationForProgram_defaultsToEnglish() {
     resourceCreator()
-        .insertProgram(
-            Locale.forLanguageTag("es-US"), "A different language!", LifecycleStage.ACTIVE);
+            .insertProgram(
+                    Locale.forLanguageTag("es-US"), "A different language!", LifecycleStage.ACTIVE);
     resourceCreator()
-        .insertProgram("English program", LifecycleStage.ACTIVE); // Missing translation
+            .insertProgram("English program", LifecycleStage.ACTIVE); // Missing translation
 
     // Set the PLAY_LANG cookie
     Http.Request request =
-        fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
+            fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
 
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -116,20 +115,20 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void edit_differentApplicant_returnsUnauthorizedResult() {
     Result result =
-        controller
-            .edit(fakeRequest().build(), currentApplicant.id + 1, 1L)
-            .toCompletableFuture()
-            .join();
+            controller
+                    .edit(fakeRequest().build(), currentApplicant.id + 1, 1L)
+                    .toCompletableFuture()
+                    .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
   public void edit_invalidProgram_returnsBadRequest() {
     Result result =
-        controller
-            .edit(fakeRequest().build(), currentApplicant.id, 9999L)
-            .toCompletableFuture()
-            .join();
+            controller
+                    .edit(fakeRequest().build(), currentApplicant.id, 9999L)
+                    .toCompletableFuture()
+                    .join();
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
@@ -137,54 +136,54 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void edit_withNewProgram_redirectsToFirstBlock() {
     Program program =
-        ProgramBuilder.newProgram()
-            .withBlock()
-            .withQuestion(TestQuestionBank.applicantName())
-            .build();
+            ProgramBuilder.newProgram()
+                    .withBlock()
+                    .withQuestion(testQuestionBank().applicantName())
+                    .build();
 
     Result result =
-        controller
-            .edit(fakeRequest().build(), currentApplicant.id, program.id)
-            .toCompletableFuture()
-            .join();
+            controller
+                    .edit(fakeRequest().build(), currentApplicant.id, program.id)
+                    .toCompletableFuture()
+                    .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
-        .hasValue(
-            routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "1")
-                .url());
+            .hasValue(
+                    routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "1")
+                            .url());
   }
 
   @Test
   public void edit_redirectsToFirstIncompleteBlock() {
     QuestionDefinition colorQuestion =
-        TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+            testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
     Program program =
-        ProgramBuilder.newProgram()
-            .withBlock()
-            .withQuestionDefinition(colorQuestion)
-            .withBlock()
-            .withQuestion(TestQuestionBank.applicantAddress())
-            .build();
+            ProgramBuilder.newProgram()
+                    .withBlock()
+                    .withQuestionDefinition(colorQuestion)
+                    .withBlock()
+                    .withQuestion(testQuestionBank().applicantAddress())
+                    .build();
     // Answer the color question
     currentApplicant
-        .getApplicantData()
-        .putString(colorQuestion.getPath().join("text"), "forest green");
+            .getApplicantData()
+            .putString(colorQuestion.getPath().join("text"), "forest green");
     currentApplicant.getApplicantData().putLong(colorQuestion.getLastUpdatedTimePath(), 12345L);
     currentApplicant.getApplicantData().putLong(colorQuestion.getProgramIdPath(), 456L);
     currentApplicant.save();
 
     Result result =
-        controller
-            .edit(fakeRequest().build(), currentApplicant.id, program.id)
-            .toCompletableFuture()
-            .join();
+            controller
+                    .edit(fakeRequest().build(), currentApplicant.id, program.id)
+                    .toCompletableFuture()
+                    .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
-        .hasValue(
-            routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "2")
-                .url());
+            .hasValue(
+                    routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "2")
+                            .url());
   }
 
   // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Should redirect to
@@ -194,13 +193,13 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
     Program program = resourceCreator().insertProgram("My Program");
 
     Result result =
-        controller
-            .edit(fakeRequest().build(), currentApplicant.id, program.id)
-            .toCompletableFuture()
-            .join();
+            controller
+                    .edit(fakeRequest().build(), currentApplicant.id, program.id)
+                    .toCompletableFuture()
+                    .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
-        .hasValue(routes.ApplicantProgramsController.index(currentApplicant.id).url());
+            .hasValue(routes.ApplicantProgramsController.index(currentApplicant.id).url());
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -36,17 +36,17 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void index_differentApplicant_returnsUnauthorizedResult() {
     Result result =
-            controller
-                    .index(fakeRequest().build(), currentApplicant.id + 1)
-                    .toCompletableFuture()
-                    .join();
+        controller
+            .index(fakeRequest().build(), currentApplicant.id + 1)
+            .toCompletableFuture()
+            .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
   public void index_withNoPrograms_returnsEmptyResult() {
     Result result =
-            controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
+        controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
@@ -61,7 +61,7 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
     resourceCreator().insertProgram("three", LifecycleStage.DRAFT);
 
     Result result =
-            controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
+        controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("one");
@@ -74,18 +74,18 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
     Program program = resourceCreator().insertProgram("program", LifecycleStage.ACTIVE);
 
     Result result =
-            controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
+        controller.index(fakeRequest().build(), currentApplicant.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-            .contains(routes.ApplicantProgramsController.edit(currentApplicant.id, program.id).url());
+        .contains(routes.ApplicantProgramsController.edit(currentApplicant.id, program.id).url());
   }
 
   @Test
   public void index_usesMessagesForUserPreferredLocale() {
     // Set the PLAY_LANG cookie
     Http.Request request =
-            fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
+        fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
 
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -96,14 +96,14 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void index_missingTranslationForProgram_defaultsToEnglish() {
     resourceCreator()
-            .insertProgram(
-                    Locale.forLanguageTag("es-US"), "A different language!", LifecycleStage.ACTIVE);
+        .insertProgram(
+            Locale.forLanguageTag("es-US"), "A different language!", LifecycleStage.ACTIVE);
     resourceCreator()
-            .insertProgram("English program", LifecycleStage.ACTIVE); // Missing translation
+        .insertProgram("English program", LifecycleStage.ACTIVE); // Missing translation
 
     // Set the PLAY_LANG cookie
     Http.Request request =
-            fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
+        fakeRequest().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
 
     Result result = controller.index(request, currentApplicant.id).toCompletableFuture().join();
 
@@ -115,20 +115,20 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void edit_differentApplicant_returnsUnauthorizedResult() {
     Result result =
-            controller
-                    .edit(fakeRequest().build(), currentApplicant.id + 1, 1L)
-                    .toCompletableFuture()
-                    .join();
+        controller
+            .edit(fakeRequest().build(), currentApplicant.id + 1, 1L)
+            .toCompletableFuture()
+            .join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test
   public void edit_invalidProgram_returnsBadRequest() {
     Result result =
-            controller
-                    .edit(fakeRequest().build(), currentApplicant.id, 9999L)
-                    .toCompletableFuture()
-                    .join();
+        controller
+            .edit(fakeRequest().build(), currentApplicant.id, 9999L)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
   }
@@ -136,54 +136,54 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
   @Test
   public void edit_withNewProgram_redirectsToFirstBlock() {
     Program program =
-            ProgramBuilder.newProgram()
-                    .withBlock()
-                    .withQuestion(testQuestionBank().applicantName())
-                    .build();
+        ProgramBuilder.newProgram()
+            .withBlock()
+            .withQuestion(testQuestionBank().applicantName())
+            .build();
 
     Result result =
-            controller
-                    .edit(fakeRequest().build(), currentApplicant.id, program.id)
-                    .toCompletableFuture()
-                    .join();
+        controller
+            .edit(fakeRequest().build(), currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
-            .hasValue(
-                    routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "1")
-                            .url());
+        .hasValue(
+            routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "1")
+                .url());
   }
 
   @Test
   public void edit_redirectsToFirstIncompleteBlock() {
     QuestionDefinition colorQuestion =
-            testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
     Program program =
-            ProgramBuilder.newProgram()
-                    .withBlock()
-                    .withQuestionDefinition(colorQuestion)
-                    .withBlock()
-                    .withQuestion(testQuestionBank().applicantAddress())
-                    .build();
+        ProgramBuilder.newProgram()
+            .withBlock()
+            .withQuestionDefinition(colorQuestion)
+            .withBlock()
+            .withQuestion(testQuestionBank().applicantAddress())
+            .build();
     // Answer the color question
     currentApplicant
-            .getApplicantData()
-            .putString(colorQuestion.getPath().join("text"), "forest green");
+        .getApplicantData()
+        .putString(colorQuestion.getPath().join("text"), "forest green");
     currentApplicant.getApplicantData().putLong(colorQuestion.getLastUpdatedTimePath(), 12345L);
     currentApplicant.getApplicantData().putLong(colorQuestion.getProgramIdPath(), 456L);
     currentApplicant.save();
 
     Result result =
-            controller
-                    .edit(fakeRequest().build(), currentApplicant.id, program.id)
-                    .toCompletableFuture()
-                    .join();
+        controller
+            .edit(fakeRequest().build(), currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
-            .hasValue(
-                    routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "2")
-                            .url());
+        .hasValue(
+            routes.ApplicantProgramBlocksController.edit(currentApplicant.id, program.id, "2")
+                .url());
   }
 
   // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Should redirect to
@@ -193,13 +193,13 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
     Program program = resourceCreator().insertProgram("My Program");
 
     Result result =
-            controller
-                    .edit(fakeRequest().build(), currentApplicant.id, program.id)
-                    .toCompletableFuture()
-                    .join();
+        controller
+            .edit(fakeRequest().build(), currentApplicant.id, program.id)
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(FOUND);
     assertThat(result.redirectLocation())
-            .hasValue(routes.ApplicantProgramsController.index(currentApplicant.id).url());
+        .hasValue(routes.ApplicantProgramsController.index(currentApplicant.id).url());
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
@@ -18,10 +18,13 @@ import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http;
 import support.ResourceCreator;
 import support.TestConstants;
+import support.TestQuestionBank;
 
 public class WithMockedApplicantProfiles {
 
   private static final ProfileUtils MOCK_UTILS = Mockito.mock(ProfileUtils.class);
+
+  private static TestQuestionBank testQuestionBank = new TestQuestionBank(true);
 
   private static Injector injector;
   private static ResourceCreator resourceCreator;
@@ -45,6 +48,15 @@ public class WithMockedApplicantProfiles {
 
   protected ResourceCreator resourceCreator() {
     return resourceCreator;
+  }
+
+  protected TestQuestionBank testQuestionBank() {
+    return testQuestionBank;
+  }
+
+  protected void clearDatabase() {
+    testQuestionBank().reset();
+    resourceCreator().truncateTables();
   }
 
   protected Applicant createApplicantWithMockedProfile() {

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -30,8 +30,8 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void listPrograms() {
-    Program one = resourceCreator().insertProgram("one");
-    Program two = resourceCreator().insertProgram("two");
+    Program one = resourceCreator.insertProgram("one");
+    Program two = resourceCreator.insertProgram("two");
 
     ImmutableList<Program> allPrograms = repo.listPrograms().toCompletableFuture().join();
 
@@ -47,8 +47,8 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void lookupProgram_findsCorrectProgram() {
-    resourceCreator().insertProgram("one");
-    Program two = resourceCreator().insertProgram("two");
+    resourceCreator.insertProgram("one");
+    Program two = resourceCreator.insertProgram("two");
 
     Optional<Program> found = repo.lookupProgram(two.id).toCompletableFuture().join();
 
@@ -68,7 +68,7 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void updateProgramSync() {
-    Program existing = resourceCreator().insertProgram("old name");
+    Program existing = resourceCreator.insertProgram("old name");
     Program updates =
         new Program(
             existing.getProgramDefinition().toBuilder()

--- a/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
@@ -34,8 +34,8 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void listQuestions() {
-    Question one = resourceCreator().insertQuestion("path.one");
-    Question two = resourceCreator().insertQuestion("path.two");
+    Question one = resourceCreator.insertQuestion("path.one");
+    Question two = resourceCreator.insertQuestion("path.two");
 
     Set<Question> list = repo.listQuestions().toCompletableFuture().join();
 
@@ -51,8 +51,8 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void lookupQuestion_findsCorrectQuestion() {
-    resourceCreator().insertQuestion("path.one");
-    Question existing = resourceCreator().insertQuestion("path.existing");
+    resourceCreator.insertQuestion("path.one");
+    Question existing = resourceCreator.insertQuestion("path.existing");
 
     Optional<Question> found = repo.lookupQuestion(existing.id).toCompletableFuture().join();
 
@@ -62,7 +62,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_noConflicts_ok() throws Exception {
     QuestionDefinition applicantAddress =
-        testQuestionBank().applicantAddress().getQuestionDefinition();
+        testQuestionBank.applicantAddress().getQuestionDefinition();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress)
             .clearId()
@@ -77,7 +77,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_sameQuestion_hasConflict() {
-    Question applicantAddress = testQuestionBank().applicantAddress();
+    Question applicantAddress = testQuestionBank.applicantAddress();
     Optional<Question> maybeConflict =
         repo.findPathConflictingQuestion(applicantAddress.getQuestionDefinition());
 
@@ -86,7 +86,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_differentVersion_hasConflict() throws Exception {
-    Question applicantName = testQuestionBank().applicantName();
+    Question applicantName = testQuestionBank.applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
             .setId(123123L)
@@ -100,7 +100,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_samePath_hasConflict() throws Exception {
-    Question applicantName = testQuestionBank().applicantName();
+    Question applicantName = testQuestionBank.applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).clearId().build();
 
@@ -112,7 +112,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_repeaterConflictsWithNonRepeater_hasConflict()
       throws Exception {
-    Question householdMembers = testQuestionBank().applicantHouseholdMembers();
+    Question householdMembers = testQuestionBank.applicantHouseholdMembers();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(householdMembers.getQuestionDefinition())
             .clearId()
@@ -127,7 +127,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_startsWithNewPath_hasConflict() throws Exception {
-    Question applicantName = testQuestionBank().applicantName();
+    Question applicantName = testQuestionBank.applicantName();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
             .clearId()
@@ -142,7 +142,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_newPathStartsWithNonRepeater_hasConflict()
       throws Exception {
-    Question applicantName = testQuestionBank().applicantName();
+    Question applicantName = testQuestionBank.applicantName();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
             .clearId()
@@ -157,7 +157,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_newPathStartsWithRepeater_hasNoConflict()
       throws Exception {
-    Question householdMembers = testQuestionBank().applicantHouseholdMembers();
+    Question householdMembers = testQuestionBank.applicantHouseholdMembers();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(householdMembers.getQuestionDefinition())
             .clearId()
@@ -179,8 +179,8 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void lookupQuestionByPath_findsCorrectQuestion() {
-    resourceCreator().insertQuestion("path.one");
-    Question existing = resourceCreator().insertQuestion("path.existing");
+    resourceCreator.insertQuestion("path.one");
+    Question existing = resourceCreator.insertQuestion("path.existing");
 
     Optional<Question> found =
         repo.lookupQuestionByPath("path.existing").toCompletableFuture().join();
@@ -190,8 +190,8 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void lookupQuestionByPath_versioningNotSupportedYet() {
-    resourceCreator().insertQuestion("path.one");
-    resourceCreator().insertQuestion("path.one", 2L);
+    resourceCreator.insertQuestion("path.one");
+    resourceCreator.insertQuestion("path.one", 2L);
 
     assertThatThrownBy(() -> repo.lookupQuestionByPath("path.one").toCompletableFuture().join())
         .isInstanceOf(java.util.concurrent.CompletionException.class)
@@ -241,7 +241,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void updateQuestion() throws UnsupportedQuestionTypeException {
-    Question question = resourceCreator().insertQuestion("path.one");
+    Question question = resourceCreator.insertQuestion("path.one");
     QuestionDefinition questionDefinition = question.getQuestionDefinition();
     questionDefinition =
         new QuestionDefinitionBuilder(questionDefinition).setDescription("new description").build();
@@ -254,7 +254,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void updateQuestionSync() throws UnsupportedQuestionTypeException {
-    Question question = resourceCreator().insertQuestion("path.one");
+    Question question = resourceCreator.insertQuestion("path.one");
     QuestionDefinition questionDefinition = question.getQuestionDefinition();
     questionDefinition =
         new QuestionDefinitionBuilder(questionDefinition).setDescription("new description").build();

--- a/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
@@ -17,7 +17,6 @@ import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 import services.question.types.TextQuestionDefinition;
-import support.TestQuestionBank;
 
 public class QuestionRepositoryTest extends WithPostgresContainer {
 
@@ -63,7 +62,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_noConflicts_ok() throws Exception {
     QuestionDefinition applicantAddress =
-        TestQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank().applicantAddress().getQuestionDefinition();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantAddress)
             .clearId()
@@ -78,7 +77,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_sameQuestion_hasConflict() {
-    Question applicantAddress = TestQuestionBank.applicantAddress();
+    Question applicantAddress = testQuestionBank().applicantAddress();
     Optional<Question> maybeConflict =
         repo.findPathConflictingQuestion(applicantAddress.getQuestionDefinition());
 
@@ -87,7 +86,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_differentVersion_hasConflict() throws Exception {
-    Question applicantName = TestQuestionBank.applicantName();
+    Question applicantName = testQuestionBank().applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
             .setId(123123L)
@@ -101,7 +100,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_samePath_hasConflict() throws Exception {
-    Question applicantName = TestQuestionBank.applicantName();
+    Question applicantName = testQuestionBank().applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).clearId().build();
 
@@ -113,7 +112,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_repeaterConflictsWithNonRepeater_hasConflict()
       throws Exception {
-    Question householdMembers = TestQuestionBank.applicantHouseholdMembers();
+    Question householdMembers = testQuestionBank().applicantHouseholdMembers();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(householdMembers.getQuestionDefinition())
             .clearId()
@@ -128,7 +127,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void findPathConflictingQuestion_startsWithNewPath_hasConflict() throws Exception {
-    Question applicantName = TestQuestionBank.applicantName();
+    Question applicantName = testQuestionBank().applicantName();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
             .clearId()
@@ -143,7 +142,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_newPathStartsWithNonRepeater_hasConflict()
       throws Exception {
-    Question applicantName = TestQuestionBank.applicantName();
+    Question applicantName = testQuestionBank().applicantName();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition())
             .clearId()
@@ -158,7 +157,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   @Test
   public void findPathConflictingQuestion_newPathStartsWithRepeater_hasNoConflict()
       throws Exception {
-    Question householdMembers = TestQuestionBank.applicantHouseholdMembers();
+    Question householdMembers = testQuestionBank().applicantHouseholdMembers();
     QuestionDefinition newQuestionDefinition =
         new QuestionDefinitionBuilder(householdMembers.getQuestionDefinition())
             .clearId()

--- a/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
@@ -32,11 +32,11 @@ public class VersionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void publishProgram_simple() {
-    Program active = resourceCreator().insertProgram("name");
+    Program active = resourceCreator.insertProgram("name");
     active.setLifecycleStage(LifecycleStage.ACTIVE);
     active.setVersion(1L);
     active.save();
-    Program draft = resourceCreator().insertProgram("name");
+    Program draft = resourceCreator.insertProgram("name");
     draft.setLifecycleStage(LifecycleStage.DRAFT);
     draft.setVersion(2L);
     draft.save();
@@ -53,7 +53,7 @@ public class VersionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void publishProgram_passthrough() {
-    Program active = resourceCreator().insertProgram("passthrough");
+    Program active = resourceCreator.insertProgram("passthrough");
     active.setLifecycleStage(LifecycleStage.ACTIVE);
     active.setVersion(1L);
     active.save();
@@ -99,14 +99,14 @@ public class VersionRepositoryTest extends WithPostgresContainer {
       throws ProgramNotFoundException, DuplicateProgramQuestionException, QuestionNotFoundException,
           ProgramBlockNotFoundException {
     // Create program, version 1, with an old version of this question.
-    Question question1 = resourceCreator().insertQuestion("foo.bar", 1, "q");
-    Program program = resourceCreator().insertProgram("program", LifecycleStage.ACTIVE);
-    resourceCreator().addQuestionToProgram(program, question1);
+    Question question1 = resourceCreator.insertQuestion("foo.bar", 1, "q");
+    Program program = resourceCreator.insertProgram("program", LifecycleStage.ACTIVE);
+    resourceCreator.addQuestionToProgram(program, question1);
     program.refresh();
     assertThat(program.getVersion()).isEqualTo(1);
 
     // Create question 2, in draft state.
-    Question question2 = resourceCreator().insertQuestion("foo.bar", 2, "q");
+    Question question2 = resourceCreator.insertQuestion("foo.bar", 2, "q");
     question2.setLifecycleStage(LifecycleStage.DRAFT);
     question2.save();
 

--- a/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
@@ -99,14 +99,14 @@ public class VersionRepositoryTest extends WithPostgresContainer {
       throws ProgramNotFoundException, DuplicateProgramQuestionException, QuestionNotFoundException,
           ProgramBlockNotFoundException {
     // Create program, version 1, with an old version of this question.
-    Question question1 = resourceCreator.insertQuestion("foo.bar", 1, "q");
-    Program program = resourceCreator.insertProgram("program", LifecycleStage.ACTIVE);
-    resourceCreator.addQuestionToProgram(program, question1);
+    Question question1 = resourceCreator().insertQuestion("foo.bar", 1, "q");
+    Program program = resourceCreator().insertProgram("program", LifecycleStage.ACTIVE);
+    resourceCreator().addQuestionToProgram(program, question1);
     program.refresh();
     assertThat(program.getVersion()).isEqualTo(1);
 
     // Create question 2, in draft state.
-    Question question2 = resourceCreator.insertQuestion("foo.bar", 2, "q");
+    Question question2 = resourceCreator().insertQuestion("foo.bar", 2, "q");
     question2.setLifecycleStage(LifecycleStage.DRAFT);
     question2.save();
 

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -25,9 +25,9 @@ public class WithPostgresContainer {
 
   protected static Materializer mat;
 
-  private static ResourceCreator resourceCreator;
+  protected static ResourceCreator resourceCreator;
 
-  private static TestQuestionBank testQuestionBank = new TestQuestionBank(true);
+  protected static TestQuestionBank testQuestionBank = new TestQuestionBank(true);
 
   @BeforeClass
   public static void startPlay() {
@@ -51,14 +51,6 @@ public class WithPostgresContainer {
 
   protected <T> T instanceOf(Class<T> clazz) {
     return app.injector().instanceOf(clazz);
-  }
-
-  protected ResourceCreator resourceCreator() {
-    return resourceCreator;
-  }
-
-  protected TestQuestionBank testQuestionBank() {
-    return testQuestionBank;
   }
 
   @Before

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -25,7 +25,9 @@ public class WithPostgresContainer {
 
   protected static Materializer mat;
 
-  protected static ResourceCreator resourceCreator;
+  private static ResourceCreator resourceCreator;
+
+  private static TestQuestionBank testQuestionBank = new TestQuestionBank(true);
 
   @BeforeClass
   public static void startPlay() {
@@ -55,6 +57,10 @@ public class WithPostgresContainer {
     return resourceCreator;
   }
 
+  protected TestQuestionBank testQuestionBank() {
+    return testQuestionBank;
+  }
+
   @Before
   public void truncateTables() {
     EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
@@ -65,6 +71,6 @@ public class WithPostgresContainer {
 
   @Before
   public void resetSupportQuestionsCache() {
-    TestQuestionBank.reset();
+    testQuestionBank.reset();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -16,10 +16,12 @@ import support.TestQuestionBank;
 
 public class BlockTest {
 
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+
   private static final NameQuestionDefinition NAME_QUESTION =
-      (NameQuestionDefinition) TestQuestionBank.applicantName().getQuestionDefinition();
+      (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
   private static final TextQuestionDefinition COLOR_QUESTION =
-      (TextQuestionDefinition) TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+      (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
 
   @Test
   public void createNewBlock() {

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -26,9 +26,9 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
   @Before
   public void setUp() {
     applicantData = new ApplicantData();
-    nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
-    colorQuestion = testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
-    addressQuestion = testQuestionBank().applicantAddress().getQuestionDefinition();
+    nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    colorQuestion = testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+    addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newProgram()
             .withBlock("Block one")

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -13,7 +13,6 @@ import repository.WithPostgresContainer;
 import services.program.ProgramDefinition;
 import services.question.types.QuestionDefinition;
 import support.ProgramBuilder;
-import support.TestQuestionBank;
 
 public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContainer {
 
@@ -27,9 +26,9 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
   @Before
   public void setUp() {
     applicantData = new ApplicantData();
-    nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
-    colorQuestion = TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
-    addressQuestion = TestQuestionBank.applicantAddress().getQuestionDefinition();
+    nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
+    colorQuestion = testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
+    addressQuestion = testQuestionBank().applicantAddress().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newProgram()
             .withBlock("Block one")

--- a/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
@@ -30,7 +30,6 @@ import services.program.ExportEngine;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import support.ProgramBuilder;
-import support.TestQuestionBank;
 
 public class CsvExporterTest extends WithPostgresContainer {
   private static Program fakeProgramWithCsvExport;
@@ -161,7 +160,7 @@ public class CsvExporterTest extends WithPostgresContainer {
     ProgramDefinition definition =
         ProgramBuilder.newProgram()
             .withBlock()
-            .withQuestion(TestQuestionBank.applicantFavoriteColor())
+            .withQuestion(testQuestionBank().applicantFavoriteColor())
             .buildDefinition();
     ExporterService exporterService = instanceOf(ExporterService.class);
 

--- a/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
@@ -160,7 +160,7 @@ public class CsvExporterTest extends WithPostgresContainer {
     ProgramDefinition definition =
         ProgramBuilder.newProgram()
             .withBlock()
-            .withQuestion(testQuestionBank().applicantFavoriteColor())
+            .withQuestion(testQuestionBank.applicantFavoriteColor())
             .buildDefinition();
     ExporterService exporterService = instanceOf(ExporterService.class);
 

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -12,6 +12,8 @@ import support.TestQuestionBank;
 
 public class BlockDefinitionTest {
 
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+
   @Test
   public void createBlockDefinition() {
     BlockDefinition block =
@@ -88,7 +90,7 @@ public class BlockDefinitionTest {
             .setDescription("Block Description")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    TestQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
+                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
             .build();
 
     assertThat(blockDefinition.isRepeater()).isTrue();
@@ -103,11 +105,11 @@ public class BlockDefinitionTest {
   }
 
   private BlockDefinition makeBlockDefinitionWithQuestions() {
-    QuestionDefinition nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
     QuestionDefinition addressQuestion =
-        TestQuestionBank.applicantAddress().getQuestionDefinition();
+        testQuestionBank.applicantAddress().getQuestionDefinition();
     QuestionDefinition colorQuestion =
-        TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
 
     BlockDefinition block =
         BlockDefinition.builder()

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -12,6 +12,8 @@ import support.TestQuestionBank;
 
 public class ProgramDefinitionTest {
 
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+
   @Test
   public void createProgramDefinition() {
     BlockDefinition blockA =
@@ -70,10 +72,10 @@ public class ProgramDefinitionTest {
 
   @Test
   public void hasQuestion_trueIfTheProgramUsesTheQuestion() {
-    QuestionDefinition questionA = TestQuestionBank.applicantName().getQuestionDefinition();
-    QuestionDefinition questionB = TestQuestionBank.applicantAddress().getQuestionDefinition();
+    QuestionDefinition questionA = testQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition questionB = testQuestionBank.applicantAddress().getQuestionDefinition();
     QuestionDefinition questionC =
-        TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
 
     BlockDefinition blockA =
         BlockDefinition.builder()

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -36,9 +36,9 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Before
   public void setUp() {
-    addressQuestion = testQuestionBank().applicantAddress().getQuestionDefinition();
-    colorQuestion = testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
-    nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
+    addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
+    colorQuestion = testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+    nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
   }
 
   @Test
@@ -356,7 +356,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void addRepeatedBlockToProgram() throws Exception {
-    Question repeatedQuestion = testQuestionBank().applicantHouseholdMembers();
+    Question repeatedQuestion = testQuestionBank.applicantHouseholdMembers();
     Program program =
         ProgramBuilder.newProgram().withBlock().withQuestion(repeatedQuestion).build();
 

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -21,7 +21,6 @@ import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.ProgramBuilder;
-import support.TestQuestionBank;
 
 public class ProgramServiceImplTest extends WithPostgresContainer {
 
@@ -37,9 +36,9 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Before
   public void setUp() {
-    addressQuestion = TestQuestionBank.applicantAddress().getQuestionDefinition();
-    colorQuestion = TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
-    nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
+    addressQuestion = testQuestionBank().applicantAddress().getQuestionDefinition();
+    colorQuestion = testQuestionBank().applicantFavoriteColor().getQuestionDefinition();
+    nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
   }
 
   @Test
@@ -357,7 +356,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void addRepeatedBlockToProgram() throws Exception {
-    Question repeatedQuestion = TestQuestionBank.applicantHouseholdMembers();
+    Question repeatedQuestion = testQuestionBank().applicantHouseholdMembers();
     Program program =
         ProgramBuilder.newProgram().withBlock().withQuestion(repeatedQuestion).build();
 

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -21,7 +21,6 @@ import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 import services.question.types.TextQuestionDefinition;
-import support.TestQuestionBank;
 
 public class QuestionServiceImplTest extends WithPostgresContainer {
   QuestionServiceImpl questionService;
@@ -54,7 +53,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void create_failsWhenPathConflicts() throws Exception {
-    Question applicantName = TestQuestionBank.applicantName();
+    Question applicantName = testQuestionBank().applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).clearId().build();
 
@@ -106,7 +105,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void update_returnsQuestionDefinitionWhenSucceeds() throws Exception {
-    QuestionDefinition nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion).setDescription("updated description").build();
 
@@ -135,7 +134,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWhenQuestionInvariantsChange() throws Exception {
-    QuestionDefinition nameQuestion = TestQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
 
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion)

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -53,7 +53,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void create_failsWhenPathConflicts() throws Exception {
-    Question applicantName = testQuestionBank().applicantName();
+    Question applicantName = testQuestionBank.applicantName();
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder(applicantName.getQuestionDefinition()).clearId().build();
 
@@ -105,7 +105,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void update_returnsQuestionDefinitionWhenSucceeds() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion).setDescription("updated description").build();
 
@@ -134,7 +134,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWhenQuestionInvariantsChange() throws Exception {
-    QuestionDefinition nameQuestion = testQuestionBank().applicantName().getQuestionDefinition();
+    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
 
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(nameQuestion)

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
@@ -12,7 +12,6 @@ import services.Path;
 import services.question.exceptions.InvalidPathException;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.QuestionNotFoundException;
-import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -21,6 +20,8 @@ import services.question.types.TextQuestionDefinition;
 import support.TestQuestionBank;
 
 public class ReadOnlyQuestionServiceImplTest {
+
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
   private final Path invalidPath = Path.create("invalid.path");
   private final ReadOnlyQuestionService emptyService =
@@ -32,15 +33,15 @@ public class ReadOnlyQuestionServiceImplTest {
   private ReadOnlyQuestionService service;
 
   @Before
-  public void setupQuestions() throws UnsupportedQuestionTypeException {
+  public void setupQuestions() {
     // The tests mimic that the persisted questions are read into ReadOnlyQuestionService.
     // Therefore, question ids cannot be empty.
     nameQuestion =
-        (NameQuestionDefinition) TestQuestionBank.applicantName().getQuestionDefinition();
+        (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
     addressQuestion =
-        (AddressQuestionDefinition) TestQuestionBank.applicantAddress().getQuestionDefinition();
+        (AddressQuestionDefinition) testQuestionBank.applicantAddress().getQuestionDefinition();
     basicQuestion =
-        (TextQuestionDefinition) TestQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+        (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
     questions = ImmutableList.of(nameQuestion, addressQuestion, basicQuestion);
     service = new ReadOnlyQuestionServiceImpl(questions);
   }
@@ -59,7 +60,7 @@ public class ReadOnlyQuestionServiceImplTest {
   @Test
   public void getRepeaterQuestions() {
     QuestionDefinition repeaterQuestion =
-        TestQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
 
     ReadOnlyQuestionService repeaterService =
         new ReadOnlyQuestionServiceImpl(
@@ -83,7 +84,7 @@ public class ReadOnlyQuestionServiceImplTest {
   @Test
   public void makePath_withRepeater() throws Exception {
     QuestionDefinition householdMembers =
-        TestQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
     service = new ReadOnlyQuestionServiceImpl(ImmutableList.of(householdMembers));
 
     Path path = service.makePath(Optional.of(householdMembers.getId()), "some question name", true);
@@ -94,7 +95,7 @@ public class ReadOnlyQuestionServiceImplTest {
 
   @Test
   public void makePath_withBadRepeater_throws() {
-    QuestionDefinition applicantName = TestQuestionBank.applicantName().getQuestionDefinition();
+    QuestionDefinition applicantName = testQuestionBank.applicantName().getQuestionDefinition();
     service = new ReadOnlyQuestionServiceImpl(ImmutableList.of(applicantName));
 
     assertThatThrownBy(

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -38,8 +38,7 @@ public class ResourceCreator {
     this.ebeanServer = Ebean.getServer(injector.instanceOf(EbeanConfig.class).defaultServer());
   }
 
-  public void clearDatabase() {
-    TestQuestionBank.reset();
+  public void truncateTables() {
     ebeanServer.truncate(
         Account.class, Applicant.class, Application.class, Program.class, Question.class);
   }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.persistence.PersistenceException;
 import models.LifecycleStage;
 import models.Question;
 import services.Path;
@@ -34,59 +33,53 @@ import services.question.types.TextQuestionDefinition;
  * retrieve the cached question.
  */
 public class TestQuestionBank {
-
   private static final long VERSION = 1L;
-  private static final Map<QuestionEnum, Question> questionCache = new ConcurrentHashMap<>();
-  private static final AtomicLong nextId = new AtomicLong(1L);
 
-  public static void reset() {
+  private boolean canSave = false;
+  private Map<QuestionEnum, Question> questionCache = new ConcurrentHashMap<>();
+  private AtomicLong nextId = new AtomicLong(1L);
+
+  public TestQuestionBank(boolean canSave) {
+    this.canSave = canSave;
+  }
+
+  public void reset() {
     questionCache.clear();
     nextId.set(1L);
   }
 
-  public static Question applicantName() {
-    return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_NAME, TestQuestionBank::applicantName);
+  // Address
+  public Question applicantAddress() {
+    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_ADDRESS, this::applicantAddress);
   }
 
-  public static Question applicantAddress() {
-    return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_ADDRESS, TestQuestionBank::applicantAddress);
+  // Name
+  public Question applicantName() {
+    return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_NAME, this::applicantName);
   }
 
-  public static Question applicantFavoriteColor() {
-    return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_FAVORITE_COLOR, TestQuestionBank::applicantFavoriteColor);
-  }
-
-  public static Question applicantHouseholdMembers() {
-    return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, TestQuestionBank::applicantHouseholdMembers);
-  }
-
-  public static Question applicantHouseholdMemberName() {
+  // Repeated name
+  public Question applicantHouseholdMemberName() {
     // Make sure the next call will have the question ready
     applicantHouseholdMembers();
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME,
-        TestQuestionBank::applicantHouseholdMemberName);
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_NAME, this::applicantHouseholdMemberName);
   }
 
-  private static Question applicantName(QuestionEnum ignore) {
-    QuestionDefinition definition =
-        new NameQuestionDefinition(
-            VERSION,
-            "applicant name",
-            Path.create("applicant.applicant_name"),
-            Optional.empty(),
-            "name of applicant",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "what is your name?"),
-            ImmutableMap.of(Locale.US, "help text"));
-    return maybeSave(definition);
+  // Repeater
+  public Question applicantHouseholdMembers() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, this::applicantHouseholdMembers);
   }
 
-  private static Question applicantAddress(QuestionEnum ignore) {
+  // Text
+  public Question applicantFavoriteColor() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_FAVORITE_COLOR, this::applicantFavoriteColor);
+  }
+
+  // Address
+  private Question applicantAddress(QuestionEnum ignore) {
     QuestionDefinition definition =
         new AddressQuestionDefinition(
             VERSION,
@@ -100,21 +93,39 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  private static Question applicantFavoriteColor(QuestionEnum ignore) {
+  // Name
+  private Question applicantName(QuestionEnum ignore) {
     QuestionDefinition definition =
-        new TextQuestionDefinition(
+        new NameQuestionDefinition(
             VERSION,
-            "applicant favorite color",
-            Path.create("applicant.applicant_favorite_color"),
+            "applicant name",
+            Path.create("applicant.applicant_name"),
             Optional.empty(),
-            "favorite color of applicant",
+            "name of applicant",
             LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "what is your favorite color?"),
+            ImmutableMap.of(Locale.US, "what is your name?"),
             ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
-  private static Question applicantHouseholdMembers(QuestionEnum ignore) {
+  // Repeated name
+  private Question applicantHouseholdMemberName(QuestionEnum ignore) {
+    Question householdMembers = applicantHouseholdMembers();
+    QuestionDefinition definition =
+            new NameQuestionDefinition(
+                    VERSION,
+                    "household members name",
+                    Path.create("applicant.applicant_household_members[].name"),
+                    Optional.of(householdMembers.id),
+                    "The applicant's household member's name",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "what is the household member's name?"),
+                    ImmutableMap.of(Locale.US, "help text"));
+    return maybeSave(definition);
+  }
+
+  // Repeater
+  private Question applicantHouseholdMembers(QuestionEnum ignore) {
     QuestionDefinition definition =
         new RepeaterQuestionDefinition(
             VERSION,
@@ -125,31 +136,29 @@ public class TestQuestionBank {
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "Who are your household members?"),
             ImmutableMap.of(Locale.US, "help text"));
-
     return maybeSave(definition);
   }
 
-  private static Question applicantHouseholdMemberName(QuestionEnum ignore) {
-    Question householdMembers = applicantHouseholdMembers();
+  // Text
+  private Question applicantFavoriteColor(QuestionEnum ignore) {
     QuestionDefinition definition =
-        new NameQuestionDefinition(
-            VERSION,
-            "household members name",
-            Path.create("applicant.applicant_household_members[].name"),
-            Optional.of(householdMembers.id),
-            "The applicant's household member's name",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(Locale.US, "what is the household member's name?"),
-            ImmutableMap.of(Locale.US, "help text"));
-
+            new TextQuestionDefinition(
+                    VERSION,
+                    "applicant favorite color",
+                    Path.create("applicant.applicant_favorite_color"),
+                    Optional.empty(),
+                    "favorite color of applicant",
+                    LifecycleStage.ACTIVE,
+                    ImmutableMap.of(Locale.US, "what is your favorite color?"),
+                    ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
-  private static Question maybeSave(QuestionDefinition questionDefinition) {
+  private Question maybeSave(QuestionDefinition questionDefinition) {
     Question question = new Question(questionDefinition);
-    try {
+    if (canSave) {
       question.save();
-    } catch (ExceptionInInitializerError | NoClassDefFoundError | PersistenceException ignore) {
+    } else {
       question.id = nextId.getAndIncrement();
       try {
         question.loadQuestionDefinition();

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -39,6 +39,10 @@ public class TestQuestionBank {
   private Map<QuestionEnum, Question> questionCache = new ConcurrentHashMap<>();
   private AtomicLong nextId = new AtomicLong(1L);
 
+  /**
+   * Pass `true` if there is a database that comes up with the test (e.g., the test class extends
+   * WithPostgresContainer), otherwise false.
+   */
   public TestQuestionBank(boolean canSave) {
     this.canSave = canSave;
   }
@@ -112,15 +116,15 @@ public class TestQuestionBank {
   private Question applicantHouseholdMemberName(QuestionEnum ignore) {
     Question householdMembers = applicantHouseholdMembers();
     QuestionDefinition definition =
-            new NameQuestionDefinition(
-                    VERSION,
-                    "household members name",
-                    Path.create("applicant.applicant_household_members[].name"),
-                    Optional.of(householdMembers.id),
-                    "The applicant's household member's name",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "what is the household member's name?"),
-                    ImmutableMap.of(Locale.US, "help text"));
+        new NameQuestionDefinition(
+            VERSION,
+            "household members name",
+            Path.create("applicant.applicant_household_members[].name"),
+            Optional.of(householdMembers.id),
+            "The applicant's household member's name",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "what is the household member's name?"),
+            ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 
@@ -142,15 +146,15 @@ public class TestQuestionBank {
   // Text
   private Question applicantFavoriteColor(QuestionEnum ignore) {
     QuestionDefinition definition =
-            new TextQuestionDefinition(
-                    VERSION,
-                    "applicant favorite color",
-                    Path.create("applicant.applicant_favorite_color"),
-                    Optional.empty(),
-                    "favorite color of applicant",
-                    LifecycleStage.ACTIVE,
-                    ImmutableMap.of(Locale.US, "what is your favorite color?"),
-                    ImmutableMap.of(Locale.US, "help text"));
+        new TextQuestionDefinition(
+            VERSION,
+            "applicant favorite color",
+            Path.create("applicant.applicant_favorite_color"),
+            Optional.empty(),
+            "favorite color of applicant",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(Locale.US, "what is your favorite color?"),
+            ImmutableMap.of(Locale.US, "help text"));
     return maybeSave(definition);
   }
 

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBankTest.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBankTest.java
@@ -8,22 +8,24 @@ import org.junit.Test;
 
 public class TestQuestionBankTest {
 
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+
   @Before
   public void reset() {
-    TestQuestionBank.reset();
+    testQuestionBank.reset();
   }
 
   @Test
   public void withoutDatabase_canGetQuestion() {
-    Question question = TestQuestionBank.applicantAddress();
+    Question question = testQuestionBank.applicantAddress();
 
     assertThat(question.id).isEqualTo(1L);
   }
 
   @Test
   public void withoutDatabase_setsId() {
-    TestQuestionBank.applicantAddress();
-    Question question = TestQuestionBank.applicantName();
+    testQuestionBank.applicantAddress();
+    Question question = testQuestionBank.applicantName();
 
     assertThat(question.id).isEqualTo(2L);
   }


### PR DESCRIPTION
### Description
There was a conflict in tests that used `TestQuestionBank`. The source of the problem was the `maybeSave` method, which attempted to `save` and catch errors if there was no database present. For some reason, this wasn't working well and caused tests to fail with a strange error when a test *with* a database was run sequentially after a test *without* a database.

The fix is to specify upon construction whether the `TestQuestionBank` `canSave` questions.

This bug was discovered in #812.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
