### PR TITLE
Remove unused methods from ReadOnlyQuestionService

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionService.java
@@ -1,7 +1,6 @@
 package services.question;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Locale;
 import java.util.Optional;
 import services.Path;
 import services.question.exceptions.InvalidQuestionTypeException;
@@ -43,12 +42,4 @@ public interface ReadOnlyQuestionService {
    * @throws QuestionNotFoundException if the question for the ID does not exist.
    */
   QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException;
-
-  /**
-   * When getting question text and help text we need to send the Locale. If absent it will use the
-   * preferred locale.
-   */
-  void setPreferredLocale(Locale locale);
-
-  Locale getPreferredLocale();
 }

--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyQuestionServiceImpl.java
@@ -7,14 +7,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import models.LifecycleStage;
 import models.Question;
 import models.Version;
-import services.LocalizationUtils;
 import services.Path;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.QuestionNotFoundException;
@@ -27,8 +25,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
   private final ImmutableMap<Long, QuestionDefinition> questionsById;
   private final ImmutableSet<QuestionDefinition> upToDateQuestions;
   private final ActiveAndDraftQuestions activeAndDraftQuestions;
-
-  private Locale preferredLocale = LocalizationUtils.DEFAULT_LOCALE;
 
   public ReadOnlyQuestionServiceImpl(Version activeVersion, Version draftVersion) {
     checkNotNull(activeVersion);
@@ -124,15 +120,5 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
       return questionsById.get(id);
     }
     throw new QuestionNotFoundException(id);
-  }
-
-  @Override
-  public Locale getPreferredLocale() {
-    return this.preferredLocale;
-  }
-
-  @Override
-  public void setPreferredLocale(Locale locale) {
-    this.preferredLocale = locale;
   }
 }


### PR DESCRIPTION
### Description
`ReadOnlyQuestionService` had methods to get and set the preferred locale - this is done in the applicant service, so these methods are unused.
