### PR TITLE
Ensure that we request roles from ADFS.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/LoginController.java
+++ b/universal-application-tool-0.0.1/app/controllers/LoginController.java
@@ -10,6 +10,7 @@ import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.play.PlayWebContext;
 import org.pac4j.play.http.PlayHttpActionAdapter;
 import play.mvc.Controller;
@@ -54,6 +55,7 @@ public class LoginController extends Controller {
       return badRequest("Identity provider secrets not configured.");
     }
     PlayWebContext webContext = new PlayWebContext(request);
+    webContext.setRequestAttribute(OidcConfiguration.SCOPE, client.getConfiguration().getScope());
     Optional<RedirectionAction> redirect = client.getRedirectionAction(webContext, sessionStore);
     if (redirect.isPresent()) {
       return (Result) httpActionAdapter.adapt(redirect.get(), webContext);

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -140,6 +140,7 @@ public class SecurityModule extends AbstractModule {
     }
     config.setUseNonce(true);
     config.setWithState(false);
+    config.setScope("openid profile email");
     OidcClient client = new OidcClient(config);
     client.setCallbackUrl(baseUrl + "/callback");
     client.setProfileCreator(
@@ -164,6 +165,7 @@ public class SecurityModule extends AbstractModule {
     config.setDiscoveryURI(this.configuration.getString("adfs.discovery_uri"));
     config.setResponseMode("form_post");
     config.setResponseType("id_token");
+    config.setScope("openid profile email allatclaims");
     config.setUseNonce(true);
     config.setWithState(false);
     OidcClient client = new OidcClient(config);


### PR DESCRIPTION
### Description
This will ensure we can tell whether a user is meant to be a UAT admin or program admin - once it is configured on the ADFS side.  It's a no-op for now.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
