### PR TITLE
Stop clobbering translations when questions are edited

### DIFF
--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -73,7 +73,7 @@ describe('Admin can manage translations', () => {
     const adminQuestions = new AdminQuestions(page);
 
     // Add a new question.
-    const questionName = 'number-question-translated';
+    const questionName = 'translate-no-clobber';
     await adminQuestions.addNumberQuestion(questionName);
 
     // Add a translation for a non-English language.

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -65,6 +65,31 @@ describe('Admin can manage translations', () => {
     expect(await page.innerText('.cf-applicant-question-help-text')).toContain('Spanish help text');
   });
 
+  it('updating a question does not clobber translations', async () => {
+    const { browser, page } = await startSession();
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+
+    // Add a new question.
+    const questionName = 'number-question-translated';
+    await adminQuestions.addNumberQuestion(questionName);
+
+    // Add a translation for a non-English language.
+    await adminQuestions.goToQuestionTranslationPage(questionName);
+    const adminTranslations = new AdminTranslations(page);
+    await adminTranslations.selectLanguage('Spanish');
+    await adminTranslations.editQuestionTranslations('something different', 'help text different');
+
+    // Edit the question again and update the question.
+    await adminQuestions.updateQuestion(questionName);
+
+    // View the question translations and check that the Spanish translations are still there.
+    await adminQuestions.goToQuestionTranslationPage(questionName);
+    await adminTranslations.selectLanguage('Spanish');
+    expect(await page.getAttribute('#localize-question-text', 'value')).toContain('something different');
+  });
+
   it('Applicant sees toast message warning translation is not complete', async () => {
     const { browser, page } = await startSession();
 

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -63,6 +63,7 @@ describe('Admin can manage translations', () => {
 
     expect(await page.innerText('.cf-applicant-question-text')).toContain('Spanish question text');
     expect(await page.innerText('.cf-applicant-question-help-text')).toContain('Spanish help text');
+    await endSession(browser);
   });
 
   it('updating a question does not clobber translations', async () => {
@@ -88,6 +89,7 @@ describe('Admin can manage translations', () => {
     await adminQuestions.goToQuestionTranslationPage(questionName);
     await adminTranslations.selectLanguage('Spanish');
     expect(await page.getAttribute('#localize-question-text', 'value')).toContain('something different');
+    await endSession(browser);
   });
 
   it('Applicant sees toast message warning translation is not complete', async () => {

--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -4,10 +4,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
 import forms.QuestionForm;
 import forms.QuestionFormBuilder;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
@@ -18,6 +20,7 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.CiviFormError;
 import services.ErrorAnd;
+import services.LocalizationUtils;
 import services.Path;
 import services.question.QuestionService;
 import services.question.ReadOnlyQuestionService;
@@ -130,7 +133,8 @@ public class QuestionController extends CiviFormController {
 
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = getBuilderWithQuestionPath(roService, questionForm).build();
+      questionDefinition =
+          getBuilderWithQuestionPath(roService, Optional.empty(), questionForm).build();
     } catch (UnsupportedQuestionTypeException e) {
       // Valid question type that is not yet fully supported.
       return badRequest(e.getMessage());
@@ -191,9 +195,17 @@ public class QuestionController extends CiviFormController {
     ReadOnlyQuestionService roService =
         service.getReadOnlyQuestionService().toCompletableFuture().join();
 
+    Optional<QuestionDefinition> maybeExisting;
+    try {
+      maybeExisting = Optional.of(roService.getQuestionDefinition(id));
+    } catch (QuestionNotFoundException e) {
+      maybeExisting = Optional.empty();
+    }
+
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = getBuilderWithQuestionPath(roService, questionForm).setId(id).build();
+      questionDefinition =
+          getBuilderWithQuestionPath(roService, maybeExisting, questionForm).setId(id).build();
     } catch (UnsupportedQuestionTypeException e) {
       // Failed while trying to update a question that was already created for the given question
       // type
@@ -229,14 +241,22 @@ public class QuestionController extends CiviFormController {
   }
 
   private QuestionDefinitionBuilder getBuilderWithQuestionPath(
-      ReadOnlyQuestionService roService, QuestionForm questionForm) {
+      ReadOnlyQuestionService roService,
+      Optional<QuestionDefinition> existing,
+      QuestionForm questionForm) {
     try {
       Path path =
           roService.makePath(
               questionForm.getEnumeratorId(),
               questionForm.getQuestionName(),
               questionForm.getQuestionType().equals(QuestionType.ENUMERATOR));
-      return questionForm.getBuilder(path);
+      QuestionDefinitionBuilder updated = questionForm.getBuilder(path);
+
+      if (existing.isPresent()) {
+        updated = mergeLocalizations(existing.get(), updated, questionForm);
+      }
+
+      return updated;
     } catch (QuestionNotFoundException | InvalidQuestionTypeException e) {
       throw new RuntimeException(
           String.format(
@@ -245,6 +265,25 @@ public class QuestionController extends CiviFormController {
               questionForm),
           e);
     }
+  }
+
+  private QuestionDefinitionBuilder mergeLocalizations(
+      QuestionDefinition existing, QuestionDefinitionBuilder updated, QuestionForm questionForm) {
+    // Instead of overwriting all localizations, we just want to overwrite the
+    // one for the default locale (the only one possible to change in the form).
+    ImmutableMap<Locale, String> localizedQuestionText =
+        LocalizationUtils.overwriteExistingTranslation(
+            existing.getQuestionText(),
+            LocalizationUtils.DEFAULT_LOCALE,
+            questionForm.getQuestionText());
+    ImmutableMap<Locale, String> localizedQuestionHelpText =
+        LocalizationUtils.overwriteExistingTranslation(
+            existing.getQuestionHelpText(),
+            LocalizationUtils.DEFAULT_LOCALE,
+            questionForm.getQuestionHelpText());
+    updated.setQuestionText(localizedQuestionText);
+    updated.setQuestionHelpText(localizedQuestionHelpText);
+    return updated;
   }
 
   private String invalidQuestionTypeMessage(String questionType) {

--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -269,8 +269,8 @@ public class QuestionController extends CiviFormController {
 
   private QuestionDefinitionBuilder mergeLocalizations(
       QuestionDefinition existing, QuestionDefinitionBuilder updated, QuestionForm questionForm) {
-    // Instead of overwriting all localizations, we just want to overwrite the
-    // one for the default locale (the only one possible to change in the form).
+    // Instead of overwriting all localizations, we just want to overwrite the one
+    // for the default locale (the only one possible to change in the edit form).
     ImmutableMap<Locale, String> localizedQuestionText =
         LocalizationUtils.overwriteExistingTranslation(
             existing.getQuestionText(),
@@ -281,8 +281,10 @@ public class QuestionController extends CiviFormController {
             existing.getQuestionHelpText(),
             LocalizationUtils.DEFAULT_LOCALE,
             questionForm.getQuestionHelpText());
+
     updated.setQuestionText(localizedQuestionText);
     updated.setQuestionHelpText(localizedQuestionHelpText);
+
     return updated;
   }
 


### PR DESCRIPTION
### Description
When any part of a question was edited, it would overwrite the entire translation map for question text and help text. This merges the existing localizations with the new ones, so that we don't lose all the translation work on a question if (for example) the description is updated.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1021 
