### PR TITLE
Ensure transactionality of creating new drafts.

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -60,16 +60,10 @@ public class QuestionRepository {
       } else {
         Question newDraft =
             new Question(new QuestionDefinitionBuilder(definition).setId(null).build());
-        try {
-          ebeanServer.beginTransaction();
-          insertQuestionSync(newDraft);
-          newDraft.addVersion(draftVersion);
-          newDraft.save();
-          versionRepositoryProvider.get().updateProgramsForNewDraftQuestion(definition.getId());
-          ebeanServer.commitTransaction();
-        } finally {
-          ebeanServer.endTransaction();
-        }
+        insertQuestionSync(newDraft);
+        newDraft.addVersion(draftVersion);
+        newDraft.save();
+        versionRepositoryProvider.get().updateProgramsForNewDraftQuestion(definition.getId());
         return newDraft;
       }
     } catch (UnsupportedQuestionTypeException e) {


### PR DESCRIPTION
### Description
Removed the handle-after-the-fact of creating new drafts - which was sloppy and never desirable, it was a hack to avoid a problem I introduced - and instead use the normal database thing for that problem, which is transactions.  ebeans transactions aren't perfect, but they do work for this use case - `requiresNew` suspends a parent transaction which can be revived after the fact.

Addresses the problem referenced here:
https://civiform.slack.com/archives/C02022VFNCF/p1619731485002800

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary