### PR TITLE
Allow us to configure auto-apply-down in the environment variables.

### DIFF
--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -308,6 +308,7 @@ play.evolutions {
     useLocks = true
     autoApply = true
     autoApplyDowns = false
+    autoApplyDowns = ${?DATABASE_APPLY_DESTRUCTIVE_CHANGES}
   }
 }
 


### PR DESCRIPTION
### Description
If you set the "DATABASE_APPLY_DESTRUCTIVE_CHANGES" in the environment variable console, the destructive changes will be automatically applied.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)