### PR TITLE
Delete `QuestionDefinition#getScalarType` and `ReadOnlyQuestionService` methods that were only used in tests.

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
@@ -1,16 +1,13 @@
 package services.question;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Optional;
 import services.Path;
-import services.question.exceptions.InvalidPathException;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
 import services.question.types.RepeaterQuestionDefinition;
-import services.question.types.ScalarType;
 
 /**
  * The ReadOnlyQuestionService contains all synchronous, in-memory operations for
@@ -30,9 +27,6 @@ public interface ReadOnlyQuestionService {
   /** Returns all repeater question definitions. */
   ImmutableList<RepeaterQuestionDefinition> getUpToDateRepeaterQuestions();
 
-  /** Returns all scalars for this version. */
-  ImmutableMap<Path, ScalarType> getAllScalars();
-
   /**
    * Create the {@link Path} for a question from the path of the repeater id (if provided) and the
    * question name.
@@ -41,35 +35,11 @@ public interface ReadOnlyQuestionService {
       throws InvalidQuestionTypeException, QuestionNotFoundException;
 
   /**
-   * Returns all of the scalar properties for a given path.
-   *
-   * <p>If the path is to a QUESTION, it will return the question's scalar objects.
-   *
-   * <p>If the path is to a SCALAR, it will return a single scalar.
-   *
-   * <p>If the path is invalid it will throw an InvalidPathException.
-   */
-  ImmutableMap<Path, ScalarType> getPathScalars(Path path) throws InvalidPathException;
-
-  /**
-   * Gets the type of the node if it exist.
-   *
-   * <p>If the path is invalid it will return PathType.NONE.
-   */
-  PathType getPathType(Path path);
-
-  /**
    * Gets the question definition for a ID.
    *
    * @throws QuestionNotFoundException if the question for the ID does not exist.
    */
   QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException;
-
-  /**
-   * Checks whether a specific path is valid. A path is valid in this context if it represents a
-   * real path to a value.
-   */
-  boolean isValid(Path path);
 
   /**
    * When getting question text and help text we need to send the Locale. If absent it will use the

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -277,10 +277,6 @@ public abstract class QuestionDefinition {
         getLastUpdatedTimePath(), getLastUpdatedTimeType(), getProgramIdPath(), getProgramIdType());
   }
 
-  public Optional<ScalarType> getScalarType(Path path) {
-    return Optional.ofNullable(this.getScalars().get(path));
-  }
-
   /** Validate that all required fields are present and valid for the question. */
   public ImmutableSet<CiviFormError> validate() {
     ImmutableSet.Builder<CiviFormError> errors = new ImmutableSet.Builder<>();

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -100,7 +100,6 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
     ReadOnlyQuestionService emptyService = completionStage.toCompletableFuture().join();
 
     assertThat(emptyService.getAllQuestions()).isEmpty();
-    assertThat(emptyService.getAllScalars()).isEmpty();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
@@ -4,18 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import services.Path;
-import services.question.exceptions.InvalidPathException;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.AddressQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
-import services.question.types.ScalarType;
 import services.question.types.TextQuestionDefinition;
 import support.TestQuestionBank;
 
@@ -23,7 +20,6 @@ public class ReadOnlyQuestionServiceImplTest {
 
   private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
-  private final Path invalidPath = Path.create("invalid.path");
   private final ReadOnlyQuestionService emptyService =
       new ReadOnlyQuestionServiceImpl(ImmutableList.of());
   private NameQuestionDefinition nameQuestion;
@@ -49,7 +45,6 @@ public class ReadOnlyQuestionServiceImplTest {
   @Test
   public void getAll_returnsEmpty() {
     assertThat(emptyService.getAllQuestions()).isEmpty();
-    assertThat(emptyService.getAllScalars()).isEmpty();
   }
 
   @Test
@@ -111,78 +106,8 @@ public class ReadOnlyQuestionServiceImplTest {
   }
 
   @Test
-  public void getAllScalars() {
-    ImmutableMap.Builder<Path, ScalarType> scalars = ImmutableMap.builder();
-    scalars.putAll(nameQuestion.getScalars());
-    scalars.putAll(addressQuestion.getScalars());
-    scalars.putAll(basicQuestion.getScalars());
-    assertThat(service.getAllScalars()).isEqualTo(scalars.build());
-  }
-
-  @Test
-  public void getPathScalars_forQuestion() throws InvalidPathException {
-    ImmutableMap<Path, ScalarType> result =
-        service.getPathScalars(Path.create("applicant.applicant_address"));
-    ImmutableMap<Path, ScalarType> expected = addressQuestion.getScalars();
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  public void getPathScalars_forScalar() throws InvalidPathException {
-    ImmutableMap<Path, ScalarType> result =
-        service.getPathScalars(Path.create("applicant.applicant_address.city"));
-    ImmutableMap<Path, ScalarType> expected =
-        ImmutableMap.of(Path.create("applicant.applicant_address.city"), ScalarType.STRING);
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  public void getPathScalars_forInvalidPath() {
-    assertThatThrownBy(() -> service.getPathScalars(invalidPath))
-        .isInstanceOf(InvalidPathException.class)
-        .hasMessage("Path not found: " + invalidPath.path());
-  }
-
-  @Test
-  public void getPathType_forInvalidPath() {
-    assertThat(service.getPathType(invalidPath)).isEqualTo(PathType.NONE);
-  }
-
-  @Test
-  public void getPathType_forQuestion() {
-    assertThat(service.getPathType(Path.create("applicant.applicant_favorite_color")))
-        .isEqualTo(PathType.QUESTION);
-  }
-
-  @Test
-  public void getPathType_forScalar() {
-    assertThat(service.getPathType(Path.create("applicant.applicant_name.first")))
-        .isEqualTo(PathType.SCALAR);
-  }
-
-  @Test
   public void getQuestionDefinition_byId() throws QuestionNotFoundException {
     long questionId = nameQuestion.getId();
     assertThat(service.getQuestionDefinition(questionId)).isEqualTo(nameQuestion);
-  }
-
-  @Test
-  public void isValid_returnsFalseForInvalid() {
-    assertThat(service.isValid(Path.create("invalidPath"))).isFalse();
-  }
-
-  @Test
-  public void isValid_returnsFalseWhenEmpty() {
-    assertThat(emptyService.isValid(Path.empty())).isFalse();
-  }
-
-  @Test
-  public void isValid_returnsTrueForQuestion() {
-    assertThat(service.isValid(Path.create("applicant.applicant_name"))).isTrue();
-  }
-
-  @Test
-  public void isValid_returnsTrueForScalar() {
-    assertThat(service.isValid(Path.create("applicant.applicant_name.first"))).isTrue();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -337,26 +337,6 @@ public class QuestionDefinitionTest {
             Path.create("path.to.question.updated_in_program"),
             ScalarType.LONG);
     assertThat(question.getScalars()).containsAllEntriesOf(expectedScalars);
-    assertThat(question.getScalarType(Path.create("path.to.question.text")).get())
-        .isEqualTo(ScalarType.STRING);
-    assertThat(
-            question.getScalarType(Path.create("path.to.question.text")).get().getClassFor().get())
-        .isEqualTo(String.class);
-  }
-
-  @Test
-  public void newQuestionMissingScalar_returnsOptionalEmpty() {
-    QuestionDefinition question =
-        new TextQuestionDefinition(
-            1L,
-            "",
-            Path.empty(),
-            Optional.empty(),
-            "",
-            LifecycleStage.ACTIVE,
-            ImmutableMap.of(),
-            ImmutableMap.of());
-    assertThat(question.getScalarType(Path.create("notPresent"))).isEqualTo(Optional.empty());
   }
 
   @Test


### PR DESCRIPTION
### Description
Deleted:
* `QuestionDefinition#getScalarType(Path)`
* `ReadOnlyQuestionService#getAllScalars()`
* `ReadOnlyQuestionService#getPathScalars(Path)`
* `ReadOnlyQuestionService#getPathType(Path)`
* `ReadOnlyQuestionService#isValid(Path)`

This cleanup is being done in preparation for a large refactor required for #783.