### PR TITLE
Deeplinking: only return active programs.

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.TxScope;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -121,8 +122,14 @@ public class ProgramRepository {
             program.getSlug();
             program.save();
           }
+          ImmutableList<Program> activePrograms =
+              versionRepository.get().getActiveVersion().getPrograms();
+          List<Program> programsMatchingSlug =
+              ebeanServer.find(Program.class).where().eq("slug", slug).findList();
           Optional<Program> programMaybe =
-              ebeanServer.find(Program.class).where().eq("slug", slug).findOneOrEmpty();
+              activePrograms.stream()
+                  .filter(activeProgram -> programsMatchingSlug.contains(activeProgram))
+                  .findFirst();
           if (programMaybe.isPresent()) {
             return programMaybe.get();
           }

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -63,6 +63,11 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
                 + " localized_name, localized_description) values ('Old Schema Entry',"
                 + " 'Description', '[]', '[]', '{\"en_us\": \"a\"}', '{\"en_us\": \"b\"}');")
         .execute();
+    DB.sqlUpdate(
+            "insert into versions_programs (versions_id, programs_id) values ("
+                + "(select id from versions where lifecycle_stage = 'active'),"
+                + "(select id from programs where name = 'Old Schema Entry'));")
+        .execute();
 
     Program found = repo.getForSlug("old-schema-entry").toCompletableFuture().join();
 


### PR DESCRIPTION
### Description
This prevents people from guessing draft program slugs or getting errors when several versions of a program exist.

The test is a little weird but it's meant to simulate the migration from v19 to v20.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
