### PR TITLE
Improve the repeater question renderer

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -64,16 +64,20 @@ function removeQuestionOption(event: Event) {
 
 /** In the repeater form - add a new input field for a repeated entity. */
 function addNewRepeaterField(event: Event) {
-  // Copy the answer template and remove ID and hidden properties.
-  const newField = document.getElementById("repeater-field-template").cloneNode(true) as HTMLElement;
-  newField.classList.remove("hidden");
-  newField.removeAttribute("id");
+  // Copy the first repeater field
+  const newField = document.querySelector(".repeater-field").cloneNode(true) as HTMLElement;
+
+  // Remove the text
+  const newTextField = newField.querySelector("[type=text]") as HTMLInputElement;
+  newTextField.value = null;
 
   const repeaterFields = document.getElementById("repeater-fields");
-
-  // Set new checkbox value to the index
   const index = repeaterFields.querySelectorAll(".repeater-field").length;
-  newField.querySelector("[type=checkbox]").setAttribute("value", index.toString());
+
+  // Set new checkbox value to the index and uncheck it
+  const newCheckbox = newField.querySelector("[type=checkbox]") as HTMLInputElement;
+  newCheckbox.setAttribute("value", index.toString());
+  newCheckbox.checked = false;
 
   repeaterFields.appendChild(newField);
 }

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -62,6 +62,22 @@ function removeQuestionOption(event: Event) {
   optionDiv.parentNode.removeChild(optionDiv);
 }
 
+/** In the repeater form - add a new input field for a repeated entity. */
+function addNewRepeaterField(event: Event) {
+  // Copy the answer template and remove ID and hidden properties.
+  const newField = document.getElementById("repeater-field-template").cloneNode(true);
+  newField.classList.remove("hidden");
+  newField.removeAttribute("id");
+
+  const repeaterFields = document.getElementById("repeater-fields");
+
+  // Set new checkbox value to the index
+  const index = repeaterFields.querySelectorAll(".repeater-field").length;
+  newField.querySelector("[type=checkbox]").setAttribute("value", index.toString());
+
+  repeaterFields.appendChild(newField);
+}
+
 function init() {
   attachDropdown("create-question-button");
 
@@ -69,6 +85,12 @@ function init() {
   const questionOptionButton = document.getElementById("add-new-option");
   if (questionOptionButton) {
     questionOptionButton.addEventListener("click", addNewQuestionAnswerOptionForm);
+  }
+
+  // Configure the button on the repeater question form to add more repeater field options
+  const repeaterOptionButton = document.getElementById("repeater-field-add-button");
+  if (repeaterOptionButton) {
+    repeaterOptionButton.addEventListener("click", addNewRepeaterField);
   }
 }
 init();

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -76,7 +76,7 @@ function addNewRepeaterField(event: Event) {
 
   // Set new checkbox value to the index and uncheck it
   const newCheckbox = newField.querySelector("[type=checkbox]") as HTMLInputElement;
-  newCheckbox.setAttribute("value", index.toString());
+  newCheckbox.value = index.toString();
   newCheckbox.checked = false;
 
   repeaterFields.appendChild(newField);

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -65,7 +65,7 @@ function removeQuestionOption(event: Event) {
 /** In the repeater form - add a new input field for a repeated entity. */
 function addNewRepeaterField(event: Event) {
   // Copy the answer template and remove ID and hidden properties.
-  const newField = document.getElementById("repeater-field-template").cloneNode(true);
+  const newField = document.getElementById("repeater-field-template").cloneNode(true) as HTMLElement;
   newField.classList.remove("hidden");
   newField.removeAttribute("id");
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RepeaterQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RepeaterQuestionRenderer.java
@@ -42,7 +42,6 @@ public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQ
     return div()
         .withClasses(Styles.MX_AUTO, Styles.W_MAX)
         .with(
-            repeaterFieldTemplate(),
             div()
                 .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
                 .withText(question.getQuestionText()),
@@ -74,11 +73,5 @@ public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQ
             .getContainer();
 
     return div().withClasses(REPEATER_FIELD_CLASSES).with(optionInput, removeOptionBox);
-  }
-
-  public static Tag repeaterFieldTemplate() {
-    return repeaterField("placeholder", Optional.empty(), 0)
-        .withClasses(REPEATER_FIELD_CLASSES, Styles.HIDDEN)
-        .withId(TEMPLATE_ID);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RepeaterQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RepeaterQuestionRenderer.java
@@ -2,15 +2,27 @@ package views.questiontypes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.p;
 
+import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Optional;
 import services.applicant.question.ApplicantQuestion;
+import services.question.types.RepeaterQuestionDefinition;
 import views.BaseHtmlView;
+import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
+import views.style.StyleUtils;
 import views.style.Styles;
 
 public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
+
+  public static final String REPEATER_FIELDS_ID = "repeater-fields";
+  public static final String TEMPLATE_ID = "repeater-field-template";
+  public static final String ADD_ELEMENT_BUTTON_ID = "repeater-field-add-button";
+  public static final String REPEATER_FIELD_CLASS = "repeater-field";
+
+  private static final String REPEATER_FIELD_CLASSES =
+      StyleUtils.joinStyles(REPEATER_FIELD_CLASS, Styles.FLEX, Styles.FLEX_ROW, Styles.MB_4);
 
   private final ApplicantQuestion question;
 
@@ -20,10 +32,14 @@ public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQ
 
   @Override
   public Tag render() {
+    ContainerTag repeaterFields = div().withId(REPEATER_FIELDS_ID);
+    // TODO: add each answer as a repeaterField
+    repeaterFields.with(repeaterField("placeholder", Optional.empty(), 0));
+
     return div()
-        .withId(question.getPath().path())
         .withClasses(Styles.MX_AUTO, Styles.W_MAX)
         .with(
+            repeaterFieldTemplate(),
             div()
                 .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
                 .withText(question.getQuestionText()),
@@ -33,7 +49,33 @@ public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQ
                     Styles.TEXT_BASE,
                     Styles.FONT_THIN,
                     Styles.MB_2)
-                .withText(question.getQuestionHelpText())
-                .with(p("TODO: implement the renderer for repeater questions")));
+                .withText(question.getQuestionHelpText()),
+            repeaterFields,
+            button(ADD_ELEMENT_BUTTON_ID, "add element"))
+        .withType("button");
+  }
+
+  public static Tag repeaterField(
+      String placeholderText, Optional<String> existingOption, int index) {
+    ContainerTag optionInput =
+        FieldWithLabel.input()
+            .setFieldName(RepeaterQuestionDefinition.REPEATED_ENTITY_NAME_KEY + "[]")
+            .setPlaceholderText(placeholderText)
+            .setValue(existingOption)
+            .getContainer()
+            .withClasses(Styles.FLEX, Styles.ML_2);
+    Tag removeOptionBox =
+        FieldWithLabel.checkbox()
+            .setFieldName(RepeaterQuestionDefinition.REPEATED_ENTITY_NAME_KEY + "_delete[]")
+            .setValue(String.valueOf(index))
+            .getContainer();
+
+    return div().withClasses(REPEATER_FIELD_CLASSES).with(optionInput, removeOptionBox);
+  }
+
+  public static Tag repeaterFieldTemplate() {
+    return repeaterField("placeholder", Optional.empty(), 0)
+        .withClasses(REPEATER_FIELD_CLASSES, Styles.HIDDEN)
+        .withId(TEMPLATE_ID);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RepeaterQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RepeaterQuestionRenderer.java
@@ -21,6 +21,9 @@ public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQ
   public static final String ADD_ELEMENT_BUTTON_ID = "repeater-field-add-button";
   public static final String REPEATER_FIELD_CLASS = "repeater-field";
 
+  // TODO(#859): make this admin-configurable
+  private static final String PLACEHOLDER = "Placeholder";
+
   private static final String REPEATER_FIELD_CLASSES =
       StyleUtils.joinStyles(REPEATER_FIELD_CLASS, Styles.FLEX, Styles.FLEX_ROW, Styles.MB_4);
 
@@ -34,7 +37,7 @@ public class RepeaterQuestionRenderer extends BaseHtmlView implements ApplicantQ
   public Tag render() {
     ContainerTag repeaterFields = div().withId(REPEATER_FIELDS_ID);
     // TODO: add each answer as a repeaterField
-    repeaterFields.with(repeaterField("placeholder", Optional.empty(), 0));
+    repeaterFields.with(repeaterField(PLACEHOLDER, Optional.empty(), 0));
 
     return div()
         .withClasses(Styles.MX_AUTO, Styles.W_MAX)


### PR DESCRIPTION
### Description
Update `RepeaterQuestionRenderer` and add a typescript function for clicking the add field button.

![image](https://user-images.githubusercontent.com/12072571/115743608-ad920c00-a346-11eb-8af2-e30e0aae0e53.png)

The html form for the repeater question should have two parts: an array of string values for repeated entity name, and an array of repeated entities to delete, which is quite different from all of our other question types.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #705 