### PR TITLE
Use civiform.seattle.gov certificate instead of seattle.civiform.com.

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -125,6 +125,8 @@ Resources:
               Value: !Sub '{{resolve:secretsmanager:${Environment}-oidc-secrets:SecretString:IDCS_CLIENT_ID}}'
             - Name: IDCS_SECRET
               Value: !Sub '{{resolve:secretsmanager:${Environment}-oidc-secrets:SecretString:IDCS_SECRET}}'
+            - Name: IDCS_DISCOVERY_URI
+              Value: !Sub '{{resolve:secretsmanager:${Environment}-oidc-secrets:SecretString:IDCS_DISCOVERY_URI}}'
             - Name: ADFS_CLIENT_ID
               Value: !Sub '{{resolve:secretsmanager:${Environment}-oidc-secrets:SecretString:ADFS_CLIENT_ID}}'
             - Name: ADFS_SECRET

--- a/infra/load_balancer.yaml
+++ b/infra/load_balancer.yaml
@@ -3,7 +3,7 @@ Description: 'The public load balancer for Civiform, plus a dummy target that dr
 Mappings:
   Certificate:
     prod:
-      CertArn: arn:aws:acm:us-west-2:405662711265:certificate/f014a620-3d5b-4fbd-8d7a-055030599f1f
+      CertArn: arn:aws:acm:us-west-2:405662711265:certificate/74f32a1f-e8aa-453c-88f1-b2aac0f7e92b
     staging:
       CertArn: arn:aws:acm:us-west-2:405662711265:certificate/e35f35af-6329-4277-8cbf-a8c8a6ab2b40
 Parameters:

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'The main stack for CiviForm.'
 Mappings:
+  Container:
+    prod:
+      Domain: civiform.seattle.gov
+    staging:
+      Domain: staging.seattle.civiform.com
   DNS:
     prod:
       # The city's DNS is configured as a CNAME to this address.
@@ -95,7 +100,7 @@ Resources:
         LBTargetName: !GetAtt 'LB.Outputs.LBTarget'
         ContainerSecurityGroup: !GetAtt 'SecurityGroups.Outputs.ContainerGroup'
         S3BucketName: !GetAtt 'Filestore.Outputs.bucketname'
-        DomainName: !FindInMap [DNS, !Ref Environment, Domain]
+        DomainName: !FindInMap [Container, !Ref Environment, Domain]
         Environment: !Ref Environment
         S3TaskRole: !FindInMap [S3TaskRoles, !Ref Environment, role]
   Monitoring:

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -3,6 +3,7 @@ Description: 'The main stack for CiviForm.'
 Mappings:
   DNS:
     prod:
+      # The city's DNS is configured as a CNAME to this address.
       Domain: seattle.civiform.com
       HostedZone: Z02860647AHUYUQTEAPO
     staging:


### PR DESCRIPTION
### Description
Each load balancer rule can only use one certificate.  This will mean people accessing seattle.civiform.com will get an SSL error - is that okay, do you think?  Or should I pursue another solution?

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary