### PR TITLE
Only allow accesses on ports 80 and 443.

### DIFF
--- a/infra/security_groups.yaml
+++ b/infra/security_groups.yaml
@@ -36,7 +36,13 @@ Resources:
       GroupName: !Join [".", [!Ref Environment, "civiform-publiclb.sg"]]
       VpcId: !Ref 'VPCId'
       SecurityGroupIngress:
-        - IpProtocol: -1
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: '0.0.0.0/0'
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
           CidrIp: '0.0.0.0/0'
 Outputs:
   LbGroup:


### PR DESCRIPTION
### Description
At city's request, lb should only be accessible on the ports it serves traffic on.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
