### PR TITLE
Display supported languages for each question in admin view

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -106,8 +106,16 @@ public class DatabaseSeedController extends DevController {
                 Optional.empty(),
                 "description",
                 LifecycleStage.ACTIVE,
-                ImmutableMap.of(Locale.US, "What is your name?"),
-                ImmutableMap.of(Locale.US, "help text")))
+                ImmutableMap.of(
+                    Locale.US,
+                    "What is your name?",
+                    Locale.forLanguageTag("es-US"),
+                    "¿Cómo se llama?"),
+                ImmutableMap.of(
+                    Locale.US,
+                    "help text",
+                    Locale.forLanguageTag("es-US"),
+                    "Ponga su nombre legal")))
         .getResult();
   }
 

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -219,6 +220,15 @@ public abstract class QuestionDefinition {
   /** Get the question help text for all locales. This is used for serialization. */
   public ImmutableMap<Locale, String> getQuestionHelpText() {
     return this.questionHelpText;
+  }
+
+  /**
+   * Get a set of {@link Locale}s that this question supports. A question fully supports a locale if
+   * it provides translations for all applicant-visible text in that locale.
+   */
+  public ImmutableSet<Locale> getSupportedLocales() {
+    return ImmutableSet.copyOf(
+        Sets.intersection(this.questionText.keySet(), this.questionHelpText.keySet()));
   }
 
   /** Get the validation predicates. */

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
@@ -19,6 +19,7 @@ import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import models.LifecycleStage;
 import play.twirl.api.Content;
 import services.question.exceptions.TranslationNotFoundException;
@@ -132,15 +133,16 @@ public final class QuestionsListView extends BaseHtmlView {
   private Tag renderQuestionTableHeaderRow() {
     return thead(
         tr().withClasses(Styles.BORDER_B, Styles.BG_GRAY_200, Styles.TEXT_LEFT)
-            .with(th("Info").withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.W_2_5))
-            .with(th("Question text").withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.W_2_5))
+            .with(th("Info").withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.W_1_4))
+            .with(th("Question text").withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.W_1_3))
+            .with(th("Supported languages").withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.W_1_6))
             .with(
                 th("Actions")
                     .withClasses(
                         BaseStyles.TABLE_CELL_STYLES,
                         Styles.TEXT_RIGHT,
                         Styles.PR_8,
-                        Styles.W_1_5)));
+                        Styles.W_1_6)));
   }
 
   /** Display this as a table row with all fields. */
@@ -178,6 +180,7 @@ public final class QuestionsListView extends BaseHtmlView {
             StyleUtils.even(Styles.BG_GRAY_100))
         .with(renderInfoCell(definition))
         .with(renderQuestionTextCell(definition))
+        .with(renderSupportedLanguages(definition))
         .with(renderActionsCell(activeDefinition, draftDefinition, definition));
   }
 
@@ -203,6 +206,19 @@ public final class QuestionsListView extends BaseHtmlView {
 
     return td().with(div(questionText).withClasses(Styles.FONT_SEMIBOLD))
         .with(div(questionHelpText).withClasses(Styles.TEXT_XS))
+        .withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.PR_12);
+  }
+
+  /**
+   * Render the supported languages for this question in US English (ex: "es-US" will appear as
+   * "Spanish").
+   */
+  private Tag renderSupportedLanguages(QuestionDefinition definition) {
+    String formattedLanguages =
+        definition.getSupportedLocales().stream()
+            .map(locale -> locale.getDisplayLanguage(Locale.US))
+            .collect(Collectors.joining(", "));
+    return td().with(div(formattedLanguages))
         .withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.PR_12);
   }
 

--- a/universal-application-tool-0.0.1/test/forms/CheckboxQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/CheckboxQuestionFormTest.java
@@ -24,7 +24,7 @@ public class CheckboxQuestionFormTest {
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
-    form.setQuestionHelpText("");
+    form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
     QuestionDefinitionBuilder builder = form.getBuilder(path);
@@ -43,7 +43,7 @@ public class CheckboxQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "cat")),
                 QuestionOption.create(2L, ImmutableMap.of(Locale.US, "dog")),
@@ -65,7 +65,7 @@ public class CheckboxQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "hello")),
                 QuestionOption.create(2L, ImmutableMap.of(Locale.US, "world"))));

--- a/universal-application-tool-0.0.1/test/forms/DropdownQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/DropdownQuestionFormTest.java
@@ -24,7 +24,7 @@ public class DropdownQuestionFormTest {
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
-    form.setQuestionHelpText("");
+    form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
     QuestionDefinitionBuilder builder = form.getBuilder(path);
@@ -43,7 +43,7 @@ public class DropdownQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "cat")),
                 QuestionOption.create(2L, ImmutableMap.of(Locale.US, "dog")),
@@ -65,7 +65,7 @@ public class DropdownQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "hello")),
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "world"))));

--- a/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
@@ -25,7 +25,7 @@ public class MultiOptionQuestionFormTest {
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
-    form.setQuestionHelpText("");
+    form.setQuestionHelpText("help text");
     form.setMinChoicesRequired("1");
     form.setMaxChoicesAllowed("10");
     form.setOptions(ImmutableList.of("one", "two"));
@@ -43,7 +43,7 @@ public class MultiOptionQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(QuestionOption.create(1L, ImmutableMap.of(Locale.US, "option one"))),
             MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create(1, 10));
 
@@ -65,7 +65,7 @@ public class MultiOptionQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(QuestionOption.create(1L, ImmutableMap.of(Locale.US, "option 1"))),
             MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create(1, 10));
 
@@ -88,7 +88,7 @@ public class MultiOptionQuestionFormTest {
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
-    form.setQuestionHelpText("");
+    form.setQuestionHelpText("help text");
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
     form.setOptions(ImmutableList.of("one", "two"));
@@ -106,7 +106,7 @@ public class MultiOptionQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(QuestionOption.create(1L, ImmutableMap.of(Locale.US, "option one"))),
             MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create());
 

--- a/universal-application-tool-0.0.1/test/forms/RadioButtonQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/RadioButtonQuestionFormTest.java
@@ -24,7 +24,7 @@ public class RadioButtonQuestionFormTest {
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
-    form.setQuestionHelpText("");
+    form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
     QuestionDefinitionBuilder builder = form.getBuilder(path);
@@ -43,7 +43,7 @@ public class RadioButtonQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "cat")),
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "dog")),
@@ -65,7 +65,7 @@ public class RadioButtonQuestionFormTest {
             "description",
             LifecycleStage.ACTIVE,
             ImmutableMap.of(Locale.US, "What is the question text?"),
-            ImmutableMap.of(),
+            ImmutableMap.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "hello")),
                 QuestionOption.create(1L, ImmutableMap.of(Locale.US, "world"))));

--- a/universal-application-tool-0.0.1/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -41,6 +41,25 @@ public class MultiOptionQuestionDefinitionTest {
   }
 
   @Test
+  public void getSupportedLocales_onlyIncludesLocalesSupportedByQuestionTextAndOptions()
+      throws UnsupportedQuestionTypeException {
+    QuestionDefinition definition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.DROPDOWN)
+            .setName("")
+            .setDescription("")
+            .setPath(Path.empty())
+            .setQuestionText(ImmutableMap.of(Locale.US, "test", Locale.FRANCE, "test"))
+            .setQuestionHelpText(ImmutableMap.of(Locale.US, "test", Locale.FRANCE, "test"))
+            .setQuestionOptions(
+                ImmutableList.of(QuestionOption.create(1L, ImmutableMap.of(Locale.US, "option 1"))))
+            .setLifecycleStage(LifecycleStage.ACTIVE)
+            .build();
+
+    assertThat(definition.getSupportedLocales()).containsExactly(Locale.US);
+  }
+
+  @Test
   public void getOptionsForLocale_failsForMissingLocale() throws UnsupportedQuestionTypeException {
     QuestionDefinition definition =
         new QuestionDefinitionBuilder()

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -393,4 +393,33 @@ public class QuestionDefinitionTest {
             CiviFormError.of("blank description"),
             CiviFormError.of("no question text"));
   }
+
+  @Test
+  public void getSupportedLocales_onlyReturnsFullySupportedLocales() {
+    QuestionDefinition definition =
+        new TextQuestionDefinition(
+            1L,
+            "test",
+            Path.empty(),
+            Optional.empty(),
+            "test",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(
+                Locale.US,
+                "question?",
+                Locale.forLanguageTag("es-US"),
+                "pregunta",
+                Locale.FRANCE,
+                "question"),
+            ImmutableMap.of(
+                Locale.US,
+                "help",
+                Locale.forLanguageTag("es-US"),
+                "ayuda",
+                Locale.GERMAN,
+                "Hilfe"));
+
+    assertThat(definition.getSupportedLocales())
+        .containsExactly(Locale.US, Locale.forLanguageTag("es-US"));
+  }
 }


### PR DESCRIPTION
### Description
Allow an admin to quickly see which languages/locales are supported for a given question.

1. Adds a `getSupportedLanguages` method to `QuestionDefinition`
2. Adds a table column in the question list for supported locales

### Checklist
- [x] Created tests which fail without the change (if possible)

### Issue(s)
#221, #778

![Screen Shot 2021-04-21 at 10 49 39 AM](https://user-images.githubusercontent.com/8559046/115599360-60ebf980-a290-11eb-8eff-d2a9ed1f62c7.png)
