### PR TITLE
Check that we see the select language page before selecting a language

### DIFF
--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -49,6 +49,8 @@ describe('Create program and manage translations', () => {
     await logout(page);
 
     // Set applicant preferred language to Spanish
+    // DO NOT LOG IN AS TEST USER. We want a fresh guest so we can guarantee
+    // the language has not yet been set.
     await loginAsGuest(page);
     await selectApplicantLanguage(page, 'Español');
     const applicantQuestions = new ApplicantQuestions(page);

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -59,11 +59,18 @@ export const userDisplayName = () => {
   }
 }
 
+/**
+ * The option to select a language is only shown once for a given applicant. If this is
+ * the first time they see this page, select the given language. Otherwise continue.
+ */
 export const selectApplicantLanguage = async (page: Page, language: string) => {
-  if (!isTestUser()) {
+  const maybeSelectLanguagePage = await page.$('#select-language');
+  if (maybeSelectLanguagePage) {
     await page.selectOption('select', { label: language });
     await page.click('button');
   }
+  const programIndexTitle = await page.$('#float-title');
+  expect(programIndexTitle).toBeDefined();
 }
 
 export const dropTables = async (page: Page) => {


### PR DESCRIPTION
### Description
Originally, we skipped the select language page for the test IDCS user. For now, we want to:
1. Check if we are on the select language page before selecting a language, and skip if not.
2. Use the guest if we want to force a particular language, since the test user already has preferred language set.
