### PR TITLE
Remove unused BlockDefinition#hasPaths

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
@@ -152,16 +152,6 @@ public abstract class BlockDefinition {
   }
 
   @JsonIgnore
-  public boolean hasPaths(List<Path> paths) {
-    return scalarPaths().containsAll(ImmutableSet.copyOf(paths));
-  }
-
-  @JsonIgnore
-  public boolean hasPaths(Path... paths) {
-    return hasPaths(ImmutableList.copyOf(paths));
-  }
-
-  @JsonIgnore
   public boolean hasSameId(BlockDefinition other) {
     return other.id() == id();
   }

--- a/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
@@ -8,7 +8,6 @@ import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.util.List;
 import java.util.Optional;
 import services.Path;
 import services.question.types.QuestionDefinition;

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -2,7 +2,6 @@ package services.program;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import org.junit.Test;
 import services.Path;

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -49,25 +49,6 @@ public class BlockDefinitionTest {
   }
 
   @Test
-  public void hasPaths() {
-    BlockDefinition block = makeBlockDefinitionWithQuestions();
-    ImmutableList<Path> paths =
-        ImmutableList.of(
-            Path.create("applicant.applicant_name.first"),
-            Path.create("applicant.applicant_name.middle"),
-            Path.create("applicant.applicant_name.last"),
-            Path.create("applicant.applicant_address.street"),
-            Path.create("applicant.applicant_address.city"),
-            Path.create("applicant.applicant_address.state"),
-            Path.create("applicant.applicant_address.zip"),
-            Path.create("applicant.applicant_favorite_color.text"));
-
-    assertThat(block.hasPaths(paths)).isTrue();
-
-    assertThat(block.hasPaths(Path.create("fake.path"))).isFalse();
-  }
-
-  @Test
   public void isRepeater_isFalse() {
     BlockDefinition blockDefinition = makeBlockDefinitionWithQuestions();
 


### PR DESCRIPTION
### Description
We're trying to keep most/all `Path` related things in the `services.applicant` package or subpackages since a real `Path` should have applicant context. 

Also, this method isn't even being used.
