### PR TITLE
Go back to using repeaterId in BlockDefinition json properties.

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/BlockDefinition.java
@@ -75,7 +75,7 @@ public abstract class BlockDefinition {
    *
    * @return the BlockDefinition ID for this block definitions enumerator, if it exists
    */
-  @JsonProperty("enumeratorId")
+  @JsonProperty("repeaterId")
   public abstract Optional<Long> enumeratorId();
 
   /**
@@ -135,7 +135,7 @@ public abstract class BlockDefinition {
     @JsonProperty("description")
     public abstract Builder setDescription(String value);
 
-    @JsonProperty("enumeratorId")
+    @JsonProperty("repeaterId")
     public abstract Builder setEnumeratorId(Optional<Long> enumeratorId);
 
     @JsonProperty("hidePredicate")


### PR DESCRIPTION
### Description
Rollback the BlockDefinition JsonProperty changes that break production from #986 
