### PR TITLE
Increase prober timeout

### DIFF
--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest --testTimeout=120000 --forceExit --maxConcurrency=1 --runInBand",
-    "probe": "jest --testTimeout=60000 --forceExit --maxConcurrency=1 --runInBand"
+    "probe": "jest --testTimeout=120000 --forceExit --maxConcurrency=1 --runInBand"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",


### PR DESCRIPTION
### Description
Prober frequently times out, increase the timeout limit to match test.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
