### PR TITLE
Return all administrators of a given program - independent of version.

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.inject.Provider;
+import models.Account;
 import models.LifecycleStage;
 import models.Program;
 import models.Version;
@@ -136,5 +137,14 @@ public class ProgramRepository {
           throw new RuntimeException(new ProgramNotFoundException(slug));
         },
         executionContext.current());
+  }
+
+  public ImmutableList<Account> getProgramAdministrators(long programId) throws ProgramNotFoundException {
+    Optional<Program> program = ebeanServer.find(Program.class).setId(programId).findOneOrEmpty();
+    if (program.isEmpty()) {
+        throw new ProgramNotFoundException(programId);
+    }
+    String name = program.get().getProgramDefinition().adminName();
+    return ImmutableList.copyOf(ebeanServer.find(Account.class).where().arrayContains("admin_of", name).findList());
   }
 }

--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -139,12 +139,14 @@ public class ProgramRepository {
         executionContext.current());
   }
 
-  public ImmutableList<Account> getProgramAdministrators(long programId) throws ProgramNotFoundException {
+  public ImmutableList<Account> getProgramAdministrators(long programId)
+      throws ProgramNotFoundException {
     Optional<Program> program = ebeanServer.find(Program.class).setId(programId).findOneOrEmpty();
     if (program.isEmpty()) {
-        throw new ProgramNotFoundException(programId);
+      throw new ProgramNotFoundException(programId);
     }
     String name = program.get().getProgramDefinition().adminName();
-    return ImmutableList.copyOf(ebeanServer.find(Account.class).where().arrayContains("admin_of", name).findList());
+    return ImmutableList.copyOf(
+        ebeanServer.find(Account.class).where().arrayContains("admin_of", name).findList());
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -120,13 +120,11 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
     assertThat(repo.getProgramAdministrators(withAdmins.id)).isEmpty();
     admin.addAdministeredProgram(withAdmins.getProgramDefinition());
     admin.save();
-    assertThat(repo.getProgramAdministrators(withAdmins.id)).isNotEmpty();
-    assertThat(repo.getProgramAdministrators(withAdmins.id)).contains(admin);
+    assertThat(repo.getProgramAdministrators(withAdmins.id)).containsExactly(admin);
 
     // This draft, despite not existing when the admin association happened, should
     // still have the same admin associated.
     Program newDraft = repo.createOrUpdateDraft(withAdmins);
-    assertThat(repo.getProgramAdministrators(newDraft.id)).isNotEmpty();
-    assertThat(repo.getProgramAdministrators(newDraft.id)).contains(admin);
+    assertThat(repo.getProgramAdministrators(newDraft.id)).containsExactly(admin);
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -121,12 +121,12 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
     admin.addAdministeredProgram(withAdmins.getProgramDefinition());
     admin.save();
     assertThat(repo.getProgramAdministrators(withAdmins.id)).isNotEmpty();
-    assertThat(repo.getProgramAdministrators(withAdmins.id)).containsExactly(admin);
+    assertThat(repo.getProgramAdministrators(withAdmins.id)).contains(admin);
 
     // This draft, despite not existing when the admin association happened, should
     // still have the same admin associated.
     Program newDraft = repo.createOrUpdateDraft(withAdmins);
     assertThat(repo.getProgramAdministrators(newDraft.id)).isNotEmpty();
-    assertThat(repo.getProgramAdministrators(newDraft.id)).containsExactly(admin);
+    assertThat(repo.getProgramAdministrators(newDraft.id)).contains(admin);
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -8,9 +8,11 @@ import io.ebean.DB;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import models.Account;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
+import services.program.ProgramNotFoundException;
 import services.program.TranslationNotFoundException;
 
 public class ProgramRepositoryTest extends WithPostgresContainer {
@@ -108,5 +110,23 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
     assertThat(updated.getProgramDefinition().id()).isEqualTo(existing.id);
     assertThat(updated.getProgramDefinition().localizedName())
         .isEqualTo(ImmutableMap.of(Locale.US, "new name"));
+  }
+
+  @Test
+  public void returnsAllAdmins() throws ProgramNotFoundException {
+    Program withAdmins = resourceCreator.insertActiveProgram("with admins");
+    Account admin = new Account();
+    admin.save();
+    assertThat(repo.getProgramAdministrators(withAdmins.id)).isEmpty();
+    admin.addAdministeredProgram(withAdmins.getProgramDefinition());
+    admin.save();
+    assertThat(repo.getProgramAdministrators(withAdmins.id)).isNotEmpty();
+    assertThat(repo.getProgramAdministrators(withAdmins.id)).containsExactly(admin);
+
+    // This draft, despite not existing when the admin association happened, should
+    // still have the same admin associated.
+    Program newDraft = repo.createOrUpdateDraft(withAdmins);
+    assertThat(repo.getProgramAdministrators(newDraft.id)).isNotEmpty();
+    assertThat(repo.getProgramAdministrators(newDraft.id)).containsExactly(admin);
   }
 }


### PR DESCRIPTION
### Description
This makes sure we can track which program admins should be allowed to administer a given program as the versions increment, without relying on flaky transaction logic.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
