### PR TITLE
Use Scalar#name instead of toString().toLowerCase().

### DIFF
--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -92,7 +92,7 @@ public abstract class Path {
   /**
    * Append a path to the path.
    *
-   * If joining a {@link Scalar}, please use {@link Path#join(Scalar)} instead.
+   * <p>If joining a {@link Scalar}, please use {@link Path#join(Scalar)} instead.
    */
   public Path join(String path) {
     Path other = Path.create(path);
@@ -129,6 +129,14 @@ public abstract class Path {
    */
   public boolean isArrayElement() {
     return ARRAY_INDEX_REGEX.matcher(keyName()).find();
+  }
+
+  /** Returns this path as a path to an array element, e.g. {@code applicant.children[3]}. */
+  public Path asArrayElement() {
+    if (isArrayElement()) {
+      return this;
+    }
+    return parentPath().join(keyName() + ARRAY_SUFFIX);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -103,7 +103,7 @@ public abstract class Path {
    * to append to a path.
    */
   public Path join(Scalar scalar) {
-    Path other = Path.create(scalar.toString().toLowerCase());
+    Path other = Path.create(scalar.name());
     return Path.create(
         ImmutableList.<String>builder().addAll(segments()).addAll(other.segments()).build());
   }

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -89,7 +89,11 @@ public abstract class Path {
     return Path.create(segments().subList(0, segments().size() - 1));
   }
 
-  /** Append a path to the path. */
+  /**
+   * Append a path to the path.
+   *
+   * If joining a {@link Scalar}, please use {@link Path#join(Scalar)} instead.
+   */
   public Path join(String path) {
     Path other = Path.create(path);
     return Path.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -91,7 +91,15 @@ public class ApplicantServiceImpl implements ApplicantService {
     boolean updatePathsContainReservedKeys =
         !Sets.intersection(
                 Scalar.getMetadataScalarKeys(),
-                updates.stream().map(Update::path).map(Path::keyName).collect(Collectors.toSet()))
+                updates.stream()
+                    .map(
+                        update -> {
+                          if (update.path().isArrayElement()) {
+                            return update.path().withoutArrayReference().keyName();
+                          }
+                          return update.path().keyName();
+                        })
+                    .collect(Collectors.toSet()))
             .isEmpty();
     if (updatePathsContainReservedKeys) {
       return CompletableFuture.failedFuture(

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -5,11 +5,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import java.time.Clock;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import models.Applicant;
 import models.Application;
@@ -20,21 +22,16 @@ import repository.ApplicantRepository;
 import services.ErrorAnd;
 import services.Path;
 import services.WellKnownPaths;
+import services.applicant.question.Scalar;
 import services.program.BlockDefinition;
 import services.program.PathNotInBlockException;
 import services.program.ProgramBlockNotFoundException;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
 import services.question.exceptions.UnsupportedScalarTypeException;
-import services.question.types.QuestionDefinition;
 import services.question.types.ScalarType;
 
 public class ApplicantServiceImpl implements ApplicantService {
-  private static final ImmutableSet<String> RESERVED_SCALAR_KEYS =
-      ImmutableSet.of(
-          QuestionDefinition.METADATA_UPDATE_TIME_KEY,
-          QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY);
-
   private final ApplicantRepository applicantRepository;
   private final ProgramService programService;
   private final Clock clock;
@@ -92,7 +89,10 @@ public class ApplicantServiceImpl implements ApplicantService {
             .collect(ImmutableSet.toImmutableSet());
 
     boolean updatePathsContainReservedKeys =
-        updates.stream().anyMatch(u -> RESERVED_SCALAR_KEYS.contains(u.path().keyName()));
+        !Sets.intersection(
+                Scalar.getMetadataScalarKeys(),
+                updates.stream().map(Update::path).map(Path::keyName).collect(Collectors.toSet()))
+            .isEmpty();
     if (updatePathsContainReservedKeys) {
       return CompletableFuture.failedFuture(
           new IllegalArgumentException("Path contained reserved scalar key"));
@@ -210,7 +210,7 @@ public class ApplicantServiceImpl implements ApplicantService {
   }
 
   private void writeMetadataForPath(Path path, ApplicantData data, long programId) {
-    data.putLong(path.join(QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY), programId);
-    data.putLong(path.join(QuestionDefinition.METADATA_UPDATE_TIME_KEY), clock.millis());
+    data.putLong(path.join(Scalar.PROGRAM_UPDATED_IN), programId);
+    data.putLong(path.join(Scalar.UPDATED_AT), clock.millis());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -111,6 +111,8 @@ public enum Scalar {
       metadataScalarKeys =
           METADATA_SCALARS.keySet().stream()
               .map(Scalar::name)
+              .map(String::toLowerCase) // TODO(783, kct): get rid of this once scalars are defined
+              // entirely in Block.
               .collect(ImmutableSet.toImmutableSet());
     }
     return metadataScalarKeys;

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -1,6 +1,7 @@
 package services.applicant.question;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionType;
@@ -63,6 +64,8 @@ public enum Scalar {
           UPDATED_AT, ScalarType.LONG,
           PROGRAM_UPDATED_IN, ScalarType.LONG);
 
+  private static ImmutableSet<String> metadataScalarKeys;
+
   /**
    * Returns the scalars for a specific {@link QuestionType}.
    *
@@ -100,5 +103,16 @@ public enum Scalar {
 
   public static ImmutableMap<Scalar, ScalarType> getMetadataScalars() {
     return METADATA_SCALARS;
+  }
+
+  /** A set of Scalar strings that represent keys where metadata is stored. */
+  public static ImmutableSet<String> getMetadataScalarKeys() {
+    if (metadataScalarKeys == null) {
+      metadataScalarKeys =
+          METADATA_SCALARS.keySet().stream()
+              .map(Scalar::name)
+              .collect(ImmutableSet.toImmutableSet());
+    }
+    return metadataScalarKeys;
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -21,9 +21,6 @@ import services.question.exceptions.TranslationNotFoundException;
 
 /** Defines a single question. */
 public abstract class QuestionDefinition {
-  public static final String METADATA_UPDATE_TIME_KEY = "updated_at";
-  public static final String METADATA_UPDATE_PROGRAM_ID_KEY = "updated_in_program";
-
   private final OptionalLong id;
   private final String name;
   private final Path path;

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import services.Path;
 import services.applicant.question.Scalar;
 import support.ProgramBuilder;
 
@@ -173,9 +174,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
                             applicant.id, program.id, "1"))
                     .bodyForm(
                         ImmutableMap.of(
-                            "applicant.applicant_name.first_name",
+                            Path.create("applicant.applicant_name")
+                                .join(Scalar.FIRST_NAME)
+                                .toString(),
                             "FirstName",
-                            "applicant.applicant_name.last_name",
+                            Path.create("applicant.applicant_name")
+                                .join(Scalar.LAST_NAME)
+                                .toString(),
                             "")))
             .build();
 
@@ -200,9 +205,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
             .bodyForm(
                 ImmutableMap.of(
-                    "applicant.applicant_name.first_name",
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
                     "FirstName",
-                    "applicant.applicant_name.last_name",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
                     "LastName"))
             .build();
 
@@ -227,9 +232,9 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
             .bodyForm(
                 ImmutableMap.of(
-                    "applicant.applicant_name.first_name",
+                    Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),
                     "FirstName",
-                    "applicant.applicant_name.last_name",
+                    Path.create("applicant.applicant_name").join(Scalar.LAST_NAME).toString(),
                     "LastName"))
             .build();
 

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -153,7 +153,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
 
   @Test
   public void update_reservedPathsInRequest_returnsBadRequest() {
-    String reservedPath = "metadata." + Scalar.PROGRAM_UPDATED_IN.name();
+    String reservedPath = Path.create("metadata").join(Scalar.PROGRAM_UPDATED_IN).toString();
     Request request =
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
             .bodyForm(ImmutableMap.of(reservedPath, "value"))

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import services.question.types.QuestionDefinition;
+import services.applicant.question.Scalar;
 import support.ProgramBuilder;
 
 public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantProfiles {
@@ -152,7 +152,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
 
   @Test
   public void update_reservedPathsInRequest_returnsBadRequest() {
-    String reservedPath = "metadata." + QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY;
+    String reservedPath = "metadata." + Scalar.PROGRAM_UPDATED_IN.name();
     Request request =
         fakeRequest(routes.ApplicantProgramBlocksController.update(applicant.id, program.id, "1"))
             .bodyForm(ImmutableMap.of(reservedPath, "value"))

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -105,6 +105,22 @@ public class PathTest {
   }
 
   @Test
+  public void asArrayElement() {
+    Path path = Path.create("one.two[3].four").asArrayElement();
+
+    assertThat(path.isArrayElement()).isTrue();
+    assertThat(path.toString()).isEqualTo("one.two[3].four[]");
+  }
+
+  @Test
+  public void asArrayElement_alreadyAnArrayElement() {
+    Path path = Path.create("one.two[3].four[5]").asArrayElement();
+
+    assertThat(path.isArrayElement()).isTrue();
+    assertThat(path.toString()).isEqualTo("one.two[3].four[5]");
+  }
+
+  @Test
   public void withoutArrayReference() {
     Path path = Path.create("one.two[3]");
     assertThat(path.withoutArrayReference()).isEqualTo(Path.create("one.two"));

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -18,6 +18,7 @@ import repository.ApplicantRepository;
 import repository.WithPostgresContainer;
 import services.ErrorAnd;
 import services.Path;
+import services.applicant.question.Scalar;
 import services.program.PathNotInBlockException;
 import services.program.ProgramBlockNotFoundException;
 import services.program.ProgramDefinition;
@@ -111,16 +112,14 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     ApplicantData applicantDataAfter =
         applicantRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
 
-    Path programIdPath =
-        Path.create("applicant.name." + QuestionDefinition.METADATA_UPDATE_PROGRAM_ID_KEY);
-    Path timestampPath =
-        Path.create("applicant.name." + QuestionDefinition.METADATA_UPDATE_TIME_KEY);
+    Path programIdPath = Path.create("applicant.name." + Scalar.PROGRAM_UPDATED_IN.name());
+    Path timestampPath = Path.create("applicant.name." + Scalar.UPDATED_AT.name());
     assertThat(applicantDataAfter.readLong(programIdPath)).hasValue(programDefinition.id());
     assertThat(applicantDataAfter.readLong(timestampPath)).isPresent();
   }
 
   @Test
-  public void stageAndUpdateIfValid_rawUpdatesContainMultiSelectAnswers_isOk() throws Exception {
+  public void stageAndUpdateIfValid_rawUpdatesContainMultiSelectAnswers_isOk() {
     QuestionDefinition multiSelectQuestion =
         questionService
             .create(
@@ -235,7 +234,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   @Test
   public void stageAndUpdateIfValid_hasIllegalArgumentExceptionForReservedScalarKeys() {
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
-    String reservedScalar = "applicant.name." + QuestionDefinition.METADATA_UPDATE_TIME_KEY;
+    String reservedScalar = "applicant.name." + Scalar.UPDATED_AT.name();
     ImmutableMap<String, String> updates = ImmutableMap.of(reservedScalar, "12345");
 
     assertThatExceptionOfType(CompletionException.class)

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -251,6 +251,29 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
+  public void
+      stageAndUpdateIfValid_withIllegalArrayElement_hasIllegalArgumentExceptionForReservedScalarKeys() {
+    Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
+    String reservedScalar =
+        Path.create("applicant.name")
+            .join(Scalar.UPDATED_AT)
+            .asArrayElement()
+            .atIndex(0)
+            .toString();
+    ImmutableMap<String, String> updates = ImmutableMap.of(reservedScalar, "12345");
+
+    assertThatExceptionOfType(CompletionException.class)
+        .isThrownBy(
+            () ->
+                subject
+                    .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", updates)
+                    .toCompletableFuture()
+                    .join())
+        .withCauseInstanceOf(IllegalArgumentException.class)
+        .withMessageContaining("Path contained reserved scalar key");
+  }
+
+  @Test
   public void createApplicant_createsANewApplicant() {
     Applicant applicant = subject.createApplicant(1l).toCompletableFuture().join();
 

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -73,8 +73,8 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
 
     ImmutableSet<Update> updates =
         ImmutableSet.of(
-            Update.create(Path.create("applicant.name.first_name"), "Alice"),
-            Update.create(Path.create("applicant.name.last_name"), "Doe"));
+            Update.create(Path.create("applicant.name.FIRST_NAME"), "Alice"),
+            Update.create(Path.create("applicant.name.LAST_NAME"), "Doe"));
 
     ErrorAnd<ReadOnlyApplicantProgramService, Exception> errorAnd =
         subject
@@ -97,8 +97,8 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
 
     ImmutableSet<Update> updates =
         ImmutableSet.of(
-            Update.create(Path.create("applicant.name.first_name"), "Alice"),
-            Update.create(Path.create("applicant.name.last_name"), "Doe"));
+            Update.create(Path.create("applicant.name.FIRST_NAME"), "Alice"),
+            Update.create(Path.create("applicant.name.LAST_NAME"), "Doe"));
 
     ErrorAnd<ReadOnlyApplicantProgramService, Exception> errorAnd =
         subject
@@ -140,8 +140,8 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
 
     ImmutableMap<String, String> rawUpdates =
         ImmutableMap.<String, String>builder()
-            .put("applicant.checkbox.selection[0]", "1")
-            .put("applicant.checkbox.selection[1]", "2")
+            .put("applicant.checkbox.SELECTION[0]", "1")
+            .put("applicant.checkbox.SELECTION[1]", "2")
             .build();
 
     ErrorAnd<ReadOnlyApplicantProgramService, Exception> errorAnd =
@@ -156,7 +156,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     ApplicantData applicantDataAfter =
         applicantRepository.lookupApplicantSync(applicant.id).get().getApplicantData();
 
-    assertThat(applicantDataAfter.readList(Path.create("applicant.checkbox.selection")))
+    assertThat(applicantDataAfter.readList(Path.create("applicant.checkbox.SELECTION")))
         .hasValue(ImmutableList.of(1L, 2L));
   }
 


### PR DESCRIPTION
### Description
`Scalar#name()` is more appropriate to use as keys in the JSON data.

Also makes and uses `Scalar#getMetadataScalarKeys()`.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
