### PR TITLE
More enumerator/repeated context in block

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -14,7 +14,6 @@ import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.PresentsErrors;
 import services.program.BlockDefinition;
 import services.program.ProgramQuestionDefinition;
-import services.question.types.QuestionDefinition;
 import services.question.types.ScalarType;
 
 /** Represents a block in the context of a specific user's application. */
@@ -40,7 +39,7 @@ public final class Block {
   private final BlockDefinition blockDefinition;
   private final ApplicantData applicantData;
   private final Path contextualizedPath;
-  private final ImmutableMap<QuestionDefinition, String> entityNames;
+  private final ImmutableList<RepeatedEntity> repeatedEntities;
 
   private Optional<ImmutableList<ApplicantQuestion>> questionsMemo = Optional.empty();
   private Optional<ImmutableMap<Path, ScalarType>> scalarsMemo = Optional.empty();
@@ -50,12 +49,12 @@ public final class Block {
       BlockDefinition blockDefinition,
       ApplicantData applicantData,
       Path contextualizedPath,
-      ImmutableMap<QuestionDefinition, String> entityNames) {
+      ImmutableList<RepeatedEntity> repeatedEntities) {
     this.id = id;
     this.blockDefinition = checkNotNull(blockDefinition);
     this.applicantData = checkNotNull(applicantData);
     this.contextualizedPath = checkNotNull(contextualizedPath);
-    this.entityNames = checkNotNull(entityNames);
+    this.repeatedEntities = checkNotNull(repeatedEntities);
   }
 
   public String getId() {
@@ -71,18 +70,14 @@ public final class Block {
   }
 
   /**
-   * For repeated blocks, this returns a mapping from an {@link
-   * services.question.types.QuestionType#ENUMERATOR} {@link QuestionDefinition} to the entity name
-   * for that enumerator associated with this repeated block.
-   *
-   * <p>{@link ImmutableMap}s are ordered, and the order represents the nesting of the repeated
-   * entities. The first map entry is for the first enumerator, followed by more and more deeply
-   * nested enumerators.
+   * Returns the list of {@link RepeatedEntity}s associated with this repeated block, where the
+   * first entity is the repeated entity from the first enumerator question, followed by more and
+   * more deeply nested repeated entities.
    *
    * <p>If this is not a repeated block, the map will be empty.
    */
-  public ImmutableMap<QuestionDefinition, String> getEntityNames() {
-    return entityNames;
+  public ImmutableList<RepeatedEntity> getRepeatedEntities() {
+    return repeatedEntities;
   }
 
   /** This block is an enumerator block if its {@link BlockDefinition} is an enumerator. */

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -14,6 +14,7 @@ import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.PresentsErrors;
 import services.program.BlockDefinition;
 import services.program.ProgramQuestionDefinition;
+import services.question.types.QuestionDefinition;
 import services.question.types.ScalarType;
 
 /** Represents a block in the context of a specific user's application. */
@@ -39,6 +40,7 @@ public final class Block {
   private final BlockDefinition blockDefinition;
   private final ApplicantData applicantData;
   private final Path contextualizedPath;
+  private final ImmutableMap<QuestionDefinition, String> entityNames;
 
   private Optional<ImmutableList<ApplicantQuestion>> questionsMemo = Optional.empty();
   private Optional<ImmutableMap<Path, ScalarType>> scalarsMemo = Optional.empty();
@@ -47,11 +49,13 @@ public final class Block {
       String id,
       BlockDefinition blockDefinition,
       ApplicantData applicantData,
-      Path contextualizedPath) {
+      Path contextualizedPath,
+      ImmutableMap<QuestionDefinition, String> entityNames) {
     this.id = id;
     this.blockDefinition = checkNotNull(blockDefinition);
     this.applicantData = checkNotNull(applicantData);
     this.contextualizedPath = checkNotNull(contextualizedPath);
+    this.entityNames = checkNotNull(entityNames);
   }
 
   public String getId() {
@@ -64,6 +68,21 @@ public final class Block {
 
   public String getDescription() {
     return blockDefinition.description();
+  }
+
+  /**
+   * For repeated blocks, this returns a mapping from an {@link
+   * services.question.types.QuestionType#ENUMERATOR} {@link QuestionDefinition} to the entity name
+   * for that enumerator associated with this repeated block.
+   *
+   * <p>{@link ImmutableMap}s are ordered, and the order represents the nesting of the repeated
+   * entities. The first map entry is for the first enumerator, followed by more and more deeply
+   * nested enumerators.
+   *
+   * <p>If this is not a repeated block, the map will be empty.
+   */
+  public ImmutableMap<QuestionDefinition, String> getEntityNames() {
+    return entityNames;
   }
 
   /** This block is an enumerator block if its {@link BlockDefinition} is an enumerator. */

--- a/universal-application-tool-0.0.1/app/services/applicant/RepeatedEntity.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/RepeatedEntity.java
@@ -1,0 +1,24 @@
+package services.applicant;
+
+import com.google.auto.value.AutoValue;
+import services.question.types.QuestionDefinition;
+
+/** A repeated entity represents one of the applicant's answers to an enumerator question. */
+@AutoValue
+public abstract class RepeatedEntity {
+
+  public static RepeatedEntity create(
+      QuestionDefinition enumeratorQuestionDefinition, String entityName) {
+    assert enumeratorQuestionDefinition.isEnumerator();
+    return new AutoValue_RepeatedEntity(enumeratorQuestionDefinition, entityName);
+  }
+
+  /**
+   * The {@link services.question.types.QuestionType#ENUMERATOR} question definition associated with
+   * this repeated entity.
+   */
+  public abstract QuestionDefinition enumeratorQuestionDefinition();
+
+  /** The entity name provided by the applicant. */
+  public abstract String entityName();
+}

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -3,6 +3,7 @@ package services.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import services.Path;
@@ -32,7 +33,9 @@ public class BlockTest {
   public void createNewBlock() {
     BlockDefinition definition =
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
-    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block(
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
     assertThat(block.getId()).isEqualTo("1");
     assertThat(block.getName()).isEqualTo("name");
     assertThat(block.getDescription()).isEqualTo("description");
@@ -51,11 +54,31 @@ public class BlockTest {
 
     new EqualsTester()
         .addEqualityGroup(
-            new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH),
-            new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH))
+            new Block(
+                "1",
+                definition,
+                new ApplicantData(),
+                ApplicantData.APPLICANT_PATH,
+                ImmutableMap.of()),
+            new Block(
+                "1",
+                definition,
+                new ApplicantData(),
+                ApplicantData.APPLICANT_PATH,
+                ImmutableMap.of()))
         .addEqualityGroup(
-            new Block("2", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH),
-            new Block("2", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH))
+            new Block(
+                "2",
+                definition,
+                new ApplicantData(),
+                ApplicantData.APPLICANT_PATH,
+                ImmutableMap.of()),
+            new Block(
+                "2",
+                definition,
+                new ApplicantData(),
+                ApplicantData.APPLICANT_PATH,
+                ImmutableMap.of()))
         .addEqualityGroup(
             new Block(
                 "1",
@@ -63,17 +86,19 @@ public class BlockTest {
                     .addQuestion(ProgramQuestionDefinition.create(question))
                     .build(),
                 new ApplicantData(),
-                ApplicantData.APPLICANT_PATH),
+                ApplicantData.APPLICANT_PATH,
+                ImmutableMap.of()),
             new Block(
                 "1",
                 definition.toBuilder()
                     .addQuestion(ProgramQuestionDefinition.create(question))
                     .build(),
                 new ApplicantData(),
-                ApplicantData.APPLICANT_PATH))
+                ApplicantData.APPLICANT_PATH,
+                ImmutableMap.of()))
         .addEqualityGroup(
-            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH),
-            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH))
+            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH, ImmutableMap.of()),
+            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH, ImmutableMap.of()))
         .testEquals();
   }
 
@@ -82,7 +107,8 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
     ApplicantData applicantData = new ApplicantData();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     ImmutableList<ApplicantQuestion> expected =
         ImmutableList.of(
@@ -96,7 +122,8 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
     ApplicantData applicantData = new ApplicantData();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(
             block.getScalarType(
@@ -143,7 +170,8 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
     ApplicantData applicantData = new ApplicantData();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
   }
@@ -154,7 +182,9 @@ public class BlockTest {
   public void hasErrors_returnsFalseIfBlockHasNoQuestions() {
     BlockDefinition definition =
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
-    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block(
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.hasErrors()).isFalse();
   }
@@ -162,7 +192,9 @@ public class BlockTest {
   @Test
   public void hasErrors_returnsFalseIfQuestionsHaveNoErrors() {
     BlockDefinition definition = setUpBlockWithQuestions();
-    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block(
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.hasErrors()).isFalse();
   }
@@ -171,7 +203,9 @@ public class BlockTest {
   public void isComplete_returnsTrueForBlockWithNoQuestions() {
     BlockDefinition definition =
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
-    Block block = new Block("1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block(
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
@@ -181,7 +215,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     // No questions filled in yet.
     assertThat(block.isCompleteWithoutErrors()).isFalse();
@@ -194,7 +229,8 @@ public class BlockTest {
     answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isCompleteWithoutErrors()).isFalse();
   }
@@ -207,7 +243,8 @@ public class BlockTest {
     answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
@@ -217,7 +254,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isCompleteWithoutErrors()).isFalse();
 
@@ -232,7 +270,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.wasCompletedInProgram(1L)).isFalse();
   }
@@ -242,7 +281,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
     // Answer questions in different program.
     answerNameQuestion(applicantData, 567L);
     answerColorQuestion(applicantData, 567L);
@@ -255,7 +295,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
     answerNameQuestion(applicantData, 1L);
 
     assertThat(block.wasCompletedInProgram(1L)).isFalse();
@@ -266,7 +307,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
     answerNameQuestion(applicantData, 22L);
     answerColorQuestion(applicantData, 22L);
 
@@ -278,7 +320,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
     answerNameQuestion(applicantData, 100L);
     answerColorQuestion(applicantData, 200L);
 
@@ -298,7 +341,8 @@ public class BlockTest {
                     testQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
             .build();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isEnumerator()).isTrue();
   }
@@ -308,7 +352,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isEnumerator()).isFalse();
   }
@@ -325,7 +370,8 @@ public class BlockTest {
             .setDescription("")
             .addQuestion(ProgramQuestionDefinition.create(enumeratorQuestionDefinition))
             .build();
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     ApplicantQuestion enumeratorQuestion = block.getEnumeratorQuestion();
 
@@ -345,7 +391,8 @@ public class BlockTest {
                     testQuestionBank.applicantFile().getQuestionDefinition()))
             .build();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isFileUpload()).isTrue();
   }
@@ -355,7 +402,8 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
 
-    Block block = new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH);
+    Block block =
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
 
     assertThat(block.isFileUpload()).isFalse();
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -3,7 +3,6 @@ package services.applicant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import services.Path;
@@ -35,7 +34,7 @@ public class BlockTest {
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
     Block block =
         new Block(
-            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableList.of());
     assertThat(block.getId()).isEqualTo("1");
     assertThat(block.getName()).isEqualTo("name");
     assertThat(block.getDescription()).isEqualTo("description");
@@ -59,26 +58,26 @@ public class BlockTest {
                 definition,
                 new ApplicantData(),
                 ApplicantData.APPLICANT_PATH,
-                ImmutableMap.of()),
+                ImmutableList.of()),
             new Block(
                 "1",
                 definition,
                 new ApplicantData(),
                 ApplicantData.APPLICANT_PATH,
-                ImmutableMap.of()))
+                ImmutableList.of()))
         .addEqualityGroup(
             new Block(
                 "2",
                 definition,
                 new ApplicantData(),
                 ApplicantData.APPLICANT_PATH,
-                ImmutableMap.of()),
+                ImmutableList.of()),
             new Block(
                 "2",
                 definition,
                 new ApplicantData(),
                 ApplicantData.APPLICANT_PATH,
-                ImmutableMap.of()))
+                ImmutableList.of()))
         .addEqualityGroup(
             new Block(
                 "1",
@@ -87,7 +86,7 @@ public class BlockTest {
                     .build(),
                 new ApplicantData(),
                 ApplicantData.APPLICANT_PATH,
-                ImmutableMap.of()),
+                ImmutableList.of()),
             new Block(
                 "1",
                 definition.toBuilder()
@@ -95,10 +94,10 @@ public class BlockTest {
                     .build(),
                 new ApplicantData(),
                 ApplicantData.APPLICANT_PATH,
-                ImmutableMap.of()))
+                ImmutableList.of()))
         .addEqualityGroup(
-            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH, ImmutableMap.of()),
-            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH, ImmutableMap.of()))
+            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH, ImmutableList.of()),
+            new Block("1", definition, applicant, ApplicantData.APPLICANT_PATH, ImmutableList.of()))
         .testEquals();
   }
 
@@ -108,7 +107,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     ImmutableList<ApplicantQuestion> expected =
         ImmutableList.of(
@@ -123,7 +122,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(
             block.getScalarType(
@@ -171,7 +170,7 @@ public class BlockTest {
     ApplicantData applicantData = new ApplicantData();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
   }
@@ -184,7 +183,7 @@ public class BlockTest {
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
     Block block =
         new Block(
-            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.hasErrors()).isFalse();
   }
@@ -194,7 +193,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
     Block block =
         new Block(
-            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.hasErrors()).isFalse();
   }
@@ -205,7 +204,7 @@ public class BlockTest {
         BlockDefinition.builder().setId(123L).setName("name").setDescription("description").build();
     Block block =
         new Block(
-            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+            "1", definition, new ApplicantData(), ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
@@ -216,7 +215,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     // No questions filled in yet.
     assertThat(block.isCompleteWithoutErrors()).isFalse();
@@ -230,7 +229,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isCompleteWithoutErrors()).isFalse();
   }
@@ -244,7 +243,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
   }
@@ -255,7 +254,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isCompleteWithoutErrors()).isFalse();
 
@@ -271,7 +270,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.wasCompletedInProgram(1L)).isFalse();
   }
@@ -282,7 +281,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
     // Answer questions in different program.
     answerNameQuestion(applicantData, 567L);
     answerColorQuestion(applicantData, 567L);
@@ -296,7 +295,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
     answerNameQuestion(applicantData, 1L);
 
     assertThat(block.wasCompletedInProgram(1L)).isFalse();
@@ -308,7 +307,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
     answerNameQuestion(applicantData, 22L);
     answerColorQuestion(applicantData, 22L);
 
@@ -321,7 +320,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
     answerNameQuestion(applicantData, 100L);
     answerColorQuestion(applicantData, 200L);
 
@@ -342,7 +341,7 @@ public class BlockTest {
             .build();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isEnumerator()).isTrue();
   }
@@ -353,7 +352,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isEnumerator()).isFalse();
   }
@@ -371,7 +370,7 @@ public class BlockTest {
             .addQuestion(ProgramQuestionDefinition.create(enumeratorQuestionDefinition))
             .build();
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     ApplicantQuestion enumeratorQuestion = block.getEnumeratorQuestion();
 
@@ -392,7 +391,7 @@ public class BlockTest {
             .build();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isFileUpload()).isTrue();
   }
@@ -403,7 +402,7 @@ public class BlockTest {
     BlockDefinition definition = setUpBlockWithQuestions();
 
     Block block =
-        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableMap.of());
+        new Block("1", definition, applicantData, ApplicantData.APPLICANT_PATH, ImmutableList.of());
 
     assertThat(block.isFileUpload()).isFalse();
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -95,14 +95,26 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
 
     // Add repeated entities to applicant data
     Path enumerationPath =
-        ApplicantData.APPLICANT_PATH.join(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition().getQuestionPathSegment());
+        ApplicantData.APPLICANT_PATH.join(
+            testQuestionBank
+                .applicantHouseholdMembers()
+                .getQuestionDefinition()
+                .getQuestionPathSegment());
     applicantData.putString(enumerationPath.atIndex(0).join(Scalar.ENTITY_NAME), "first entity");
     applicantData.putString(enumerationPath.atIndex(1).join(Scalar.ENTITY_NAME), "second entity");
     applicantData.putString(enumerationPath.atIndex(2).join(Scalar.ENTITY_NAME), "third entity");
-    Path deepEnumerationPath = enumerationPath.atIndex(2).join(
-        testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition().getQuestionPathSegment());
-    applicantData.putString(deepEnumerationPath.atIndex(0).join(Scalar.ENTITY_NAME), "nested first job");
-    applicantData.putString(deepEnumerationPath.atIndex(1).join(Scalar.ENTITY_NAME), "nested second job");
+    Path deepEnumerationPath =
+        enumerationPath
+            .atIndex(2)
+            .join(
+                testQuestionBank
+                    .applicantHouseholdMemberJobs()
+                    .getQuestionDefinition()
+                    .getQuestionPathSegment());
+    applicantData.putString(
+        deepEnumerationPath.atIndex(0).join(Scalar.ENTITY_NAME), "nested first job");
+    applicantData.putString(
+        deepEnumerationPath.atIndex(1).join(Scalar.ENTITY_NAME), "nested second job");
 
     ReadOnlyApplicantProgramService service =
         new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
@@ -186,11 +198,14 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                 ScalarType.LONG,
                 questionPath.join(Scalar.UPDATED_AT),
                 ScalarType.LONG));
-    assertThat(blocks.get(10).getEntityNames()).containsExactlyEntriesOf(ImmutableMap.of(
-        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
-        "third entity",
-        testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
-        "nested second job"));
+    assertThat(blocks.get(10).getRepeatedEntities())
+        .containsExactly(
+            RepeatedEntity.create(
+                testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                "third entity"),
+            RepeatedEntity.create(
+                testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                "nested second job"));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -136,7 +136,8 @@ public class TestQuestionBank {
   // Deeply nested Number
   public Question applicantHouseholdMemberJobIncome() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_JOB_INCOME, this::applicantHouseholdMemberJobIncome);
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_JOB_INCOME,
+        this::applicantHouseholdMemberJobIncome);
   }
 
   // Radio button
@@ -285,14 +286,14 @@ public class TestQuestionBank {
     QuestionDefinition definition =
         new NumberQuestionDefinition(
             "household members jobs income",
-            Path.create("applicant.applicant_household_members[].household_members_jobs[].household_members_jobs_income"),
+            Path.create(
+                "applicant.applicant_household_members[].household_members_jobs[].household_members_jobs_income"),
             Optional.of(householdMemberJobs.id),
             "The applicant's household member's job's income",
             ImmutableMap.of(Locale.US, "What is the household member's job's income?"),
             ImmutableMap.of(Locale.US, "This is sample help text."));
 
     return maybeSave(definition);
-
   }
 
   // Radio button

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -103,6 +103,12 @@ public class TestQuestionBank {
         QuestionEnum.APPLICANT_HOUSEHOLD_MEMBERS, this::applicantHouseholdMembers);
   }
 
+  // Nested Enumerator
+  public Question applicantHouseholdMemberJobs() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_JOBS, this::applicantHouseholdMemberJobs);
+  }
+
   // File upload
   public Question applicantFile() {
     return questionCache.computeIfAbsent(QuestionEnum.APPLICANT_FILE, this::applicantFile);
@@ -125,6 +131,12 @@ public class TestQuestionBank {
   public Question applicantJugglingNumber() {
     return questionCache.computeIfAbsent(
         QuestionEnum.APPLICANT_JUGGLING_NUMBER, this::applicantJugglingNumber);
+  }
+
+  // Deeply nested Number
+  public Question applicantHouseholdMemberJobIncome() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.APPLICANT_HOUSEHOLD_MEMBER_JOB_INCOME, this::applicantHouseholdMemberJobIncome);
   }
 
   // Radio button
@@ -199,6 +211,20 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  // Nested Enumerator
+  private Question applicantHouseholdMemberJobs(QuestionEnum ignore) {
+    Question householdMembers = applicantHouseholdMembers();
+    QuestionDefinition definition =
+        new EnumeratorQuestionDefinition(
+            "household members jobs",
+            Path.create("applicant.applicant_household_members[].household_members_jobs[]"),
+            Optional.of(householdMembers.id),
+            "The applicant's household member's jobs",
+            ImmutableMap.of(Locale.US, "What are the household member's jobs?"),
+            ImmutableMap.of(Locale.US, "This is sample help text."));
+    return maybeSave(definition);
+  }
+
   // File upload
   private Question applicantFile(QuestionEnum ignore) {
     QuestionDefinition definition =
@@ -251,6 +277,22 @@ public class TestQuestionBank {
             ImmutableMap.of(Locale.US, "How many items can you juggle at one time?"),
             ImmutableMap.of(Locale.US, "This is sample help text."));
     return maybeSave(definition);
+  }
+
+  // Deeply Nested Number
+  private Question applicantHouseholdMemberJobIncome(QuestionEnum ignore) {
+    Question householdMemberJobs = applicantHouseholdMemberJobs();
+    QuestionDefinition definition =
+        new NumberQuestionDefinition(
+            "household members jobs income",
+            Path.create("applicant.applicant_household_members[].household_members_jobs[].household_members_jobs_income"),
+            Optional.of(householdMemberJobs.id),
+            "The applicant's household member's job's income",
+            ImmutableMap.of(Locale.US, "What is the household member's job's income?"),
+            ImmutableMap.of(Locale.US, "This is sample help text."));
+
+    return maybeSave(definition);
+
   }
 
   // Radio button
@@ -317,6 +359,8 @@ public class TestQuestionBank {
     APPLICANT_FILE,
     APPLICANT_HOUSEHOLD_MEMBERS,
     APPLICANT_HOUSEHOLD_MEMBER_NAME,
+    APPLICANT_HOUSEHOLD_MEMBER_JOBS,
+    APPLICANT_HOUSEHOLD_MEMBER_JOB_INCOME,
     APPLICANT_ICE_CREAM,
     APPLICANT_JUGGLING_NUMBER,
     APPLICANT_KITCHEN_TOOLS,


### PR DESCRIPTION
### Description
Blocks now has a list of the (nested) repeated entities associated with it. This should be helpful for styling applicant views, and giving more context to the summary page, and csv export.

### Issue(s)
Progress towards #665 