### PR TITLE
[WIP] Add backend support for localizing questions

### DIFF
--- a/universal-application-tool-0.0.1/app/forms/QuestionTranslationForm.java
+++ b/universal-application-tool-0.0.1/app/forms/QuestionTranslationForm.java
@@ -1,0 +1,28 @@
+package forms;
+
+public class QuestionTranslationForm {
+
+  private String questionText;
+  private String questionHelpText;
+
+  public QuestionTranslationForm() {
+    this.questionText = "";
+    this.questionHelpText = "";
+  }
+
+  public String getQuestionText() {
+    return questionText;
+  }
+
+  public void setQuestionText(String questionText) {
+    this.questionText = questionText;
+  }
+
+  public String getQuestionHelpText() {
+    return questionHelpText;
+  }
+
+  public void setQuestionHelpText(String questionHelpText) {
+    this.questionHelpText = questionHelpText;
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/LocalizationUtils.java
+++ b/universal-application-tool-0.0.1/app/services/LocalizationUtils.java
@@ -1,13 +1,27 @@
 package services;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Map;
+import javax.inject.Inject;
+import play.i18n.Lang;
+import play.i18n.Langs;
 
 public class LocalizationUtils {
 
   /** The default locale for CiviForm is US English. */
   public static final Locale DEFAULT_LOCALE = Locale.US;
+
+  private final ImmutableList<Locale> supportedLocales;
+
+  @Inject
+  public LocalizationUtils(Langs langs) {
+    this.supportedLocales =
+        langs.availables().stream().map(Lang::toLocale).collect(toImmutableList());
+  }
 
   /**
    * By design, {@link ImmutableMap}s do not have a {@code remove} method in their builders. If we
@@ -24,5 +38,9 @@ public class LocalizationUtils {
     }
     builder.put(locale, value);
     return builder.build();
+  }
+
+  public ImmutableList<Locale> getSupportedLocales() {
+    return this.supportedLocales;
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionService.java
@@ -36,22 +36,6 @@ public interface QuestionService {
   ErrorAnd<QuestionDefinition, CiviFormError> create(QuestionDefinition definition);
 
   /**
-   * Adds a new translation to an existing question definition. Returns true if the write is
-   * successful.
-   *
-   * <p>The write will fail if:
-   *
-   * <p>- The path does not resolve to a QuestionDefinition.
-   *
-   * <p>- A translation with that Locale already exists for a given question path.
-   *
-   * <p>NOTE: This does not update the version.
-   */
-  boolean addTranslation(
-      Path path, Locale locale, String questionText, Optional<String> questionHelpText)
-      throws InvalidPathException;
-
-  /**
    * Destructive overwrite of a question at a given path.
    *
    * <p>The write will fail if:

--- a/universal-application-tool-0.0.1/app/services/question/QuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionService.java
@@ -1,12 +1,9 @@
 package services.question;
 
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import services.CiviFormError;
 import services.ErrorAnd;
-import services.Path;
-import services.question.exceptions.InvalidPathException;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.types.QuestionDefinition;
 

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -33,13 +33,6 @@ public final class QuestionServiceImpl implements QuestionService {
   }
 
   @Override
-  public boolean addTranslation(
-      Path path, Locale locale, String questionText, Optional<String> questionHelpText)
-      throws InvalidPathException {
-    throw new java.lang.UnsupportedOperationException("Not supported yet.");
-  }
-
-  @Override
   public ErrorAnd<QuestionDefinition, CiviFormError> create(QuestionDefinition questionDefinition) {
     ImmutableSet<CiviFormError> validationErrors = questionDefinition.validate();
     ImmutableSet<CiviFormError> pathConflictErrors = validateNewQuestionPath(questionDefinition);

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import models.Question;
@@ -14,8 +13,6 @@ import repository.QuestionRepository;
 import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
-import services.Path;
-import services.question.exceptions.InvalidPathException;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.types.QuestionDefinition;
 

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -114,9 +115,19 @@ public class QuestionDefinitionBuilder {
     return this;
   }
 
+  public QuestionDefinitionBuilder updateQuestionText(Locale locale, String text) {
+    LocalizationUtils.overwriteExistingTranslation(this.questionText, locale, text);
+    return this;
+  }
+
   public QuestionDefinitionBuilder setQuestionHelpText(
       ImmutableMap<Locale, String> questionHelpText) {
     this.questionHelpText = questionHelpText;
+    return this;
+  }
+
+  public QuestionDefinitionBuilder updateQuestionHelpText(Locale locale, String helpText) {
+    LocalizationUtils.overwriteExistingTranslation(this.questionHelpText, locale, helpText);
     return this;
   }
 

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -1,5 +1,6 @@
 package views.admin;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.body;
 import static j2html.TagCreator.div;
@@ -7,13 +8,16 @@ import static j2html.TagCreator.head;
 import static j2html.TagCreator.main;
 import static j2html.TagCreator.nav;
 import static j2html.TagCreator.span;
-import static j2html.TagCreator.text;
 
+import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;
 import j2html.tags.Tag;
+import java.util.Locale;
 import javax.inject.Inject;
+import play.i18n.Lang;
+import play.i18n.Langs;
 import play.twirl.api.Content;
 import views.BaseHtmlLayout;
 import views.ViewUtils;
@@ -23,9 +27,13 @@ import views.style.Styles;
 
 public class AdminLayout extends BaseHtmlLayout {
 
+  private final ImmutableList<Locale> supportedLocales;
+
   @Inject
-  public AdminLayout(ViewUtils viewUtils) {
+  public AdminLayout(ViewUtils viewUtils, Langs langs) {
     super(viewUtils);
+    this.supportedLocales =
+        langs.availables().stream().map(Lang::toLocale).collect(toImmutableList());
   }
 
   private ContainerTag renderNavBar() {

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramTranslationView.java
@@ -21,6 +21,7 @@ import views.admin.AdminLayout;
 import views.components.FieldWithLabel;
 import views.components.LinkElement;
 import views.components.ToastMessage;
+import views.style.AdminStyles;
 import views.style.Styles;
 
 /** Renders a list of languages to select from, and a form for updating program information. */
@@ -80,14 +81,15 @@ public class ProgramTranslationView extends BaseHtmlView {
       long programId, Locale locale, boolean isCurrentlySelected) {
     LinkElement link =
         new LinkElement()
-            .setStyles(Styles.M_2)
             .setHref(
                 routes.AdminProgramTranslationsController.edit(programId, locale.toLanguageTag())
                     .url())
             .setText(locale.getDisplayLanguage(LocalizationUtils.DEFAULT_LOCALE));
 
     if (isCurrentlySelected) {
-      link.setStyles(Styles.M_2, Styles.BORDER_BLUE_400, Styles.BORDER_B_2);
+      link.setStyles(AdminStyles.LANGUAGE_LINK_SELECTED);
+    } else {
+      link.setStyles(AdminStyles.LANGUAGE_LINK_NOT_SELECTED);
     }
 
     return link.asAnchorText();

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
@@ -1,0 +1,29 @@
+package views.admin.questions;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Locale;
+import javax.inject.Inject;
+import play.i18n.Lang;
+import play.i18n.Langs;
+import play.twirl.api.Content;
+import views.BaseHtmlView;
+import views.admin.AdminLayout;
+
+public class QuestionTranslationView extends BaseHtmlView {
+
+  private final AdminLayout layout;
+  private final ImmutableList<Locale> supportedLanguages;
+
+  @Inject
+  public QuestionTranslationView(AdminLayout layout, Langs langs) {
+    this.layout = layout;
+    this.supportedLanguages =
+        langs.availables().stream().map(Lang::toLocale).collect(toImmutableList());
+  }
+
+  public Content render() {
+    return layout.render();
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
@@ -217,6 +217,18 @@ public final class QuestionsListView extends BaseHtmlView {
         .asAnchorText();
   }
 
+  private Tag renderQuestionTranslationLink(QuestionDefinition definition, String linkText) {
+    String link =
+        controllers.admin.routes.AdminQuestionTranslationsController.edit(
+            definition.getId(), LocalizationUtils.DEFAULT_LOCALE);
+    return new LinkElement()
+        .setId("translate-question-link-" + definition.getId())
+        .setHref(link)
+        .setText(linkText)
+        .setStyles(Styles.MR_2)
+        .asAnchorText();
+  }
+
   private Tag renderQuestionViewLink(QuestionDefinition definition, String linkText) {
     String link = controllers.admin.routes.QuestionController.show(definition.getId()).url();
     return new LinkElement()
@@ -237,9 +249,11 @@ public final class QuestionsListView extends BaseHtmlView {
       td.with(renderQuestionEditLink(active.get(), "New Version →"));
     } else if (active.isEmpty() && draft.isPresent()) {
       td.with(renderQuestionEditLink(draft.get(), "Edit Draft →"));
+      td.with(renderQuestionTranslationLink(draft.get(), "Manage Translations →"));
     } else if (active.isPresent() && draft.isPresent()) {
       td.with(renderQuestionViewLink(active.get(), "View Published →"));
       td.with(renderQuestionEditLink(draft.get(), "Edit Draft →"));
+      td.with(renderQuestionTranslationLink(draft.get(), "Manage Draft Translations →"));
     } else if (active.isEmpty() && draft.isEmpty()) {
       td.with(renderQuestionViewLink(definition, "View →"));
     }

--- a/universal-application-tool-0.0.1/app/views/style/AdminStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/AdminStyles.java
@@ -1,0 +1,9 @@
+package views.style;
+
+public class AdminStyles {
+
+  public static final String LANGUAGE_LINK_SELECTED =
+      StyleUtils.joinStyles(Styles.M_2, Styles.BORDER_BLUE_400, Styles.BORDER_B_2);
+
+  public static final String LANGUAGE_LINK_NOT_SELECTED = Styles.M_2;
+}

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -11,11 +11,13 @@ GET     /securePlayIndex            controllers.HomeController.securePlayIndex()
 GET     /admin/programs                                         controllers.admin.AdminProgramController.index(request: Request)
 GET     /admin/programs/new                                     controllers.admin.AdminProgramController.newOne(request: Request)
 GET     /admin/programs/:programId/edit                         controllers.admin.AdminProgramController.edit(request: Request, programId: Long)
-GET     /admin/programs/:programId/translations/:locale/edit    controllers.admin.AdminProgramTranslationsController.edit(request: Request, programId: Long, locale: String)
 POST    /admin/programs/:programId/newVersion                   controllers.admin.AdminProgramController.newVersionFrom(request: Request, programId: Long)
 POST    /admin/programs                                         controllers.admin.AdminProgramController.create(request: Request)
 POST    /admin/programs/publish                                 controllers.admin.AdminProgramController.publish()
 POST    /admin/programs/:programId                              controllers.admin.AdminProgramController.update(request: Request, programId: Long)
+
+# Routes for managing program localization
+GET     /admin/programs/:programId/translations/:locale/edit    controllers.admin.AdminProgramTranslationsController.edit(request: Request, programId: Long, locale: String)
 POST    /admin/programs/:programId/translations/:locale         controllers.admin.AdminProgramTranslationsController.update(request: Request, programId: Long, locale: String)
 
 # A controller for versions for an admin to set older versions live.
@@ -41,6 +43,10 @@ GET     /admin/questions/:id/edit    controllers.admin.QuestionController.edit(r
 GET     /admin/questions/:id         controllers.admin.QuestionController.show(id: Long)
 POST    /admin/questions/:id         controllers.admin.QuestionController.update(request: Request, id: Long, type: String)
 POST    /admin/questions             controllers.admin.QuestionController.create(request: Request, type: String)
+
+# Routes for editing question localizations
+GET     /admin/questions/:id/translations/:locale/edit  controllers.admin.AdminQuestionTranslationsController.edit(request: Request, id: Long, locale: String)
+POST    /admin/questions/:id/translations/:locale       controllers.admin.AdminQuestionTranslationsController.update(request: Request, id: Long, locale: String)
 
 # Controller for admins only, related to applications
 GET     /admin/programs/:programId/applications                           controllers.admin.AdminApplicationController.answerList(programId: Long)

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -39,16 +39,6 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void addTranslation_notImplemented() {
-    assertThatThrownBy(
-            () ->
-                questionService.addTranslation(
-                    Path.create("your.name"), Locale.GERMAN, "Wie heisst du?", Optional.empty()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Not supported yet.");
-  }
-
-  @Test
   public void create_failsWhenPathConflicts() throws Exception {
     Question applicantName = testQuestionBank.applicantName();
     QuestionDefinition questionDefinition =


### PR DESCRIPTION
### Description
1. Adds two new routes for editing and updating question translations
2. Implements two controller methods for the above
3. Adds an empty view for managing translations (this is the next step)
4. Removes an unused `addTranslations` method from `QuestionService`. Instead, we will use update, since some questions need to translate more than just the question text and help text (ex: answer options)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#778, #211 
