### PR TITLE
Use `Block#getScalarType` instead of `BlockDefinition#getScalarType` to make updates to `ApplicantData`

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -28,7 +28,7 @@ import repository.ApplicationRepository;
 import services.applicant.ApplicantService;
 import services.applicant.Block;
 import services.applicant.ReadOnlyApplicantProgramService;
-import services.program.ProgramBlockNotFoundException;
+import services.applicant.ProgramBlockNotFoundException;
 import services.program.ProgramNotFoundException;
 import views.applicant.ApplicantProgramBlockEditView;
 

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -27,8 +27,8 @@ import play.mvc.Result;
 import repository.ApplicationRepository;
 import services.applicant.ApplicantService;
 import services.applicant.Block;
-import services.applicant.ReadOnlyApplicantProgramService;
 import services.applicant.ProgramBlockNotFoundException;
+import services.applicant.ReadOnlyApplicantProgramService;
 import services.program.ProgramNotFoundException;
 import views.applicant.ApplicantProgramBlockEditView;
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -24,7 +24,9 @@ import services.ErrorAnd;
 import services.Path;
 import services.WellKnownPaths;
 import services.applicant.question.Scalar;
-import services.program.*;
+import services.program.PathNotInBlockException;
+import services.program.ProgramDefinition;
+import services.program.ProgramService;
 import services.question.exceptions.UnsupportedScalarTypeException;
 import services.question.types.ScalarType;
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ProgramBlockNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ProgramBlockNotFoundException.java
@@ -1,4 +1,4 @@
-package services.program;
+package services.applicant;
 
 public class ProgramBlockNotFoundException extends Exception {
   public ProgramBlockNotFoundException(long programId, String blockId) {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -2,13 +2,18 @@ package services.applicant.question;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import services.Path;
 import services.applicant.ApplicantData;
+import services.question.exceptions.InvalidQuestionTypeException;
+import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
+import services.question.types.ScalarType;
 
 /**
  * Represents a question in the context of a specific applicant. Other type-specific classes (e.g.
@@ -64,6 +69,28 @@ public class ApplicantQuestion {
    */
   public Path getContextualizedPath() {
     return contextualizedPath.join(questionDefinition.getQuestionPathSegment());
+  }
+
+  /**
+   * Returns the map of contextualized paths to scalars and their {@link ScalarType}s used by this
+   * question. This includes metadata paths.
+   *
+   * <p>This should not be used for {@link QuestionType#REPEATER} questions.
+   */
+  public ImmutableMap<Path, ScalarType> getContextualizedScalars() {
+    try {
+      return ImmutableMap.<Scalar, ScalarType>builder()
+          .putAll(Scalar.getScalars(getType()))
+          .putAll(Scalar.getMetadataScalars())
+          .build()
+          .entrySet()
+          .stream()
+          .collect(
+              ImmutableMap.toImmutableMap(
+                  entry -> getContextualizedPath().join(entry.getKey()), Map.Entry::getValue));
+    } catch (InvalidQuestionTypeException | UnsupportedQuestionTypeException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public boolean hasErrors() {

--- a/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
@@ -6,13 +6,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
-import services.Path;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
-import services.question.types.ScalarType;
 
 /**
  * Defines a single program block, which contains a list of questions and data about the block.
@@ -115,44 +111,6 @@ public abstract class BlockDefinition {
   @Memoized
   public int getQuestionCount() {
     return programQuestionDefinitions().size();
-  }
-
-  @JsonIgnore
-  @Memoized
-  public ImmutableMap<Path, ScalarType> scalarTypes() {
-    ImmutableMap.Builder<Path, ScalarType> scalarTypesBuilder = ImmutableMap.builder();
-    programQuestionDefinitions().stream()
-        .map(ProgramQuestionDefinition::getQuestionDefinition)
-        .map(QuestionDefinition::getScalars)
-        .forEach(scalarTypesBuilder::putAll);
-
-    return scalarTypesBuilder.build();
-  }
-
-  @JsonIgnore
-  @Memoized
-  public ImmutableSet<Path> scalarPaths() {
-    return scalarTypes().keySet();
-  }
-
-  /**
-   * For multi-select questions (like checkbox), we must append {@code []} to the field name so that
-   * the Play framework allows multiple form keys with the same value. When updates are passed in
-   * the request, they are of the format {@code path.selection[index]}. However, the scalar path
-   * does not end in {@code []}, so we remove the array element information here before checking the
-   * type.
-   */
-  @JsonIgnore
-  public Optional<ScalarType> getScalarType(Path path) {
-    if (path.isArrayElement()) {
-      path = path.withoutArrayReference();
-    }
-    return Optional.ofNullable(scalarTypes().get(path));
-  }
-
-  @JsonIgnore
-  public boolean hasSameId(BlockDefinition other) {
-    return other.id() == id();
   }
 
   @AutoValue.Builder

--- a/universal-application-tool-0.0.1/app/services/program/PathNotInBlockException.java
+++ b/universal-application-tool-0.0.1/app/services/program/PathNotInBlockException.java
@@ -4,11 +4,7 @@ import services.Path;
 
 public class PathNotInBlockException extends Exception {
 
-  // TODO: use block definition's reference to its program definition for ProgramDefinition.id when
-  // it is available.
-  public PathNotInBlockException(BlockDefinition block, Path path) {
-    super(
-        String.format(
-            "Block (ID %d) in program (ID ?) does not contain path %s", block.id(), path.path()));
+  public PathNotInBlockException(String blockId, Path path) {
+    super(String.format("Block (ID %s) does not contain path %s", blockId, path));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -20,7 +20,6 @@ import services.ErrorAnd;
 import services.Path;
 import services.applicant.question.Scalar;
 import services.program.PathNotInBlockException;
-import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.question.QuestionOption;
@@ -197,7 +196,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void stageAndUpdateIfValid_hasProgramBlockDefinitionNotFoundException() {
+  public void stageAndUpdateIfValid_hasProgramBlockNotFoundException() {
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
     ImmutableSet<Update> updates = ImmutableSet.of();
     String badBlockId = "100";
@@ -211,7 +210,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     assertThat(errorAnd.hasResult()).isFalse();
     assertThat(errorAnd.getErrors()).hasSize(1);
     assertThat(errorAnd.getErrors().asList().get(0))
-        .isInstanceOf(ProgramBlockDefinitionNotFoundException.class);
+        .isInstanceOf(ProgramBlockNotFoundException.class);
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -104,12 +104,12 @@ public class BlockTest {
         .contains(ScalarType.STRING);
     assertThat(
             block.getScalarType(
-                    ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.MIDDLE_NAME)))
-            .contains(ScalarType.STRING);
+                ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.MIDDLE_NAME)))
+        .contains(ScalarType.STRING);
     assertThat(
             block.getScalarType(
-                    ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.LAST_NAME)))
-            .contains(ScalarType.STRING);
+                ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.LAST_NAME)))
+        .contains(ScalarType.STRING);
     assertThat(
             block.getScalarType(
                 ApplicantData.APPLICANT_PATH

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -7,10 +7,12 @@ import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import services.Path;
 import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.Scalar;
 import services.program.BlockDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.ScalarType;
 import services.question.types.TextQuestionDefinition;
 import support.QuestionAnswerer;
 import support.TestQuestionBank;
@@ -87,6 +89,63 @@ public class BlockTest {
             new ApplicantQuestion(NAME_QUESTION, applicantData),
             new ApplicantQuestion(COLOR_QUESTION, applicantData));
     assertThat(block.getQuestions()).containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void getScalarType_returnsAllScalarTypes() {
+    BlockDefinition definition = setUpBlockWithQuestions();
+    ApplicantData applicantData = new ApplicantData();
+
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+
+    assertThat(
+            block.getScalarType(
+                ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.FIRST_NAME)))
+        .contains(ScalarType.STRING);
+    assertThat(
+            block.getScalarType(
+                    ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.MIDDLE_NAME)))
+            .contains(ScalarType.STRING);
+    assertThat(
+            block.getScalarType(
+                    ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.LAST_NAME)))
+            .contains(ScalarType.STRING);
+    assertThat(
+            block.getScalarType(
+                ApplicantData.APPLICANT_PATH
+                    .join("applicant_name")
+                    .join(Scalar.PROGRAM_UPDATED_IN)))
+        .contains(ScalarType.LONG);
+    assertThat(
+            block.getScalarType(
+                ApplicantData.APPLICANT_PATH.join("applicant_name").join(Scalar.UPDATED_AT)))
+        .contains(ScalarType.LONG);
+    assertThat(
+            block.getScalarType(
+                ApplicantData.APPLICANT_PATH.join("applicant_favorite_color").join(Scalar.TEXT)))
+        .contains(ScalarType.STRING);
+    assertThat(
+            block.getScalarType(
+                ApplicantData.APPLICANT_PATH
+                    .join("applicant_favorite_color")
+                    .join(Scalar.PROGRAM_UPDATED_IN)))
+        .contains(ScalarType.LONG);
+    assertThat(
+            block.getScalarType(
+                ApplicantData.APPLICANT_PATH
+                    .join("applicant_favorite_color")
+                    .join(Scalar.UPDATED_AT)))
+        .contains(ScalarType.LONG);
+  }
+
+  @Test
+  public void getScalarType_forNonExistentPath_returnsEmpty() {
+    BlockDefinition definition = setUpBlockWithQuestions();
+    ApplicantData applicantData = new ApplicantData();
+
+    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+
+    assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
   }
 
   // TODO(https://github.com/seattle-uat/universal-application-tool/issues/377): Add more tests for

--- a/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
@@ -1,17 +1,20 @@
 package services.applicant.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.testing.EqualsTester;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import services.Path;
 import services.applicant.ApplicantData;
-import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
+import services.question.types.ScalarType;
 import support.TestQuestionBank;
 
 @RunWith(JUnitParamsRunner.class)
@@ -20,9 +23,42 @@ public class ApplicantQuestionTest {
   private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
   @Test
+  public void getContextualizedScalars_returnsContextualizedScalarsAndMetadataForType() {
+    ApplicantQuestion testApplicantQuestion =
+        new ApplicantQuestion(
+            testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+            new ApplicantData(),
+            ApplicantData.APPLICANT_PATH);
+
+    ImmutableMap<Path, ScalarType> expected =
+        ImmutableMap.of(
+            Path.create("applicant.applicant_favorite_color").join(Scalar.TEXT),
+            ScalarType.STRING,
+            Path.create("applicant.applicant_favorite_color").join(Scalar.UPDATED_AT),
+            ScalarType.LONG,
+            Path.create("applicant.applicant_favorite_color").join(Scalar.PROGRAM_UPDATED_IN),
+            ScalarType.LONG);
+
+    assertThat(testApplicantQuestion.getContextualizedScalars().entrySet())
+        .containsExactlyElementsOf(expected.entrySet());
+  }
+
+  @Test
+  public void getContextualizedScalars_forEnumerationQuestion_throwsInvalidQuestionTypeException() {
+    ApplicantQuestion enumerationApplicantQuestion =
+        new ApplicantQuestion(
+            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+            new ApplicantData(),
+            ApplicantData.APPLICANT_PATH);
+
+    assertThatThrownBy(() -> enumerationApplicantQuestion.getContextualizedScalars())
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(InvalidQuestionTypeException.class);
+  }
+
+  @Test
   @Parameters(source = QuestionType.class)
-  public void errorsPresenterExtendedForAllTypes(QuestionType questionType)
-      throws UnsupportedQuestionTypeException {
+  public void errorsPresenterExtendedForAllTypes(QuestionType questionType) {
     QuestionDefinition definition =
         testQuestionBank.getSampleQuestionsForAllTypes().get(questionType).getQuestionDefinition();
     ApplicantQuestion question = new ApplicantQuestion(definition, new ApplicantData());

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import org.junit.Test;
-import services.Path;
 import services.question.types.QuestionDefinition;
-import services.question.types.ScalarType;
 import support.TestQuestionBank;
 
 public class BlockDefinitionTest {
@@ -23,28 +21,6 @@ public class BlockDefinitionTest {
             .build();
 
     assertThat(block.id()).isEqualTo(123L);
-  }
-
-  @Test
-  public void getScalarType() {
-    BlockDefinition block = makeBlockDefinitionWithQuestions();
-    assertThat(block.getScalarType(Path.create("applicant.applicant_name.first_name")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_name.middle_name")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_name.last_name")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_address.street")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_address.city")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_address.state")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_address.zip")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("applicant.applicant_favorite_color.text")))
-        .hasValue(ScalarType.STRING);
-    assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
### Description
* Add new `Block#getScalarType` and `ApplicantQuestion#getContextualizedScalars`.
* Remove the concept of scalars and other unused methods from `BlockDefinition`.
* Add new `ApplicantServiceImpl.UpdateMetadata` AutoValue type.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #783

Paired with @kendrickt 
