### PR TITLE
Add `ReadOnlyApplicantProgramService#getProgramTitle` method

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 /** Provides synchronous, read-only behavior relevant to an applicant for a specific program. */
 public interface ReadOnlyApplicantProgramService {
+  /** Returns the program title, localized to the applicant's preferred locale. */
+  String getProgramTitle();
 
   /**
    * Get the {@link Block}s for this program and applicant. This includes all blocks, whether the

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -23,6 +23,11 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
+  public String getProgramTitle() {
+    return programDefinition.getLocalizedNameOrDefault(applicantData.preferredLocale());
+  }
+
+  @Override
   public ImmutableList<Block> getAllBlocks() {
     return getBlocks(false);
   }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -52,6 +52,9 @@ public abstract class ProgramDefinition {
   /** The list of {@link ExportDefinition}s that make up the program. */
   public abstract ImmutableList<ExportDefinition> exportDefinitions();
 
+  /**
+   * Returns the localized program name for the given locale. Useful for applicant-facing things.
+   */
   public String getLocalizedNameOrDefault(Locale locale) {
     try {
       return getLocalizedName(locale);
@@ -60,7 +63,10 @@ public abstract class ProgramDefinition {
     }
   }
 
-  /** The default locale for CiviForm is US English. */
+  /**
+   * Returns the program name localized in the {@link LocalizationUtils#DEFAULT_LOCALE}. Useful for
+   * admin-facing things.
+   */
   public String getNameForDefaultLocale() {
     try {
       return getLocalizedName(LocalizationUtils.DEFAULT_LOCALE);

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -30,13 +30,31 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     colorQuestion = testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
     addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
     programDefinition =
-        ProgramBuilder.newDraftProgram()
+        ProgramBuilder.newDraftProgram("My Program")
+            .withLocalizedName(Locale.GERMAN, "Mein Programm")
             .withBlock("Block one")
             .withQuestionDefinition(nameQuestion)
             .withBlock("Block two")
             .withQuestionDefinition(colorQuestion)
             .withQuestionDefinition(addressQuestion)
             .buildDefinition();
+  }
+
+  @Test
+  public void getProgramTitle_returnsProgramTitleInDefaultLocale() {
+    ReadOnlyApplicantProgramService subject =
+        new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
+
+    assertThat(subject.getProgramTitle()).isEqualTo("My Program");
+  }
+
+  @Test
+  public void getProgramTitle_returnsProgramTitleForPreferredLocale() {
+    applicantData.setPreferredLocale(Locale.GERMAN);
+    ReadOnlyApplicantProgramService subject =
+        new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
+
+    assertThat(subject.getProgramTitle()).isEqualTo("Mein Programm");
   }
 
   @Test


### PR DESCRIPTION
### Description
Useful for displaying program title to applicants in #871.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #914 
