### PR TITLE
Contextualize paths for `Block`s

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -7,7 +7,9 @@ import com.google.common.collect.ImmutableList;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import services.Path;
 import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.PresentsErrors;
 import services.program.BlockDefinition;
 import services.program.ProgramQuestionDefinition;
 
@@ -33,18 +35,23 @@ public final class Block {
 
   private final BlockDefinition blockDefinition;
   private final ApplicantData applicantData;
+  private final Path contextualizedPath;
   private Optional<ImmutableList<ApplicantQuestion>> questionsMemo = Optional.empty();
 
-  Block(long id, BlockDefinition blockDefinition, ApplicantData applicantData) {
-    this.id = String.valueOf(id);
-    this.blockDefinition = checkNotNull(blockDefinition);
-    this.applicantData = checkNotNull(applicantData);
-  }
-
-  Block(String id, BlockDefinition blockDefinition, ApplicantData applicantData) {
+  Block(
+      String id,
+      BlockDefinition blockDefinition,
+      ApplicantData applicantData,
+      Path contextualizedPath) {
     this.id = id;
     this.blockDefinition = checkNotNull(blockDefinition);
     this.applicantData = checkNotNull(applicantData);
+    this.contextualizedPath = checkNotNull(contextualizedPath);
+  }
+
+  // TODO(#783): Remove this constructor.
+  Block(long id, BlockDefinition blockDefinition, ApplicantData applicantData) {
+    this(String.valueOf(id), blockDefinition, applicantData, Path.create("applicant"));
   }
 
   public String getId() {
@@ -67,17 +74,16 @@ public final class Block {
                   .map(ProgramQuestionDefinition::getQuestionDefinition)
                   .map(
                       questionDefinition ->
-                          new ApplicantQuestion(questionDefinition, applicantData))
+                          new ApplicantQuestion(
+                              questionDefinition, applicantData, contextualizedPath))
                   .collect(toImmutableList()));
     }
     return questionsMemo.get();
   }
 
+  /** A block has errors if any one of its {@link ApplicantQuestion}s has errors. */
   public boolean hasErrors() {
-    return getQuestions().stream()
-        .map(ApplicantQuestion::hasErrors)
-        .reduce(Boolean::logicalOr)
-        .orElse(false);
+    return getQuestions().stream().anyMatch(ApplicantQuestion::hasErrors);
   }
 
   /**
@@ -87,20 +93,28 @@ public final class Block {
    */
   public boolean isCompleteWithoutErrors() {
     // TODO(https://github.com/seattle-uat/civiform/issues/551): Stream only required scalar paths
-    // instead of all scalar paths.
-    return blockDefinition.scalarPaths().stream()
-            .filter(path -> !applicantData.hasValueAtPath(path))
-            .findAny()
-            .isEmpty()
-        && !hasErrors();
+    //  instead of all scalar paths.
+    return isComplete() && !hasErrors();
   }
 
   /**
-   * Checks whether all questions in this block were completed while applying to the given program.
+   * A block is complete if all of its {@link ApplicantQuestion}s {@link
+   * PresentsErrors#isAnswered()}.
+   */
+  private boolean isComplete() {
+    return getQuestions().stream()
+        .map(ApplicantQuestion::errorsPresenter)
+        .allMatch(PresentsErrors::isAnswered);
+  }
+
+  /**
+   * Checks that this block is complete and that at least one of the questions was answered during
+   * the program.
    *
    * @param programId the program ID to check
-   * @return true if all questions were last updated while filling out the program with the given
-   *     ID; false otherwise
+   * @return true if this block is complete at least one question was updated while filling out the
+   *     program with the given ID; false if this block is incomplete; if it is complete with
+   *     errors; or it is complete and all questions were answered in a different program.
    */
   public boolean wasCompletedInProgram(long programId) {
     return isCompleteWithoutErrors()

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -49,11 +49,6 @@ public final class Block {
     this.contextualizedPath = checkNotNull(contextualizedPath);
   }
 
-  // TODO(#783): Remove this constructor.
-  Block(long id, BlockDefinition blockDefinition, ApplicantData applicantData) {
-    this(String.valueOf(id), blockDefinition, applicantData, Path.create("applicant"));
-  }
-
   public String getId() {
     return id;
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -6,8 +6,25 @@ import java.util.Optional;
 /** Provides synchronous, read-only behavior relevant to an applicant for a specific program. */
 public interface ReadOnlyApplicantProgramService {
 
-  /** Get the program's current Blocks for the applicant. */
-  ImmutableList<Block> getCurrentBlockList();
+  /**
+   * Get the {@link Block}s for this program and applicant. This includes all blocks, whether the
+   * block was filled out in this program or a previous program.
+   */
+  ImmutableList<Block> getAllBlocks();
+
+  /**
+   * Get the {@link Block}s this applicant needs to fill out or has filled out for this program.
+   *
+   * <p>This list includes any block that is incomplete or has errors (which indicate the applicant
+   * needs to make a correction), or any block that was completed while filling out this program
+   * form.
+   *
+   * <p>This list does not include blocks that were completely filled out in a different program.
+   *
+   * @return a list of {@link Block}s that were completed by the applicant in this session or still
+   *     need to be completed for this program
+   */
+  ImmutableList<Block> getInProgressBlocks();
 
   /** Get the block with the given block ID */
   Optional<Block> getBlock(String blockId);

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -19,16 +19,14 @@ import services.question.types.QuestionType;
 public class ApplicantQuestion {
 
   private final QuestionDefinition questionDefinition;
-  private final Path applicationPathContext;
+  private final Path contextualizedPath;
   private final ApplicantData applicantData;
 
   public ApplicantQuestion(
-      QuestionDefinition questionDefinition,
-      ApplicantData applicantData,
-      Path applicationPathContext) {
+      QuestionDefinition questionDefinition, ApplicantData applicantData, Path contextualizedPath) {
     this.questionDefinition = checkNotNull(questionDefinition);
     this.applicantData = checkNotNull(applicantData);
-    this.applicationPathContext = checkNotNull(applicationPathContext);
+    this.contextualizedPath = checkNotNull(contextualizedPath);
   }
 
   // TODO(#783): Get rid of this constructor.
@@ -65,7 +63,7 @@ public class ApplicantQuestion {
    * "applicant.household_member[3].name".
    */
   public Path getContextualizedPath() {
-    return applicationPathContext.join(questionDefinition.getQuestionPathSegment());
+    return contextualizedPath.join(questionDefinition.getQuestionPathSegment());
   }
 
   public boolean hasErrors() {

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -17,6 +17,8 @@ import support.TestQuestionBank;
 
 public class BlockTest {
 
+  private static final long UNUSED_PROGRAM_ID = 1L;
+
   private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
   private static final NameQuestionDefinition NAME_QUESTION =
@@ -28,7 +30,7 @@ public class BlockTest {
   public void createNewBlock() {
     BlockDefinition definition =
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
-    Block block = new Block(1L, definition, new ApplicantData());
+    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
     assertThat(block.getId()).isEqualTo("1");
     assertThat(block.getName()).isEqualTo("name");
     assertThat(block.getDescription()).isEqualTo("description");
@@ -47,26 +49,29 @@ public class BlockTest {
 
     new EqualsTester()
         .addEqualityGroup(
-            new Block(1L, definition, new ApplicantData()),
-            new Block(1L, definition, new ApplicantData()))
+            new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH),
+            new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH))
         .addEqualityGroup(
-            new Block(2L, definition, new ApplicantData()),
-            new Block(2L, definition, new ApplicantData()))
+            new Block("2", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH),
+            new Block("2", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH))
         .addEqualityGroup(
             new Block(
-                1L,
+                "1",
                 definition.toBuilder()
                     .addQuestion(ProgramQuestionDefinition.create(question))
                     .build(),
-                new ApplicantData()),
+                new ApplicantData(),
+                ApplicantData.APPLICANT_PATH),
             new Block(
-                1L,
+                "1",
                 definition.toBuilder()
                     .addQuestion(ProgramQuestionDefinition.create(question))
                     .build(),
-                new ApplicantData()))
+                new ApplicantData(),
+                ApplicantData.APPLICANT_PATH))
         .addEqualityGroup(
-            new Block(1L, definition, applicant), new Block(1L, definition, applicant))
+            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH),
+            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH))
         .testEquals();
   }
 
@@ -75,7 +80,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
     ApplicantData applicantData = new ApplicantData();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
 
     ImmutableList<ApplicantQuestion> expected =
         ImmutableList.of(
@@ -90,7 +95,7 @@ public class BlockTest {
   public void hasErrors_returnsFalseIfBlockHasNoQuestions() {
     BlockDefinition definition =
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
-    Block block = new Block(1L, definition, new ApplicantData());
+    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
 
     assertThat(block.hasErrors()).isFalse();
   }
@@ -98,7 +103,7 @@ public class BlockTest {
   @Test
   public void hasErrors_returnsFalseIfQuestionsHaveNoErrors() {
     BlockDefinition definition = setUpBlockWithQuestions();
-    Block block = new Block(1L, definition, new ApplicantData());
+    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
 
     assertThat(block.hasErrors()).isFalse();
   }
@@ -107,7 +112,7 @@ public class BlockTest {
   public void isComplete_returnsTrueForBlockWithNoQuestions() {
     BlockDefinition definition =
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
-    Block block = new Block(1L, definition, new ApplicantData());
+    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
@@ -117,7 +122,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
 
     // No questions filled in yet.
     assertThat(block.isCompleteWithoutErrors()).isFalse();
@@ -127,10 +132,10 @@ public class BlockTest {
   public void isComplete_returnsFalseIfOneQuestionNotAnswered() {
     ApplicantData applicantData = new ApplicantData();
     // Fill in one of the questions.
-    answerColorQuestion(applicantData);
+    answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
 
     assertThat(block.isCompleteWithoutErrors()).isFalse();
   }
@@ -139,11 +144,11 @@ public class BlockTest {
   public void isComplete_returnsTrueIfAllQuestionsAnswered() {
     ApplicantData applicantData = new ApplicantData();
     // Fill in all questions.
-    answerNameQuestion(applicantData);
-    answerColorQuestion(applicantData);
+    answerNameQuestion(applicantData, UNUSED_PROGRAM_ID);
+    answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
@@ -153,13 +158,13 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
 
     assertThat(block.isCompleteWithoutErrors()).isFalse();
 
     // Complete the block.
-    answerNameQuestion(applicantData);
-    answerColorQuestion(applicantData);
+    answerNameQuestion(applicantData, UNUSED_PROGRAM_ID);
+    answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
 
@@ -168,7 +173,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
 
     assertThat(block.wasCompletedInProgram(1L)).isFalse();
   }
@@ -178,7 +183,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
     // Answer questions in different program.
     answerNameQuestion(applicantData, 567L);
     answerColorQuestion(applicantData, 567L);
@@ -191,7 +196,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
     answerNameQuestion(applicantData, 1L);
 
     assertThat(block.wasCompletedInProgram(1L)).isFalse();
@@ -202,7 +207,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
     answerNameQuestion(applicantData, 22L);
     answerColorQuestion(applicantData, 22L);
 
@@ -214,7 +219,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block(1L, definition, applicantData);
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
     answerNameQuestion(applicantData, 100L);
     answerColorQuestion(applicantData, 200L);
 
@@ -231,18 +236,10 @@ public class BlockTest {
         .build();
   }
 
-  private static void answerNameQuestion(ApplicantData data) {
-    answerNameQuestion(data, 1L);
-  }
-
   private static void answerNameQuestion(ApplicantData data, long programId) {
     Path path = Path.create("applicant.applicant_name");
     QuestionAnswerer.answerNameQuestion(data, path, "Alice", "P.", "Walker");
     QuestionAnswerer.addMetadata(data, path, programId, 12345L);
-  }
-
-  private static void answerColorQuestion(ApplicantData data) {
-    answerColorQuestion(data, 1L);
   }
 
   private static void answerColorQuestion(ApplicantData data, long programId) {

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -44,7 +44,8 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     // Answer first block in a separate program
     answerNameQuestion(programDefinition.id() + 1);
 
-    ReadOnlyApplicantProgramService subject = new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
+    ReadOnlyApplicantProgramService subject =
+        new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
     ImmutableList<Block> allBlocks = subject.getAllBlocks();
 
     assertThat(allBlocks).hasSize(2);


### PR DESCRIPTION
### Description
* Change the `Block` constructor to take a `contextualizedPath`.
* Expose new method `ReadOnlyApplicantProgramService#getAllBlocks`.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #783 
