### PR TITLE
Two  probers running at once can break each other.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -6,7 +6,7 @@ on:
 
 # Two probers running at once can break each other.
 concurrency:
-  group: staging/environment
+  group: stagingenvironment
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,6 +4,11 @@ on:
   push:
     branches: main
 
+# Two probers running at once can break each other.
+concurrency:
+  group: staging/environment
+  cancel-in-progress: true
+
 jobs:
   build_container:
     runs-on: ubuntu-18.04 # for older version of awscli.


### PR DESCRIPTION
### Description
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency documents this block.  This says "only one of these can run at a time - cancel the one in progress when you start a new one."

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
