### PR TITLE
dev/seed lists too many programs - make it list only active and draft ones

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -34,7 +34,12 @@ public class ProgramRepository {
   /** Return all programs in a list. */
   public CompletionStage<ImmutableList<Program>> listPrograms() {
     return supplyAsync(
-        () -> ImmutableList.copyOf(ebeanServer.find(Program.class).findList()), executionContext);
+        () ->
+            new ImmutableList.Builder<Program>()
+                .addAll(versionRepository.get().getActiveVersion().getPrograms())
+                .addAll(versionRepository.get().getDraftVersion().getPrograms())
+                .build(),
+        executionContext);
   }
 
   public CompletionStage<Optional<Program>> lookupProgram(long id) {


### PR DESCRIPTION
### Description
It's not beautiful but it does work!  It also fixes a sort of incipient problem - there's no transactionality around creating new drafts, so we need to be able to handle multiple drafts accidentally existing.  The first fix exposed that problem so I fixed that also.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
