### PR TITLE
Truncate all tables

### DIFF
--- a/universal-application-tool-0.0.1/app/models/Models.java
+++ b/universal-application-tool-0.0.1/app/models/Models.java
@@ -1,0 +1,16 @@
+package models;
+
+import com.google.common.collect.ImmutableList;
+
+public class Models {
+  public static final ImmutableList<Class<? extends BaseModel>> MODELS =
+      ImmutableList.of(
+          Account.class,
+          Applicant.class,
+          Application.class,
+          Program.class,
+          Question.class,
+          StoredFile.class,
+          TrustedIntermediaryGroup.class,
+          Version.class);
+}

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -11,10 +11,9 @@ import controllers.routes;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import java.util.Optional;
-import models.Account;
-import models.Applicant;
-import models.Program;
-import models.Question;
+import models.LifecycleStage;
+import models.Models;
+import models.Version;
 import org.fluentlenium.core.domain.FluentList;
 import org.fluentlenium.core.domain.FluentWebElement;
 import org.junit.Before;
@@ -39,11 +38,12 @@ public class BaseBrowserTest extends WithBrowser {
   }
 
   @Before
-  public void truncateTables() {
+  public void resetTables() {
     EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
     EbeanServer server = Ebean.getServer(config.defaultServer());
-    server.truncate(
-        Applicant.class, Program.class, Question.class, Account.class, models.Application.class);
+    server.truncate(Models.MODELS.toArray(new Class[0]));
+    Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
+    newActiveVersion.save();
   }
 
   /**

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -12,7 +12,7 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import java.util.Optional;
 import models.LifecycleStage;
-import models.Models;
+import support.Models;
 import models.Version;
 import org.fluentlenium.core.domain.FluentList;
 import org.fluentlenium.core.domain.FluentWebElement;

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -12,7 +12,6 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import java.util.Optional;
 import models.LifecycleStage;
-import support.Models;
 import models.Version;
 import org.fluentlenium.core.domain.FluentList;
 import org.fluentlenium.core.domain.FluentWebElement;
@@ -23,6 +22,7 @@ import play.api.mvc.Call;
 import play.db.ebean.EbeanConfig;
 import play.test.WithBrowser;
 import services.question.types.QuestionType;
+import support.Models;
 import support.TestConstants;
 import views.style.ReferenceClasses;
 
@@ -41,7 +41,7 @@ public class BaseBrowserTest extends WithBrowser {
   public void resetTables() {
     EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
     EbeanServer server = Ebean.getServer(config.defaultServer());
-    server.truncate(Models.MODELS.toArray(new Class[0]));
+    server.truncate(Models.modelsToTruncate());
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
     newActiveVersion.save();
   }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantInformationControllerTest.java
@@ -25,7 +25,7 @@ public class ApplicantInformationControllerTest extends WithMockedApplicantProfi
 
   @Before
   public void setup() {
-    clearDatabase();
+    resetDatabase();
     controller = instanceOf(ApplicantInformationController.class);
     userRepository = instanceOf(UserRepository.class);
     currentApplicant = createApplicantWithMockedProfile();

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -32,7 +32,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
 
   @Before
   public void setUpWithFreshApplicant() {
-    clearDatabase();
+    resetDatabase();
 
     subject = instanceOf(ApplicantProgramBlocksController.class);
     program =

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -29,7 +29,7 @@ public class ApplicantProgramsControllerTest extends WithMockedApplicantProfiles
 
   @Before
   public void setUp() {
-    clearDatabase();
+    resetDatabase();
     controller = instanceOf(ApplicantProgramsController.class);
     currentApplicant = createApplicantWithMockedProfile();
   }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/WithMockedApplicantProfiles.java
@@ -11,6 +11,8 @@ import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import models.Account;
 import models.Applicant;
+import models.LifecycleStage;
+import models.Version;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
 import play.inject.Injector;
@@ -56,9 +58,11 @@ public class WithMockedApplicantProfiles {
     return testQuestionBank;
   }
 
-  protected void clearDatabase() {
+  protected void resetDatabase() {
     testQuestionBank().reset();
     resourceCreator().truncateTables();
+    Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
+    newActiveVersion.save();
   }
 
   protected Applicant createApplicantWithMockedProfile() {

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -6,7 +6,7 @@ import akka.stream.Materializer;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import models.LifecycleStage;
-import models.Models;
+import support.Models;
 import models.Version;
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -5,11 +5,8 @@ import static play.test.Helpers.fakeApplication;
 import akka.stream.Materializer;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
-import models.Account;
-import models.Applicant;
 import models.LifecycleStage;
-import models.Program;
-import models.Question;
+import models.Models;
 import models.Version;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -58,16 +55,10 @@ public class WithPostgresContainer {
   }
 
   @Before
-  public void truncateTables() {
+  public void resetTables() {
     EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
     EbeanServer server = Ebean.getServer(config.defaultServer());
-    server.truncate(
-        Applicant.class,
-        Program.class,
-        Question.class,
-        Account.class,
-        Version.class,
-        models.Application.class);
+    server.truncate(Models.MODELS.toArray(new Class[0]));
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
     newActiveVersion.save();
   }

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -6,7 +6,6 @@ import akka.stream.Materializer;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import models.LifecycleStage;
-import support.Models;
 import models.Version;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -14,6 +13,7 @@ import org.junit.BeforeClass;
 import play.Application;
 import play.db.ebean.EbeanConfig;
 import play.test.Helpers;
+import support.Models;
 import support.ProgramBuilder;
 import support.ResourceCreator;
 import support.TestConstants;
@@ -58,7 +58,7 @@ public class WithPostgresContainer {
   public void resetTables() {
     EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
     EbeanServer server = Ebean.getServer(config.defaultServer());
-    server.truncate(Models.MODELS.toArray(new Class[0]));
+    server.truncate(Models.modelsToTruncate());
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
     newActiveVersion.save();
   }

--- a/universal-application-tool-0.0.1/test/support/Models.java
+++ b/universal-application-tool-0.0.1/test/support/Models.java
@@ -11,9 +11,11 @@ import models.StoredFile;
 import models.TrustedIntermediaryGroup;
 import models.Version;
 
-/** This is just a global constant of the list of models we have so we can truncate them in tests. */
+/**
+ * This is just a global constant of the list of models we have so we can truncate them in tests.
+ */
 public class Models {
-  public static final ImmutableList<Class<? extends BaseModel>> MODELS =
+  private static final ImmutableList<Class<? extends BaseModel>> MODELS =
       ImmutableList.of(
           Account.class,
           Applicant.class,
@@ -23,4 +25,9 @@ public class Models {
           StoredFile.class,
           TrustedIntermediaryGroup.class,
           Version.class);
+
+  /** Get the complete list of ebean models to truncate. */
+  public static Class[] modelsToTruncate() {
+    return MODELS.toArray(new Class[0]);
+  }
 }

--- a/universal-application-tool-0.0.1/test/support/Models.java
+++ b/universal-application-tool-0.0.1/test/support/Models.java
@@ -1,7 +1,17 @@
-package models;
+package support;
 
 import com.google.common.collect.ImmutableList;
+import models.Account;
+import models.Applicant;
+import models.Application;
+import models.BaseModel;
+import models.Program;
+import models.Question;
+import models.StoredFile;
+import models.TrustedIntermediaryGroup;
+import models.Version;
 
+/** This is just a global constant of the list of models we have so we can truncate them in tests. */
 public class Models {
   public static final ImmutableList<Class<? extends BaseModel>> MODELS =
       ImmutableList.of(

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 import models.Account;
 import models.Applicant;
-import models.Application;
+import models.Models;
 import models.Program;
 import models.Question;
 import play.db.ebean.EbeanConfig;
@@ -27,8 +27,7 @@ public class ResourceCreator {
   }
 
   public void truncateTables() {
-    ebeanServer.truncate(
-        Account.class, Applicant.class, Application.class, Program.class, Question.class);
+    ebeanServer.truncate(Models.MODELS.toArray(new Class[0]));
   }
 
   public Question insertQuestion(String pathString) {

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.UUID;
 import models.Account;
 import models.Applicant;
-import models.Models;
 import models.Program;
 import models.Question;
 import play.db.ebean.EbeanConfig;

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -26,7 +26,7 @@ public class ResourceCreator {
   }
 
   public void truncateTables() {
-    ebeanServer.truncate(Models.MODELS.toArray(new Class[0]));
+    ebeanServer.truncate(Models.modelsToTruncate());
   }
 
   public Question insertQuestion(String pathString) {


### PR DESCRIPTION
### Description
Instead of truncating a manually curated custom list, truncate from a shared global constant.

Almost everything needs an active version in the database, so `truncate` methods are renamed to `reset` if they create an active version.