### PR TITLE
Wait staging to stabilize before running prober

### DIFF
--- a/bin/build-and-push
+++ b/bin/build-and-push
@@ -19,6 +19,13 @@ ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name 
 ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name $STACK | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
 
 aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
-aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"
+
+deadline=$(($(date +%s) + 900))
+until aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"; do
+    if (( $(date +%s) > $deadline )); then
+        echo "deadline exceeded waiting for service update to stabilize"
+        exit 1
+    fi
+done
 
 popd

--- a/bin/deploy-prod
+++ b/bin/deploy-prod
@@ -21,4 +21,11 @@ ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name 
 ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
 
 aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
-aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"
+
+deadline=$(($(date +%s) + 900))
+until aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"; do
+    if (( $(date +%s) > $deadline )); then
+        echo "deadline exceeded waiting for service update to stabilize"
+        exit 1
+    fi
+done

--- a/bin/deploy-staging
+++ b/bin/deploy-staging
@@ -21,4 +21,11 @@ ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name 
 ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform-staging | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
 
 aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
-aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"
+
+deadline=$(($(date +%s) + 900))
+until aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"; do
+    if (( $(date +%s) > $deadline )); then
+        echo "deadline exceeded waiting for service update to stabilize"
+        exit 1
+    fi
+done


### PR DESCRIPTION
### Description
Wait for 15mins instead of default 10mins (40 * 15 secs)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

