### PR TITLE
Remove unnecessary JsonIgnore

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
@@ -18,7 +18,6 @@ public abstract class ProgramQuestionDefinition {
   @JsonProperty("id")
   public abstract long id();
 
-  @JsonIgnore
   abstract Optional<QuestionDefinition> questionDefinition();
 
   @JsonIgnore

--- a/universal-application-tool-0.0.1/app/services/question/QuestionOption.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionOption.java
@@ -1,7 +1,6 @@
 package services.question;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
@@ -21,7 +20,6 @@ public abstract class QuestionOption {
     return new AutoValue_QuestionOption(id, optionText);
   }
 
-  @JsonIgnore
   public LocalizedQuestionOption localize(Locale locale) {
     if (!optionText().containsKey(locale)) {
       throw new RuntimeException(


### PR DESCRIPTION
### Description
We don't need @JsonIgnore on properties that Jackson doesn't automatically detect as getters.
