### PR TITLE
Use access token to get jwt in prod.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -2,6 +2,7 @@ package auth;
 
 import com.google.common.collect.ImmutableSet;
 import javax.inject.Provider;
+import org.pac4j.core.credentials.Credentials;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -36,5 +37,10 @@ public class AdfsProfileAdapter extends UatProfileAdapter {
   public UatProfileData uatProfileFromOidcProfile(OidcProfile profile) {
     return mergeUatProfile(
         profileFactory.wrapProfileData(profileFactory.createNewAdmin()), profile);
+  }
+
+  @Override
+  protected void possiblyModifyConfigBasedOnCred(Credentials cred) {
+    // No need!
   }
 }

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -108,6 +108,9 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
           @Override
           public Map<String, List<String>> getHeaders() {
             Map<String, List<String>> headers = super.getHeaders();
+            if (((OidcCredentials) cred).getAccessToken() == null) {
+              return headers;
+            }
             if (headers == null) {
               headers = new HashMap<>();
             }

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -2,11 +2,17 @@ package auth;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Provider;
+import org.pac4j.core.credentials.Credentials;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.profile.OidcProfile;
 import repository.UserRepository;
 
@@ -76,5 +82,39 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   public UatProfileData uatProfileFromOidcProfile(OidcProfile profile) {
     return mergeUatProfile(
         profileFactory.wrapProfileData(profileFactory.createNewApplicant()), profile);
+  }
+
+  @Override
+  protected void possiblyModifyConfigBasedOnCred(Credentials cred) {
+    // The flow here is not immediately intuitive.  IDCS is to blame.  :)
+    // The normal flow for authenticating a user is "get user's data via POST.
+    // Decode it, check that it is signed, and use it." IDCS throws in an extra step
+    // here - in order to get IDCS's signing key, we need to provide an Authorization
+    // header proving that we have a good reason to use the signing key.
+    // Pac4j and associated tools are not well-suited to that, because it's
+    // a deviation from the OIDC spec.  Pac4j has the concept of a "resource retriever",
+    // which is used to fetch things like the signing key.  They are meant to
+    // be configured once and used indefinitely, but we only get the access
+    // token at the time the user logs in and is redirected to our server.  So,
+    // we need to slighly abuse the notion of a resource retriever.  We create our
+    // own modified resource retriever which has access to the required token.
+
+    // Note that there would normally be a significant thread-safety issue here - but
+    // we actually don't need to match up signing key tokens with actual tokens, because
+    // any valid token is sufficient.
+    this.configuration.setResourceRetriever(
+        new DefaultResourceRetriever(
+            this.configuration.getConnectTimeout(), this.configuration.getReadTimeout()) {
+          @Override
+          public Map<String, List<String>> getHeaders() {
+            Map<String, List<String>> headers = super.getHeaders();
+            if (headers == null) {
+              headers = new HashMap<>();
+            }
+            String authHeader = ((OidcCredentials) cred).getAccessToken().toAuthorizationHeader();
+            headers.put("Authorization", List.of(authHeader));
+            return headers;
+          }
+        });
   }
 }

--- a/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
@@ -2,6 +2,10 @@ package auth;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.inject.Provider;
 import models.Account;
@@ -13,6 +17,7 @@ import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.creator.OidcProfileCreator;
 import org.slf4j.Logger;
@@ -65,6 +70,25 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
   public Optional<UserProfile> create(
       Credentials cred, WebContext context, SessionStore sessionStore) {
     ProfileUtils profileUtils = new ProfileUtils(sessionStore, profileFactory);
+    // This is here because IDCS demands an authorization header to access the JWT token.
+    // There's no particular reason for IDCS to demand this but this should successfully work around
+    // that requirement by providing the current access token.  This is reasonably thread-safe
+    // because
+    // there's no requirement that the GET request use the access token for any particular request.
+    this.configuration.setResourceRetriever(
+        new DefaultResourceRetriever(
+            this.configuration.getConnectTimeout(), this.configuration.getReadTimeout()) {
+          @Override
+          public Map<String, List<String>> getHeaders() {
+            Map<String, List<String>> headers = super.getHeaders();
+            if (headers == null) {
+              headers = new HashMap<>();
+            }
+            String authHeader = ((OidcCredentials) cred).getAccessToken().toAuthorizationHeader();
+            headers.put("Authorization", List.of(authHeader));
+            return headers;
+          }
+        });
     Optional<UserProfile> oidcProfile = super.create(cred, context, sessionStore);
 
     if (oidcProfile.isEmpty()) {

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -132,7 +132,12 @@ public class SecurityModule extends AbstractModule {
     config.setSecret(this.configuration.getString("idcs.secret"));
     config.setDiscoveryURI(this.configuration.getString("idcs.discovery_uri"));
     config.setResponseMode("form_post");
-    config.setResponseType("id_token token");
+    // Our local fake IDCS doesn't support 'token' auth.
+    if (baseUrl.contains("localhost:")) {
+      config.setResponseType("id_token");
+    } else {
+      config.setResponseType("id_token token");
+    }
     config.setUseNonce(true);
     config.setWithState(false);
     OidcClient client = new OidcClient(config);

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -132,7 +132,7 @@ public class SecurityModule extends AbstractModule {
     config.setSecret(this.configuration.getString("idcs.secret"));
     config.setDiscoveryURI(this.configuration.getString("idcs.discovery_uri"));
     config.setResponseMode("form_post");
-    config.setResponseType("id_token");
+    config.setResponseType("id_token token");
     config.setUseNonce(true);
     config.setWithState(false);
     OidcClient client = new OidcClient(config);


### PR DESCRIPTION
### Description
This is pretty confusing, sorry.

The token that we receive back from IDCS is signed by the server we redirected the user to.  This is for good, obvious security reasons - if anybody could just post whatever login data they wanted, we'd be vulnerable to people sending us callbacks that didn't reflect genuinely successful logins (if they could, for instance, intercept the outgoing redirect which sets the nonce).

So, there's a signing key which the server uses to prove that it is genuinely itself sending us a genuine login.  The only way to be sure we have the right key is for us to request it from the server.  This is all part of the spec and should be handled entirely behind the scenes.

IDCS, for no good reason, introduces an authentication check in order to fetch this (public) key.  This badly confuses basically every existing auth library - if you look around you'll see a lot of them have little IDCS-compatibility modules to be able to fetch that key.

Pac4j doesn't have such a compat module, but this should serve the same purpose.

It's also only testable in prod.  Sorry about that, too - nothing for it.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
