### PR TITLE
Use secure cookies in prod

### DIFF
--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -48,4 +48,4 @@ services:
       - ADFS_SECRET
       - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
 
-    command: ~run
+    command: ~run -Dconfig.file=conf/application.dev.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,4 +40,4 @@ services:
       - ADFS_CLIENT_ID
       - ADFS_SECRET
 
-    command: -jvm-debug "*:8457" ~run
+    command: -jvm-debug "*:8457" ~run -Dconfig.file=conf/application.dev.conf

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -102,10 +102,10 @@ play.i18n {
   langs = [ "en-US", "es-US" ]
 
   # Whether the language cookie should be secure or not
-  #langCookieSecure = true
+  langCookieSecure = true
 
   # Whether the HTTP only attribute of the cookie should be set to true
-  #langCookieHttpOnly = true
+  langCookieHttpOnly = true
 }
 
 ## Play HTTP settings
@@ -142,10 +142,10 @@ play.http {
   # ~~~~~
   session {
     # Sets the cookie to be sent only over HTTPS.
-    #secure = true
+    secure = true
 
     # Sets the cookie to be accessed only by the server.
-    #httpOnly = true
+    httpOnly = true
 
     sameSite = null
 
@@ -161,10 +161,10 @@ play.http {
 
   flash {
     # Sets the cookie to be sent only over HTTPS.
-    #secure = true
+    secure = true
 
     # Sets the cookie to be accessed only by the server.
-    #httpOnly = true
+    httpOnly = true
   }
 }
 
@@ -250,7 +250,7 @@ play.filters {
   # Play then verifies that both tokens are present and match.
   csrf {
     # Sets the cookie to be sent only over HTTPS
-    cookie.secure = false
+    cookie.secure = true
 
     # Defaults to CSRFErrorHandler in the root package.
     #errorHandler = MyCSRFErrorHandler

--- a/universal-application-tool-0.0.1/conf/application.dev.conf
+++ b/universal-application-tool-0.0.1/conf/application.dev.conf
@@ -1,0 +1,21 @@
+include "application.conf"
+
+play.i18n {
+  langCookieSecure = false
+}
+
+play.http {
+  session {
+    secure = false
+  }
+
+  flash {
+    secure = false
+  }
+}
+
+play.filters {
+  csrf {
+    cookie.secure = false
+  }
+}

--- a/universal-application-tool-0.0.1/conf/application.test.conf
+++ b/universal-application-tool-0.0.1/conf/application.test.conf
@@ -1,7 +1,8 @@
-include "application.conf"
+include "application.dev.conf"
 
 db {
   default.driver = "org.h2.Driver"
   default.url = "jdbc:h2:mem:play-test-1279561349;MODE=PostgreSQL"
 }
+
 play.evolutions.db.default.enabled = "false"


### PR DESCRIPTION
Fixing cookie related items in #837

- [x] Specify HTTP only for all cookies
- [x] Specify SSL required for all cookies in prod
- [x] introduce dev application config overrides, test config inherits from it