### PR TITLE
Add new `Scalar.LINE2` for Address question type and ability to read and write its value

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
@@ -15,6 +15,7 @@ public class AddressQuestion implements PresentsErrors {
 
   private final ApplicantQuestion applicantQuestion;
   private Optional<String> streetValue;
+  private Optional<String> line2Value;
   private Optional<String> cityValue;
   private Optional<String> stateValue;
   private Optional<String> zipValue;
@@ -39,6 +40,8 @@ public class AddressQuestion implements PresentsErrors {
 
     if (definition.getDisallowPoBox() && getStreetValue().isPresent()) {
       Pattern poBoxPattern = Pattern.compile(PO_BOX_REGEX);
+      // TODO(https://github.com/seattle-uat/civiform/issues/844): Compare PO_BOX_REGEX against
+      // getLine2Value() as well.
       Matcher poBoxMatcher = poBoxPattern.matcher(getStreetValue().get());
 
       if (poBoxMatcher.matches()) {
@@ -120,6 +123,15 @@ public class AddressQuestion implements PresentsErrors {
     return streetValue;
   }
 
+  public Optional<String> getLine2Value() {
+    if (line2Value != null) {
+      return line2Value;
+    }
+
+    line2Value = applicantQuestion.getApplicantData().readString(getLine2Path());
+    return line2Value;
+  }
+
   public Optional<String> getCityValue() {
     if (cityValue != null) {
       return cityValue;
@@ -166,6 +178,10 @@ public class AddressQuestion implements PresentsErrors {
     return applicantQuestion.getContextualizedPath().join(Scalar.STREET);
   }
 
+  public Path getLine2Path() {
+    return applicantQuestion.getContextualizedPath().join(Scalar.LINE2);
+  }
+
   public Path getCityPath() {
     return applicantQuestion.getContextualizedPath().join(Scalar.CITY);
   }
@@ -180,6 +196,10 @@ public class AddressQuestion implements PresentsErrors {
 
   private boolean isStreetAnswered() {
     return applicantQuestion.getApplicantData().hasPath(getStreetPath());
+  }
+
+  private boolean isLine2Answered() {
+    return applicantQuestion.getApplicantData().hasPath(getLine2Path());
   }
 
   private boolean isCityAnswered() {
@@ -200,6 +220,10 @@ public class AddressQuestion implements PresentsErrors {
    */
   @Override
   public boolean isAnswered() {
-    return isStreetAnswered() || isCityAnswered() || isStateAnswered() || isZipAnswered();
+    return isStreetAnswered()
+        || isLine2Answered()
+        || isCityAnswered()
+        || isStateAnswered()
+        || isZipAnswered();
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -21,6 +21,7 @@ public enum Scalar {
   FILE_KEY,
   FIRST_NAME,
   LAST_NAME,
+  LINE2,
   MIDDLE_NAME,
   NUMBER,
   PROGRAM_UPDATED_IN,
@@ -34,6 +35,7 @@ public enum Scalar {
   private static final ImmutableMap<Scalar, ScalarType> ADDRESS_SCALARS =
       ImmutableMap.of(
           STREET, ScalarType.STRING,
+          LINE2, ScalarType.STRING,
           CITY, ScalarType.STRING,
           STATE, ScalarType.STRING,
           ZIP, ScalarType.STRING);

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -264,7 +264,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
   private void answerAddressQuestion(long programId) {
     Path path = Path.create("applicant.applicant_address");
     QuestionAnswerer.answerAddressQuestion(
-        applicantData, path, "123 Rhode St.", "Seattle", "WA", "12345");
+        applicantData, path, "123 Rhode St.", "", "Seattle", "WA", "12345");
     QuestionAnswerer.addMetadata(applicantData, path, programId, 12345L);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/AddressQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/AddressQuestionTest.java
@@ -69,6 +69,7 @@ public class AddressQuestionTest {
         applicantData,
         applicantQuestion.getContextualizedPath(),
         "85 Pike St",
+        "Unit B",
         "Seattle",
         "WA",
         "98101");
@@ -78,6 +79,7 @@ public class AddressQuestionTest {
     assertThat(addressQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(addressQuestion.hasQuestionErrors()).isFalse();
     assertThat(addressQuestion.getStreetValue().get()).isEqualTo("85 Pike St");
+    assertThat(addressQuestion.getLine2Value().get()).isEqualTo("Unit B");
     assertThat(addressQuestion.getCityValue().get()).isEqualTo("Seattle");
     assertThat(addressQuestion.getStateValue().get()).isEqualTo("WA");
     assertThat(addressQuestion.getZipValue().get()).isEqualTo("98101");
@@ -89,7 +91,7 @@ public class AddressQuestionTest {
         new ApplicantQuestion(
             noPoBoxAddressQuestionDefinition, applicantData, ApplicantData.APPLICANT_PATH);
     QuestionAnswerer.answerAddressQuestion(
-        applicantData, applicantQuestion.getContextualizedPath(), "", "", "", "");
+        applicantData, applicantQuestion.getContextualizedPath(), "", "", "", "", "");
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
@@ -110,6 +112,7 @@ public class AddressQuestionTest {
         applicantData,
         applicantQuestion.getContextualizedPath(),
         "123 A St",
+        "Unit B",
         "Seattle",
         "WA",
         zipValue);
@@ -133,6 +136,7 @@ public class AddressQuestionTest {
         applicantData,
         applicantQuestion.getContextualizedPath(),
         streetValue,
+        "Unit B",
         "Seattle",
         "WA",
         "98107");
@@ -162,6 +166,7 @@ public class AddressQuestionTest {
         applicantData,
         applicantQuestion.getContextualizedPath(),
         streetValue,
+        "Unit B",
         "Seattle",
         "WA",
         "98107");

--- a/universal-application-tool-0.0.1/test/support/QuestionAnswerer.java
+++ b/universal-application-tool-0.0.1/test/support/QuestionAnswerer.java
@@ -12,10 +12,12 @@ public class QuestionAnswerer {
       ApplicantData applicantData,
       Path contextualizedPath,
       String street,
+      String line2,
       String city,
       String state,
       String zip) {
     applicantData.putString(contextualizedPath.join(Scalar.STREET), street);
+    applicantData.putString(contextualizedPath.join(Scalar.LINE2), line2);
     applicantData.putString(contextualizedPath.join(Scalar.CITY), city);
     applicantData.putString(contextualizedPath.join(Scalar.STATE), state);
     applicantData.putString(contextualizedPath.join(Scalar.ZIP), zip);

--- a/universal-application-tool-0.0.1/test/support/QuestionAnswererTest.java
+++ b/universal-application-tool-0.0.1/test/support/QuestionAnswererTest.java
@@ -21,7 +21,8 @@ public class QuestionAnswererTest {
   @Test
   public void answerAddressQuestion() {
     Path path = Path.create("applicant.address");
-    QuestionAnswerer.answerAddressQuestion(applicantData, path, "street", "city", "state", "zip");
+    QuestionAnswerer.answerAddressQuestion(
+        applicantData, path, "street", "line 2", "city", "state", "zip");
 
     assertThat(applicantData.readString(path.join(Scalar.STREET))).contains("street");
     assertThat(applicantData.readString(path.join(Scalar.CITY))).contains("city");


### PR DESCRIPTION
… value in QuestionAnswerer and read its value in AddressQuestion.

### Description
* Add ability to set the address line 2 value in `QuestionAnswerer`
* Add ability to read the address line 2 value in `AddressQuestion`

To satisfy #844, we still need to make changes to the address question renderer and form binding, as well as include it in the PO box validation check (see TODO in `AddressQuestion`).

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #844 
