### PR TITLE
Add injector to ProgramBuilder for WithMockedApplicantProfiles tests.

### DIFF
--- a/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 import play.inject.Injector;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http;
+import support.ProgramBuilder;
 import support.ResourceCreator;
 import support.TestConstants;
 import support.TestQuestionBank;
@@ -40,6 +41,7 @@ public class WithMockedApplicantProfiles {
             .injector();
     resourceCreator = new ResourceCreator(injector);
     profileFactory = injector.instanceOf(ProfileFactory.class);
+    ProgramBuilder.setInjector(injector);
   }
 
   protected <T> T instanceOf(Class<T> clazz) {

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -3,7 +3,6 @@ package support;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import models.Program;
 import models.Question;
 import play.inject.Injector;

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.persistence.PersistenceException;
 import models.Program;
 import models.Question;
 import play.inject.Injector;
@@ -16,9 +15,16 @@ import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
+/**
+ * The ProgramBuilder can only be used by tests that have a database available because the programs
+ * it builds are versioned with the version table, and are persisted in the database.
+ *
+ * <p>If any tests need to use the ProgramBuilder without a database, new `public static
+ * ProgramBuilder newProgram` methods can be added to create programs that are not versioned, and do
+ * not get persisted to the database.
+ */
 public class ProgramBuilder {
 
-  private static AtomicLong nextId = new AtomicLong(1);
   private static Injector injector;
 
   ProgramDefinition.Builder builder;
@@ -53,7 +59,7 @@ public class ProgramBuilder {
     VersionRepository versionRepository = injector.instanceOf(VersionRepository.class);
     Program program = new Program(name, description, name, description);
     program.addVersion(versionRepository.getDraftVersion());
-    maybeSave(program);
+    program.save();
     ProgramDefinition.Builder builder =
         program.getProgramDefinition().toBuilder()
             .setBlockDefinitions(ImmutableList.of())
@@ -82,29 +88,12 @@ public class ProgramBuilder {
     VersionRepository versionRepository = injector.instanceOf(VersionRepository.class);
     Program program = new Program(name, description, name, description);
     program.addVersion(versionRepository.getActiveVersion());
-    maybeSave(program);
+    program.save();
     ProgramDefinition.Builder builder =
         program.getProgramDefinition().toBuilder()
             .setBlockDefinitions(ImmutableList.of())
             .setExportDefinitions(ImmutableList.of());
     return new ProgramBuilder(builder);
-  }
-
-  private static void maybeSave(Program program) {
-    try {
-      program.save();
-    } catch (ExceptionInInitializerError | NoClassDefFoundError | PersistenceException ignore) {
-      program.id = nextId.getAndIncrement();
-      program.loadProgramDefinition();
-    }
-  }
-
-  private static void maybeUpdate(Program program) {
-    try {
-      program.update();
-    } catch (NoClassDefFoundError | PersistenceException ignore) {
-      // This is ok not to update if there is no database available.
-    }
   }
 
   public ProgramBuilder withName(String name) {
@@ -162,7 +151,7 @@ public class ProgramBuilder {
     }
 
     Program program = programDefinition.toProgram();
-    maybeUpdate(program);
+    program.update();
     return program;
   }
 


### PR DESCRIPTION
### Description
All tests that use `ProgramBuilder` have the database in scope, so I didn't add methods to allow using `ProgramBuilder` without the database in scope.

Instead, the change was to call `Program#save()` directly, without catching errors, and set the `ProgramBuilder#injector` in `WithMockedApplicantProfiles` tests.