### PR TITLE
Delete Path#path.

### DIFF
--- a/universal-application-tool-0.0.1/app/models/Question.java
+++ b/universal-application-tool-0.0.1/app/models/Question.java
@@ -149,7 +149,7 @@ public class Question extends BaseModel {
 
     // TODO(https://github.com/seattle-uat/civiform/issues/673): delete this when questions don't
     //  need paths
-    path = questionDefinition.getPath().path();
+    path = questionDefinition.getPath().toString();
 
     repeaterId = questionDefinition.getRepeaterId().orElse(null);
     name = questionDefinition.getName();

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -57,16 +57,6 @@ public abstract class Path {
   }
 
   /**
-   * A single path in JSON notation, without the $. JsonPath prefix.
-   *
-   * <p>TODO: get rid of this method. Methods should use {@link Path} or {@link #toString()}.
-   */
-  @Memoized
-  public String path() {
-    return toString();
-  }
-
-  /**
    * Returns the JSON path compatible string representation of this path.
    *
    * <p>Example: {@code "applicant.children[2].favorite_color.text"}

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -336,7 +336,7 @@ public class ApplicantData {
     } catch (PathNotFoundException e) {
       return Optional.empty();
     } catch (MappingException e) {
-      throw new JsonPathTypeMismatchException(path.path(), type, e);
+      throw new JsonPathTypeMismatchException(path, type, e);
     }
   }
 
@@ -351,11 +351,11 @@ public class ApplicantData {
    */
   private <T> Optional<T> read(Path path, TypeRef<T> type) throws JsonPathTypeMismatchException {
     try {
-      return Optional.ofNullable(this.jsonData.read(path.path(), type));
+      return Optional.ofNullable(this.jsonData.read(path.toString(), type));
     } catch (PathNotFoundException e) {
       return Optional.empty();
     } catch (MappingException e) {
-      throw new JsonPathTypeMismatchException(path.path(), type.getClass(), e);
+      throw new JsonPathTypeMismatchException(path, type.getClass(), e);
     }
   }
 
@@ -463,7 +463,7 @@ public class ApplicantData {
           // Add items from lists.
           // TODO(github.com/seattle-uat/civiform/issues/405): improve merge for repeated fields.
           for (Object item : (List) entry.getValue()) {
-            this.jsonData.add(path.path(), item);
+            this.jsonData.add(path.toString(), item);
           }
         } else {
           try {

--- a/universal-application-tool-0.0.1/app/services/applicant/JsonPathTypeMismatchException.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/JsonPathTypeMismatchException.java
@@ -1,11 +1,13 @@
 package services.applicant;
 
+import services.Path;
+
 /**
  * Thrown when the expected scalar type for a given JSON path does not match the actual value at
  * that path.
  */
 public class JsonPathTypeMismatchException extends Exception {
-  public JsonPathTypeMismatchException(String path, Class type, Throwable cause) {
+  public JsonPathTypeMismatchException(Path path, Class type, Throwable cause) {
     super(path + " does not have expected type " + type, cause);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/exceptions/InvalidPathException.java
+++ b/universal-application-tool-0.0.1/app/services/question/exceptions/InvalidPathException.java
@@ -4,6 +4,6 @@ import services.Path;
 
 public class InvalidPathException extends Exception {
   public InvalidPathException(Path pathName) {
-    super("Path not found: " + pathName.path());
+    super("Path not found: " + pathName);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/exceptions/TranslationNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/question/exceptions/TranslationNotFoundException.java
@@ -1,8 +1,7 @@
 package services.question.exceptions;
 
-import services.Path;
-
 import java.util.Locale;
+import services.Path;
 
 public class TranslationNotFoundException extends Exception {
   public TranslationNotFoundException(Path path, Locale locale) {

--- a/universal-application-tool-0.0.1/app/services/question/exceptions/TranslationNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/question/exceptions/TranslationNotFoundException.java
@@ -1,11 +1,13 @@
 package services.question.exceptions;
 
+import services.Path;
+
 import java.util.Locale;
 
 public class TranslationNotFoundException extends Exception {
-  public TranslationNotFoundException(String pathName, Locale locale) {
+  public TranslationNotFoundException(Path path, Locale locale) {
     super(
         String.format(
-            "Translation not found for Question at path: %1s\n\tLocale: %2s", pathName, locale));
+            "Translation not found for Question at path: %1s\n\tLocale: %2s", path, locale));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -181,7 +181,7 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
               .collect(toImmutableList());
         }
       }
-      throw new TranslationNotFoundException(getPath().toString(), locale);
+      throw new TranslationNotFoundException(getPath(), locale);
     }
   }
 

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -214,7 +214,7 @@ public abstract class QuestionDefinition {
         return this.questionText.get(hasLocale);
       }
     }
-    throw new TranslationNotFoundException(this.getPath().path(), locale);
+    throw new TranslationNotFoundException(this.getPath(), locale);
   }
 
   /** Get the question tests for all locales. This is used for serialization. */
@@ -273,7 +273,7 @@ public abstract class QuestionDefinition {
       }
     }
 
-    throw new TranslationNotFoundException(this.getPath().path(), locale);
+    throw new TranslationNotFoundException(this.getPath(), locale);
   }
 
   /** Get the question help text for all locales. This is used for serialization. */

--- a/universal-application-tool-0.0.1/test/services/PathTest.java
+++ b/universal-application-tool-0.0.1/test/services/PathTest.java
@@ -10,10 +10,10 @@ public class PathTest {
   @Test
   public void pathWithPrefix_removesOnlyPrefixAndWhitespace() {
     String path = "favorite.color";
-    assertThat(Path.create("$.applicant." + path).path()).isEqualTo("applicant.favorite.color");
-    assertThat(Path.create(path).path()).isEqualTo(path);
-    assertThat(Path.create("      applicant.hello   ").path()).isEqualTo("applicant.hello");
-    assertThat(Path.create("    $.applicant  ").path()).isEqualTo("applicant");
+    assertThat(Path.create("$.applicant." + path).toString()).isEqualTo("applicant.favorite.color");
+    assertThat(Path.create(path).toString()).isEqualTo(path);
+    assertThat(Path.create("      applicant.hello   ").toString()).isEqualTo("applicant.hello");
+    assertThat(Path.create("    $.applicant  ").toString()).isEqualTo("applicant");
   }
 
   @Test
@@ -157,10 +157,10 @@ public class PathTest {
   @Test
   public void join() {
     Path path = Path.create("applicant.my.path");
-    assertThat(path.path()).isEqualTo("applicant.my.path");
+    assertThat(path.toString()).isEqualTo("applicant.my.path");
 
     path = path.join("another");
-    assertThat(path.path()).isEqualTo("applicant.my.path.another");
+    assertThat(path.toString()).isEqualTo("applicant.my.path.another");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -173,7 +173,7 @@ public class QuestionDefinitionTest {
 
     assertThat(question.getId()).isEqualTo(123L);
     assertThat(question.getName()).isEqualTo("name");
-    assertThat(question.getPath().path()).isEqualTo("applicant.name");
+    assertThat(question.getPath().toString()).isEqualTo("applicant.name");
     assertThat(question.getDescription()).isEqualTo("description");
     assertThat(question.getQuestionText(Locale.US)).isEqualTo("question?");
     assertThat(question.getQuestionHelpText(Locale.US)).isEqualTo("help text");


### PR DESCRIPTION
### Description
No more `Path#path()`. Use `Path#toString` for JSON stuff, and just use `Path` and let string formatting call `toString`. 

### Issue(s)
Fixes #606 
