### PR TITLE
Use transactions to apply evolutions so we don't ever wind up unable to access the DB.

### DIFF
--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -310,6 +310,8 @@ play.evolutions {
     autoApplyDowns = false
     autoApplyDowns = ${?DATABASE_APPLY_DESTRUCTIVE_CHANGES}
   }
+  # Use transactions.
+  autocommit = false
 }
 
 ## Database Connection Pool


### PR DESCRIPTION
### Description

This prevents the issue described in this long slack thread: https://civiform.slack.com/archives/C02022VFNCF/p1620100996051500.

tl;dr: if one statement in an evolution is broken, we should wind up as if it were never applied, not with it partially applied.  This make cleanup easier and safer.
