### PR TITLE
RO applicant program service from an application

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.concurrent.CompletionStage;
 import models.Applicant;
+import models.Application;
 import services.ErrorAnd;
 import services.program.ProgramDefinition;
 
@@ -43,6 +44,10 @@ public interface ApplicantService {
    */
   CompletionStage<ReadOnlyApplicantProgramService> getReadOnlyApplicantProgramService(
       long applicantId, long programId);
+
+  /** Get a {@link ReadOnlyApplicantProgramService} from an application. */
+  CompletionStage<ReadOnlyApplicantProgramService> getReadOnlyApplicantProgramService(
+      Application application);
 
   /**
    * Returns all programs that are appropriate to serve to an applicant - which is any active

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.Applicant;
+import models.Application;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.UserRepository;
 import services.ErrorAnd;
@@ -69,6 +70,14 @@ public class ApplicantServiceImpl implements ApplicantService {
                   applicant.getApplicantData(), programDefinition);
             },
             httpExecutionContext.current());
+  }
+
+  @Override
+  public CompletionStage<ReadOnlyApplicantProgramService> getReadOnlyApplicantProgramService(
+      Application application) {
+    return CompletableFuture.completedFuture(
+        new ReadOnlyApplicantProgramServiceImpl(
+            application.getApplicantData(), application.getProgram().getProgramDefinition()));
   }
 
   @Override


### PR DESCRIPTION
### Description
Allow creating a RO applicant program service from an application, which has a snapshot of applicant data, and a program associated with it.

### Issue(s)
Progress towards #665 