### PR TITLE
Fix i18n bug #856 - do not throw when locale not found

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import auth.Authorizers;
 import controllers.CiviFormController;
 import forms.ProgramForm;
-import java.util.Locale;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
@@ -15,6 +14,7 @@ import play.mvc.Result;
 import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
+import services.LocalizationUtils;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
@@ -114,7 +114,7 @@ public class AdminProgramController extends CiviFormController {
       ErrorAnd<ProgramDefinition, CiviFormError> result =
           service.updateProgramDefinition(
               id,
-              Locale.US,
+              LocalizationUtils.DEFAULT_LOCALE,
               program.getAdminDescription(),
               program.getLocalizedDisplayName(),
               program.getLocalizedDisplayDescription());

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -87,6 +87,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             .setApplicantId(applicantId)
                             .setProgramId(programId)
                             .setBlock(block.get())
+                            .setPreferredLanguageSupported(
+                                roApplicantProgramService.preferredLanguageSupported())
                             .build()));
               } else {
                 return notFound();

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -183,6 +183,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           .setApplicantId(applicantId)
                           .setProgramId(programId)
                           .setBlock(thisBlockUpdated)
+                          .setPreferredLanguageSupported(
+                              roApplicantProgramService.preferredLanguageSupported())
                           .build())));
     }
 

--- a/universal-application-tool-0.0.1/app/forms/ApplicantInformationForm.java
+++ b/universal-application-tool-0.0.1/app/forms/ApplicantInformationForm.java
@@ -1,13 +1,13 @@
 package forms;
 
 import java.util.Locale;
+import services.LocalizationUtils;
 
 public class ApplicantInformationForm {
   private Locale locale;
 
   public ApplicantInformationForm() {
-    // The default language for CiviForm is US English.
-    locale = Locale.US;
+    locale = LocalizationUtils.DEFAULT_LOCALE;
   }
 
   public Locale getLocale() {

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.LocalizedQuestionOption;
 import services.question.QuestionOption;
@@ -41,9 +42,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     try {
       // TODO: this will need revisiting to support multiple locales
       // https://github.com/seattle-uat/civiform/issues/778
-      if (qd.getSupportedLocales().contains(Locale.US)) {
+      if (qd.getSupportedLocales().contains(LocalizationUtils.DEFAULT_LOCALE)) {
         List<String> optionStrings =
-            qd.getOptionsForLocale(Locale.US).stream()
+            qd.getOptionsForLocale(LocalizationUtils.DEFAULT_LOCALE).stream()
                 .map(LocalizedQuestionOption::optionText)
                 .collect(Collectors.toList());
         this.options.addAll(optionStrings);

--- a/universal-application-tool-0.0.1/app/forms/QuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/QuestionForm.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Optional;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.exceptions.TranslationNotFoundException;
 import services.question.types.QuestionDefinition;
@@ -32,13 +33,13 @@ public abstract class QuestionForm {
     repeaterId = qd.getRepeaterId();
 
     try {
-      questionText = qd.getQuestionText(Locale.US);
+      questionText = qd.getQuestionText(LocalizationUtils.DEFAULT_LOCALE);
     } catch (TranslationNotFoundException e) {
       questionText = "Missing Text";
     }
 
     try {
-      questionHelpText = qd.getQuestionHelpText(Locale.US);
+      questionHelpText = qd.getQuestionHelpText(LocalizationUtils.DEFAULT_LOCALE);
     } catch (TranslationNotFoundException e) {
       questionHelpText = "Missing Text";
     }

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -16,6 +16,7 @@ import javax.persistence.PostUpdate;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
+import services.LocalizationUtils;
 import services.program.BlockDefinition;
 import services.program.ExportDefinition;
 import services.program.ProgramDefinition;
@@ -76,8 +77,9 @@ public class Program extends BaseModel {
     this.description = adminDescription;
     // TODO(https://github.com/seattle-uat/civiform/issues/777): Allow the admin to
     // set localized strings for applicant-visible name and description.
-    this.localizedName = ImmutableMap.of(Locale.US, defaultDisplayName);
-    this.localizedDescription = ImmutableMap.of(Locale.US, defaultDisplayDescription);
+    this.localizedName = ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, defaultDisplayName);
+    this.localizedDescription =
+        ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, defaultDisplayDescription);
     this.lifecycleStage = LifecycleStage.DRAFT;
     BlockDefinition emptyBlock =
         BlockDefinition.builder()

--- a/universal-application-tool-0.0.1/app/services/LocalizationUtils.java
+++ b/universal-application-tool-0.0.1/app/services/LocalizationUtils.java
@@ -6,6 +6,9 @@ import java.util.Map;
 
 public class LocalizationUtils {
 
+  /** The default locale for CiviForm is US English. */
+  public static final Locale DEFAULT_LOCALE = Locale.US;
+
   /**
    * By design, {@link ImmutableMap}s do not have a {@code remove} method in their builders. If we
    * want to update an existing translation, we must copy the map except the existing entry for that

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -16,13 +16,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import services.LocalizationUtils;
 import services.Path;
 import services.WellKnownPaths;
 import services.question.types.RepeaterQuestionDefinition;
 
 public class ApplicantData {
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
-  private static final Locale DEFAULT_LOCALE = Locale.US;
   private static final TypeRef<ImmutableList<Long>> IMMUTABLE_LIST_LONG_TYPE = new TypeRef<>() {};
 
   private Optional<Locale> preferredLocale;
@@ -48,7 +48,7 @@ public class ApplicantData {
 
   /** Returns this applicant's preferred locale if it is set, or the default locale if not set. */
   public Locale preferredLocale() {
-    return this.preferredLocale.orElse(DEFAULT_LOCALE);
+    return this.preferredLocale.orElse(LocalizationUtils.DEFAULT_LOCALE);
   }
 
   public void setPreferredLocale(Locale locale) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -20,4 +20,10 @@ public interface ReadOnlyApplicantProgramService {
 
   /** Get the program block with the lowest index that has missing answer data if there is one. */
   Optional<Block> getFirstIncompleteBlock();
+
+  /**
+   * Returns true if this program fully supports this applicant's preferred language, and false
+   * otherwise.
+   */
+  boolean preferredLanguageSupported();
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -81,6 +81,11 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
         .findFirst();
   }
 
+  @Override
+  public boolean preferredLanguageSupported() {
+    return programDefinition.getSupportedLocales().contains(applicantData.preferredLocale());
+  }
+
   private ImmutableList<Block> getAllBlocksForThisProgram() {
     return programDefinition.blockDefinitions().stream()
         .map(blockDefinition -> new Block(blockDefinition.id(), blockDefinition, applicantData))

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import services.Path;
 import services.applicant.ApplicantData;
-import services.question.exceptions.TranslationNotFoundException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 
@@ -40,19 +39,11 @@ public class ApplicantQuestion {
   }
 
   public String getQuestionText() {
-    try {
-      return questionDefinition.getQuestionText(applicantData.preferredLocale());
-    } catch (TranslationNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    return questionDefinition.getQuestionTextOrDefault(applicantData.preferredLocale());
   }
 
   public String getQuestionHelpText() {
-    try {
-      return questionDefinition.getQuestionHelpText(applicantData.preferredLocale());
-    } catch (TranslationNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    return questionDefinition.getQuestionHelpTextOrDefault(applicantData.preferredLocale());
   }
 
   public Path getPath() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
-import services.question.exceptions.TranslationNotFoundException;
 import services.question.types.MultiOptionQuestionDefinition;
 
 public class MultiSelectQuestion implements PresentsErrors {
@@ -127,11 +126,7 @@ public class MultiSelectQuestion implements PresentsErrors {
   }
 
   public ImmutableList<LocalizedQuestionOption> getOptions() {
-    try {
-      return getQuestionDefinition()
-          .getOptionsForLocale(applicantQuestion.getApplicantData().preferredLocale());
-    } catch (TranslationNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    return getQuestionDefinition()
+        .getOptionsForLocaleOrDefault(applicantQuestion.getApplicantData().preferredLocale());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
-import services.question.exceptions.TranslationNotFoundException;
 import services.question.types.MultiOptionQuestionDefinition;
 
 // TODO(https://github.com/seattle-uat/civiform/issues/396): Implement a question that allows for
@@ -84,12 +83,8 @@ public class SingleSelectQuestion implements PresentsErrors {
   }
 
   public ImmutableList<LocalizedQuestionOption> getOptions() {
-    try {
-      return getQuestionDefinition()
-          .getOptionsForLocale(applicantQuestion.getApplicantData().preferredLocale());
-    } catch (TranslationNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    return getQuestionDefinition()
+        .getOptionsForLocaleOrDefault(applicantQuestion.getApplicantData().preferredLocale());
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -66,7 +66,7 @@ public abstract class ProgramDefinition {
   /** The default locale for CiviForm is US English. */
   public String getNameForDefaultLocale() {
     try {
-      return getLocalizedName(Locale.US);
+      return getLocalizedName(LocalizationUtils.DEFAULT_LOCALE);
     } catch (TranslationNotFoundException e) {
       // This should never happen - US English should always be supported.
       throw new RuntimeException(e);
@@ -92,7 +92,7 @@ public abstract class ProgramDefinition {
   /** The default locale for CiviForm is US English. */
   public String getDescriptionForDefaultLocale() {
     try {
-      return getLocalizedDescription(Locale.US);
+      return getLocalizedDescription(LocalizationUtils.DEFAULT_LOCALE);
     } catch (TranslationNotFoundException e) {
       // This should never happen - US English should always be supported.
       throw new RuntimeException(e);

--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.Locale;
 import java.util.Optional;
 import models.LifecycleStage;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.exceptions.InvalidPathException;
 import services.question.exceptions.InvalidQuestionTypeException;
@@ -26,7 +27,7 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
   private final ImmutableMap<Path, QuestionDefinition> questionsByPath;
   private final ImmutableSet<QuestionDefinition> upToDateQuestions;
 
-  private Locale preferredLocale = Locale.US;
+  private Locale preferredLocale = LocalizationUtils.DEFAULT_LOCALE;
 
   public ReadOnlyQuestionServiceImpl(ImmutableList<QuestionDefinition> questions) {
     checkNotNull(questions);

--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import models.LifecycleStage;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.LocalizedQuestionOption;
 import services.question.QuestionOption;
@@ -151,6 +152,28 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
 
   public ImmutableList<QuestionOption> getOptions() {
     return this.options;
+  }
+
+  /**
+   * Attempt to get question options for the given locale. If there aren't options for the given
+   * locale, it will return the options for the default locale.
+   */
+  public ImmutableList<LocalizedQuestionOption> getOptionsForLocaleOrDefault(Locale locale) {
+    try {
+      return getOptionsForLocale(locale);
+    } catch (TranslationNotFoundException e) {
+      return getOptionsForDefaultLocale();
+    }
+  }
+
+  /** Get question options localized to CiviForm's default locale. */
+  public ImmutableList<LocalizedQuestionOption> getOptionsForDefaultLocale() {
+    try {
+      return getOptionsForLocale(LocalizationUtils.DEFAULT_LOCALE);
+    } catch (TranslationNotFoundException e) {
+      // This should never happen - there should always be options localized to the default locale.
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import models.LifecycleStage;
 import services.CiviFormError;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.exceptions.TranslationNotFoundException;
 
@@ -176,6 +177,28 @@ public abstract class QuestionDefinition {
     return this.description;
   }
 
+  /**
+   * Attempts to get question text for the given locale. If there is no text for the given locale,
+   * it will return the text in the default locale.
+   */
+  public String getQuestionTextOrDefault(Locale locale) {
+    try {
+      return getQuestionText(locale);
+    } catch (TranslationNotFoundException e) {
+      return getDefaultQuestionText();
+    }
+  }
+
+  /** Gets the question text for CiviForm's default locale. */
+  public String getDefaultQuestionText() {
+    try {
+      return getQuestionText(LocalizationUtils.DEFAULT_LOCALE);
+    } catch (TranslationNotFoundException e) {
+      // This should never happen - US English should always be supported.
+      throw new RuntimeException(e);
+    }
+  }
+
   /** Get the question text for the given locale. */
   public String getQuestionText(Locale locale) throws TranslationNotFoundException {
     if (this.questionText.containsKey(locale)) {
@@ -196,6 +219,28 @@ public abstract class QuestionDefinition {
   /** Get the question tests for all locales. This is used for serialization. */
   public ImmutableMap<Locale, String> getQuestionText() {
     return questionText;
+  }
+
+  /**
+   * Attempts to get the question help text for the given locale. If there is no help text localized
+   * to the given locale, it will return text in the default locale.
+   */
+  public String getQuestionHelpTextOrDefault(Locale locale) {
+    try {
+      return getQuestionHelpText(locale);
+    } catch (TranslationNotFoundException e) {
+      return getDefaultQuestionHelpText();
+    }
+  }
+
+  /** Gets the question help text for CiviForm's default locale. */
+  public String getDefaultQuestionHelpText() {
+    try {
+      return getQuestionHelpText(LocalizationUtils.DEFAULT_LOCALE);
+    } catch (TranslationNotFoundException e) {
+      // This should never happen - US English should always be supported.
+      throw new RuntimeException(e);
+    }
   }
 
   /** Get the question help text for the given locale. */

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -6,7 +6,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
 import models.LifecycleStage;
-import services.LocalizationUtils;
 import services.Path;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
 import models.LifecycleStage;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -66,15 +67,19 @@ public class QuestionDefinitionBuilder {
             .setName("")
             .setDescription("")
             .setPath(Path.create("sample.question.path"))
-            .setQuestionText(ImmutableMap.of(Locale.US, "Sample question text"))
-            .setQuestionHelpText(ImmutableMap.of(Locale.US, "Sample question help text"))
+            .setQuestionText(
+                ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, "Sample question text"))
+            .setQuestionHelpText(
+                ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, "Sample question help text"))
             .setLifecycleStage(LifecycleStage.ACTIVE)
             .setQuestionType(questionType);
 
     if (questionType.isMultiOptionType()) {
       builder.setQuestionOptions(
           ImmutableList.of(
-              QuestionOption.create(1L, ImmutableMap.of(Locale.US, "Sample question option"))));
+              QuestionOption.create(
+                  1L,
+                  ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, "Sample question option"))));
     }
 
     return builder;

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
@@ -17,11 +17,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import models.LifecycleStage;
 import play.twirl.api.Content;
+import services.LocalizationUtils;
 import services.question.exceptions.TranslationNotFoundException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
@@ -195,12 +195,12 @@ public final class QuestionsListView extends BaseHtmlView {
     String questionHelpText = "";
 
     try {
-      questionText = definition.getQuestionText(Locale.US);
+      questionText = definition.getQuestionText(LocalizationUtils.DEFAULT_LOCALE);
     } catch (TranslationNotFoundException e) { // Ignore. Leaving blank
     }
 
     try {
-      questionHelpText = definition.getQuestionHelpText(Locale.US);
+      questionHelpText = definition.getQuestionHelpText(LocalizationUtils.DEFAULT_LOCALE);
     } catch (TranslationNotFoundException e) { // Ignore. Leaving blank
     }
 
@@ -216,7 +216,7 @@ public final class QuestionsListView extends BaseHtmlView {
   private Tag renderSupportedLanguages(QuestionDefinition definition) {
     String formattedLanguages =
         definition.getSupportedLocales().stream()
-            .map(locale -> locale.getDisplayLanguage(Locale.US))
+            .map(locale -> locale.getDisplayLanguage(LocalizationUtils.DEFAULT_LOCALE))
             .collect(Collectors.joining(", "));
     return td().with(div(formattedLanguages))
         .withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.PR_12);

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -52,7 +52,9 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
                     .with(submitButton(params.messages().at("button.nextBlock"))));
 
     if (!params.preferredLanguageSupported()) {
-      body.with(renderLocaleNotSupportedToast(params.programId(), params.messages()));
+      body.with(
+          renderLocaleNotSupportedToast(
+              params.applicantId(), params.programId(), params.messages()));
     }
 
     return layout.render(body);
@@ -63,12 +65,15 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
    * warning. Allow them to dismiss the warning, and once it is dismissed it does not reappear for
    * the same program.
    */
-  private ContainerTag renderLocaleNotSupportedToast(long programId, Messages messages) {
-    // Note: we include programId in the ID, so that the applicant sees the warning for each program
-    // that is not properly localized. Otherwise, once dismissed, this toast would never appear for
-    // other programs.
+  private ContainerTag renderLocaleNotSupportedToast(
+      long applicantId, long programId, Messages messages) {
+    // Note: we include applicantId and programId in the ID, so that the applicant sees the warning
+    // for each program that is not properly localized. Otherwise, once dismissed, this toast would
+    // never appear for other programs. Additionally, including the applicantId ensures that this
+    // warning still appears across applicants, so that (for example) a Trusted Intermediary
+    // handling multiple applicants will see the toast displayed.
     return ToastMessage.warning(messages.at("toast.localeNotSupported"))
-        .setId(String.format("locale-not-supported-%d", programId))
+        .setId(String.format("locale-not-supported-%d-%d", applicantId, programId))
         .setDismissible(true)
         .setIgnorable(true)
         .setDuration(0)

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -1,6 +1,7 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.body;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
@@ -9,6 +10,7 @@ import static j2html.TagCreator.p;
 import com.google.auto.value.AutoValue;
 import com.google.inject.Inject;
 import controllers.applicant.routes;
+import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import play.i18n.Messages;
 import play.mvc.Http;
@@ -17,6 +19,7 @@ import play.twirl.api.Content;
 import services.applicant.Block;
 import services.applicant.question.ApplicantQuestion;
 import views.BaseHtmlView;
+import views.components.ToastMessage;
 import views.questiontypes.ApplicantQuestionRendererFactory;
 
 public final class ApplicantProgramBlockEditView extends BaseHtmlView {
@@ -36,16 +39,40 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
         routes.ApplicantProgramBlocksController.update(
                 params.applicantId(), params.programId(), params.block().getId())
             .url();
+    ContainerTag body =
+        body()
+            .with(h1(params.block().getName()))
+            .with(p(params.block().getDescription()))
+            .with(
+                form()
+                    .withAction(formAction)
+                    .withMethod(HttpVerbs.POST)
+                    .with(makeCsrfTokenInputTag(params.request()))
+                    .with(each(params.block().getQuestions(), this::renderQuestion))
+                    .with(submitButton(params.messages().at("button.nextBlock"))));
 
-    return layout.render(
-        h1(params.block().getName()),
-        p(params.block().getDescription()),
-        form()
-            .withAction(formAction)
-            .withMethod(HttpVerbs.POST)
-            .with(makeCsrfTokenInputTag(params.request()))
-            .with(each(params.block().getQuestions(), this::renderQuestion))
-            .with(submitButton(params.messages().at("button.nextBlock"))));
+    if (!params.preferredLanguageSupported()) {
+      body.with(renderLocaleNotSupportedToast(params.programId(), params.messages()));
+    }
+
+    return layout.render(body);
+  }
+
+  /**
+   * If the applicant's preferred language is not supported for this program, render a toast
+   * warning. Allow them to dismiss the warning, and once it is dismissed it does not reappear for
+   * the same program.
+   */
+  private ContainerTag renderLocaleNotSupportedToast(long programId, Messages messages) {
+    // Note: we include programId in the ID, so that the applicant sees the warning for each program
+    // that is not properly localized. Otherwise, once dismissed, this toast would never appear for
+    // other programs.
+    return ToastMessage.warning(messages.at("toast.localeNotSupported"))
+        .setId(String.format("locale-not-supported-%d", programId))
+        .setDismissible(true)
+        .setIgnorable(true)
+        .setDuration(0)
+        .getContainerTag();
   }
 
   private Tag renderQuestion(ApplicantQuestion question) {
@@ -68,6 +95,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
     abstract Block block();
 
+    abstract boolean preferredLanguageSupported();
+
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder setRequest(Http.Request request);
@@ -79,6 +108,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
       public abstract Builder setProgramId(long programId);
 
       public abstract Builder setBlock(Block block);
+
+      public abstract Builder setPreferredLanguageSupported(boolean preferredLanguageSupported);
 
       public abstract Params build();
     }

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -1,6 +1,8 @@
 # This is the default language for the application. Please provide context for each message for use in translations.
 
-# COMPONENTS - contains text used in HTML components such as buttons.
+#---------------------------------------------------------------------#
+# COMPONENTS - contains text used in HTML components such as buttons. #
+#---------------------------------------------------------------------#
 
 # The text on the button an applicant clicks to apply to a specific program.
 button.apply=Apply
@@ -8,8 +10,12 @@ button.apply=Apply
 # The button text for saving the current applicant-entered data and continuing to the next block in the form.
 button.nextBlock=Save and continue
 
-# PAGES - contains text specific to a given page.
+# A toast message that displays when a program is not fully localized to the applicant's preferred locale.
+toast.localeNotSupported=We're sorry, this program is not fully translated to English.
 
+#-------------------------------------------------#
+# PAGES - contains text specific to a given page. #
+#-------------------------------------------------#
 
 # (applicant program index view): The title of the page for the list of programs.
 title.programs=Programs

--- a/universal-application-tool-0.0.1/conf/messages.es-US
+++ b/universal-application-tool-0.0.1/conf/messages.es-US
@@ -1,5 +1,6 @@
 button.apply=Solicitar
 button.nextBlock=Guardar y continuar
+toast.localeNotSupported=Lo siento, este programa no está completamente traducido al español.
 
 title.programs=Programas
 content.benefits=obtener beneficios

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -173,6 +173,17 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     assertThat(maybeBlock.get().getName()).isEqualTo("Block two");
   }
 
+  @Test
+  public void preferredLanguageSupported_returnsTrueForDefaults() {
+    assertThat(subject.preferredLanguageSupported()).isTrue();
+  }
+
+  @Test
+  public void preferredLanguageSupported_returnsFalseForUnsupportedLang() {
+    applicantData.setPreferredLocale(Locale.CHINESE);
+    assertThat(subject.preferredLanguageSupported()).isFalse();
+  }
+
   private void answerNameQuestion() {
     answerNameQuestion(1L);
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import models.LifecycleStage;
 import org.junit.Before;
 import org.junit.Test;
+import services.LocalizationUtils;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
@@ -104,5 +105,17 @@ public class MultiSelectQuestionTest {
 
     assertThat(multiSelectQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(multiSelectQuestion.hasQuestionErrors()).isFalse();
+  }
+
+  @Test
+  public void getOptions_defaultsIfLangUnsupported() {
+    applicantData.setPreferredLocale(Locale.CHINESE);
+    ApplicantQuestion applicantQuestion = new ApplicantQuestion(CHECKBOX_QUESTION, applicantData);
+
+    MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
+
+    assertThat(multiSelectQuestion.getOptions()).isNotEmpty();
+    assertThat(multiSelectQuestion.getOptions().get(0).locale())
+        .isEqualTo(LocalizationUtils.DEFAULT_LOCALE);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -10,6 +10,7 @@ import models.Applicant;
 import models.LifecycleStage;
 import org.junit.Before;
 import org.junit.Test;
+import services.LocalizationUtils;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.question.LocalizedQuestionOption;
@@ -82,5 +83,18 @@ public class SingleSelectQuestionTest {
     assertThat(singleSelectQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(singleSelectQuestion.hasQuestionErrors()).isFalse();
     assertThat(singleSelectQuestion.getSelectedOptionValue()).isEmpty();
+  }
+
+  @Test
+  public void getOptions_defaultsIfLangUnsupported() {
+    applicantData.setPreferredLocale(Locale.CHINESE);
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(dropdownQuestionDefinition, applicantData);
+
+    SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
+
+    assertThat(singleSelectQuestion.getOptions()).isNotEmpty();
+    assertThat(singleSelectQuestion.getOptions().get(0).locale())
+        .isEqualTo(LocalizationUtils.DEFAULT_LOCALE);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.CiviFormError;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.exceptions.TranslationNotFoundException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -298,6 +299,40 @@ public class QuestionDefinitionTest {
             ImmutableMap.of(),
             ImmutableMap.of());
     assertThat(question.getQuestionHelpText(Locale.FRANCE)).isEqualTo("");
+  }
+
+  @Test
+  public void getQuestionTextOrDefault_returnsDefaultIfNotFound() {
+    QuestionDefinition question =
+        new TextQuestionDefinition(
+            1L,
+            "",
+            Path.empty(),
+            Optional.empty(),
+            "",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, "default"),
+            ImmutableMap.of());
+
+    assertThat(question.getQuestionTextOrDefault(Locale.forLanguageTag("und")))
+        .isEqualTo("default");
+  }
+
+  @Test
+  public void getQuestionHelpTextOrDefault_returnsDefaultIfNotFound() {
+    QuestionDefinition question =
+        new TextQuestionDefinition(
+            1L,
+            "",
+            Path.empty(),
+            Optional.empty(),
+            "",
+            LifecycleStage.ACTIVE,
+            ImmutableMap.of(),
+            ImmutableMap.of(LocalizationUtils.DEFAULT_LOCALE, "default"));
+
+    assertThat(question.getQuestionHelpTextOrDefault(Locale.forLanguageTag("und")))
+        .isEqualTo("default");
   }
 
   @Test


### PR DESCRIPTION
### Description
Currently, we throw an error if a question cannot be displayed in an applicant's preferred locale. This changes this behavior by:

1. Set a global default locale for CiviForm and use across app
2. Add methods to `QuestionDefinition` to fall back to the default locale text
3. Update `ApplicantQuestion` to use new fallback methods
4. Add a method to `ReadOnlyApplicantService` to determine whether the given program fully supports the applicant's preferred locale
4. Display a toast message to applicants when they apply to a program that is not fully localized to their preferred language

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #856 

<img width="724" alt="Screen Shot 2021-04-23 at 9 45 15 AM" src="https://user-images.githubusercontent.com/8559046/115905692-4c883800-a41b-11eb-994d-9ce39a733281.png">
