### PR TITLE
Accounts have names of programs they administer

### DIFF
--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -3,6 +3,8 @@ package models;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
+import io.ebean.annotation.DbArray;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +12,7 @@ import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import services.program.ProgramDefinition;
 
 @Entity
 @Table(name = "accounts")
@@ -21,6 +24,9 @@ public class Account extends BaseModel {
 
   @ManyToOne private TrustedIntermediaryGroup memberOfGroup;
   @ManyToOne private TrustedIntermediaryGroup managedByGroup;
+
+  // This must be a mutable collection so we can add to the list later.
+  @DbArray private List<String> adminOf = new ArrayList<>();
 
   private String emailAddress;
 
@@ -62,6 +68,14 @@ public class Account extends BaseModel {
 
   public Optional<TrustedIntermediaryGroup> getManagedByGroup() {
     return Optional.ofNullable(this.managedByGroup);
+  }
+
+  public ImmutableList<String> getAdministeredProgramNames() {
+    return ImmutableList.copyOf(this.adminOf);
+  }
+
+  public void addAdministeredProgram(ProgramDefinition program) {
+    this.adminOf.add(program.adminName());
   }
 
   /**

--- a/universal-application-tool-0.0.1/conf/evolutions/default/21.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/21.sql
@@ -1,0 +1,11 @@
+# --- Create a table that links programs to the program admin accounts that administer them.
+
+# --- !Ups
+alter table accounts add column admin_of varchar[];
+
+create index idx_admin_of on accounts using gin(admin_of);
+
+# --- !Downs
+drop index if exists idx_admin_of;
+
+alter table accounts drop column admin_of;

--- a/universal-application-tool-0.0.1/conf/evolutions/default/21.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/21.sql
@@ -1,4 +1,5 @@
-# --- Create a table that links programs to the program admin accounts that administer them.
+# --- Add a column to accounts with the names of programs that account administers.
+# --- Also add an index using PostgreSQL's GIN index
 
 # --- !Ups
 alter table accounts add column admin_of varchar[];

--- a/universal-application-tool-0.0.1/test/models/AccountTest.java
+++ b/universal-application-tool-0.0.1/test/models/AccountTest.java
@@ -2,21 +2,36 @@ package models;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
+import repository.UserRepository;
 import repository.WithPostgresContainer;
 import services.program.ProgramDefinition;
 import support.ProgramBuilder;
 
 public class AccountTest extends WithPostgresContainer {
 
+  private UserRepository repository;
+
+  @Before
+  public void setup() {
+    repository = instanceOf(UserRepository.class);
+  }
+
   @Test
   public void canAddAdministeredProgram() {
     Account account = new Account();
+    String email = "fake email";
+    account.setEmailAddress(email);
+
     ProgramDefinition one = ProgramBuilder.newDraftProgram("one").build().getProgramDefinition();
     ProgramDefinition two = ProgramBuilder.newDraftProgram("two").build().getProgramDefinition();
-
     account.addAdministeredProgram(one);
     account.addAdministeredProgram(two);
-    assertThat(account.getAdministeredProgramNames()).containsExactly("one", "two");
+
+    account.save();
+
+    Account found = repository.lookupAccount(email).get();
+    assertThat(found.getAdministeredProgramNames()).containsExactly("one", "two");
   }
 }

--- a/universal-application-tool-0.0.1/test/models/AccountTest.java
+++ b/universal-application-tool-0.0.1/test/models/AccountTest.java
@@ -1,0 +1,22 @@
+package models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import repository.WithPostgresContainer;
+import services.program.ProgramDefinition;
+import support.ProgramBuilder;
+
+public class AccountTest extends WithPostgresContainer {
+
+  @Test
+  public void canAddAdministeredProgram() {
+    Account account = new Account();
+    ProgramDefinition one = ProgramBuilder.newDraftProgram("one").build().getProgramDefinition();
+    ProgramDefinition two = ProgramBuilder.newDraftProgram("two").build().getProgramDefinition();
+
+    account.addAdministeredProgram(one);
+    account.addAdministeredProgram(two);
+    assertThat(account.getAdministeredProgramNames()).containsExactly("one", "two");
+  }
+}


### PR DESCRIPTION
### Description
1. `Account` has an array of program names of programs they administer
2. Create a [GIN index](https://www.compose.com/articles/take-a-dip-into-postgresql-arrays/) on `admin_of` so that querying which programs are administered by which account is cheaper

Worked with @ndmckinley 
