### PR TITLE
Program Admins (views and auth)

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/Authorizers.java
+++ b/universal-application-tool-0.0.1/app/auth/Authorizers.java
@@ -9,7 +9,8 @@ public enum Authorizers {
   APPLICANT(Labels.APPLICANT),
   UAT_ADMIN(Labels.UAT_ADMIN),
   TI(Labels.TI),
-  PROGRAM_ADMIN(Labels.PROGRAM_ADMIN);
+  PROGRAM_ADMIN(Labels.PROGRAM_ADMIN),
+  ANY_ADMIN(Labels.ANY_ADMIN);
 
   /**
    * This Labels class is required to provide references to String constants for {@link
@@ -21,6 +22,7 @@ public enum Authorizers {
     public static final String UAT_ADMIN = "uatadmin";
     public static final String TI = "trustedintermediary";
     public static final String PROGRAM_ADMIN = "programadmin";
+    public static final String ANY_ADMIN = "anyadmin";
   }
 
   private final String label;

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -36,7 +36,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  protected ImmutableSet<Roles> roles(UatProfile profile) {
+  protected ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile) {
     if (profile.getAccount().join().getMemberOfGroup().isPresent()) {
       return ImmutableSet.of(Roles.ROLE_APPLICANT, Roles.ROLE_TI);
     }

--- a/universal-application-tool-0.0.1/app/auth/UatProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfile.java
@@ -69,6 +69,10 @@ public class UatProfile {
     return profileData.getRoles().contains(Roles.ROLE_UAT_ADMIN.toString());
   }
 
+  public boolean isProgramAdmin() {
+    return this.getRoles().contains(Roles.ROLE_PROGRAM_ADMIN.name());
+  }
+
   public String getId() {
     return profileData.getId();
   }
@@ -129,6 +133,20 @@ public class UatProfile {
                         getId(), applicantId));
               }
               return null;
+            });
+  }
+
+  public CompletableFuture<Void> checkProgramAuthorization(String programName) {
+    return this.getAccount()
+        .thenApply(
+            account -> {
+              if (account.getAdministeredProgramNames().stream()
+                  .anyMatch(program -> program.equals(programName))) {
+                return null;
+              }
+              throw new SecurityException(
+                  String.format(
+                      "Account %s is not authorized to access program %s.", getId(), programName));
             });
   }
 }

--- a/universal-application-tool-0.0.1/app/auth/UatProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfile.java
@@ -14,6 +14,7 @@ import models.Account;
 import models.Applicant;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.DatabaseExecutionContext;
+import repository.ProgramRepository;
 
 /**
  * This is a "pure" wrapper of UatProfileData. Since UatProfileData is the serialized data about a
@@ -24,15 +25,18 @@ public class UatProfile {
   private DatabaseExecutionContext dbContext;
   private HttpExecutionContext httpContext;
   private UatProfileData profileData;
+  private ProgramRepository programRepository;
 
   @Inject
   public UatProfile(
       DatabaseExecutionContext dbContext,
       HttpExecutionContext httpContext,
-      UatProfileData profileData) {
+      UatProfileData profileData,
+      ProgramRepository programRepository) {
     this.dbContext = Preconditions.checkNotNull(dbContext);
     this.httpContext = Preconditions.checkNotNull(httpContext);
     this.profileData = Preconditions.checkNotNull(profileData);
+    this.programRepository = Preconditions.checkNotNull(programRepository);
   }
 
   public CompletableFuture<Applicant> getApplicant() {
@@ -143,6 +147,13 @@ public class UatProfile {
               if (account.getAdministeredProgramNames().stream()
                   .anyMatch(program -> program.equals(programName))) {
                 return null;
+              }
+              if (account.getGlobalAdmin()) {
+                // If there are no administrators for this program, then all global
+                // admins count as administrators.
+                if (this.programRepository.getProgramAdministrators(programName).isEmpty()) {
+                  return null;
+                }
               }
               throw new SecurityException(
                   String.format(

--- a/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
@@ -44,7 +44,7 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
 
   protected abstract String emailAttributeName();
 
-  protected abstract ImmutableSet<Roles> roles(UatProfile profile);
+  protected abstract ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile);
 
   /** Merge the two provided profiles into a new UatProfileData. */
   public UatProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
@@ -52,7 +52,7 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
     uatProfile.setEmailAddress(emailAddress).join();
     uatProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
     // Meaning: whatever you signed in with most recently is the role you have.
-    for (Roles role : roles(uatProfile)) {
+    for (Roles role : roles(uatProfile, oidcProfile)) {
       uatProfile.getProfileData().addRole(role.toString());
     }
     return uatProfile.getProfileData();

--- a/universal-application-tool-0.0.1/app/controllers/CiviFormController.java
+++ b/universal-application-tool-0.0.1/app/controllers/CiviFormController.java
@@ -26,4 +26,12 @@ public class CiviFormController extends Controller {
       ProfileUtils profileUtils, Http.Request request, long applicantId) {
     return profileUtils.currentUserProfile(request).orElseThrow().checkAuthorization(applicantId);
   }
+
+  protected CompletableFuture<Void> checkProgramAdminAuthorization(
+      ProfileUtils profileUtils, Http.Request request, String programName) {
+    return profileUtils
+        .currentUserProfile(request)
+        .orElseThrow()
+        .checkProgramAuthorization(programName);
+  }
 }

--- a/universal-application-tool-0.0.1/app/controllers/HomeController.java
+++ b/universal-application-tool-0.0.1/app/controllers/HomeController.java
@@ -54,6 +54,9 @@ public class HomeController extends Controller {
     if (profile.isUatAdmin()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.admin.routes.AdminProgramController.index()));
+    } else if (profile.isProgramAdmin()) {
+      return CompletableFuture.completedFuture(
+          redirect(controllers.admin.routes.ProgramAdminController.index()));
     } else {
       return profile
           .getApplicant()

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import java.time.Clock;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
 import models.Application;
 import org.pac4j.play.java.Secure;
@@ -70,6 +71,8 @@ public class AdminApplicationController extends CiviFormController {
               "Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
+    } catch (CompletionException e) {
+      return unauthorized();
     }
   }
 
@@ -91,6 +94,8 @@ public class AdminApplicationController extends CiviFormController {
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
+    } catch (CompletionException e) {
+      return unauthorized();
     }
     Optional<Application> applicationMaybe =
         this.applicationRepository.getApplication(applicationId).toCompletableFuture().join();
@@ -122,6 +127,8 @@ public class AdminApplicationController extends CiviFormController {
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
+    } catch (CompletionException e) {
+      return unauthorized();
     }
     try {
       ImmutableList<Application> applications = programService.getProgramApplications(programId);

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
@@ -57,7 +57,7 @@ public class AdminApplicationController extends CiviFormController {
     this.exporterService = checkNotNull(exporterService);
   }
 
-  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result downloadAll(Http.Request request, long programId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
@@ -73,7 +73,7 @@ public class AdminApplicationController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result download(Http.Request request, long programId, long applicationId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
@@ -84,7 +84,7 @@ public class AdminApplicationController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result show(Http.Request request, long programId, long applicationId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
@@ -115,7 +115,7 @@ public class AdminApplicationController extends CiviFormController {
             answers));
   }
 
-  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.ANY_ADMIN)
   public Result index(Http.Request request, long programId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
@@ -3,13 +3,14 @@ package controllers.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
+import controllers.CiviFormController;
 import java.time.Clock;
 import java.util.Optional;
 import javax.inject.Inject;
 import models.Application;
 import org.pac4j.play.java.Secure;
-import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
 import repository.ApplicationRepository;
@@ -25,7 +26,7 @@ import views.admin.programs.ProgramApplicationListView;
 import views.admin.programs.ProgramApplicationView;
 
 /** Controller for admins viewing responses to programs. */
-public class AdminApplicationController extends Controller {
+public class AdminApplicationController extends CiviFormController {
 
   private final ProgramService programService;
   private final ApplicantService applicantService;
@@ -33,6 +34,7 @@ public class AdminApplicationController extends Controller {
   private final ProgramApplicationListView applicationListView;
   private final ProgramApplicationView applicationView;
   private final ExporterService exporterService;
+  private final ProfileUtils profileUtils;
   private final Clock clock;
 
   @Inject
@@ -43,20 +45,23 @@ public class AdminApplicationController extends Controller {
       ProgramApplicationListView applicationListView,
       ProgramApplicationView applicationView,
       ApplicationRepository applicationRepository,
+      ProfileUtils profileUtils,
       Clock clock) {
     this.programService = checkNotNull(programService);
     this.applicantService = checkNotNull(applicantService);
     this.applicationListView = checkNotNull(applicationListView);
+    this.profileUtils = checkNotNull(profileUtils);
     this.applicationView = checkNotNull(applicationView);
     this.applicationRepository = checkNotNull(applicationRepository);
     this.clock = clock;
     this.exporterService = checkNotNull(exporterService);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public Result downloadAll(long programId) {
+  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  public Result downloadAll(Http.Request request, long programId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
+      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
       String filename = String.format("%s-%s.csv", program.adminName(), clock.instant().toString());
       String csv = exporterService.getProgramCsv(programId);
       return ok(csv)
@@ -68,13 +73,25 @@ public class AdminApplicationController extends Controller {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public Result download(long programId, long applicationId) {
-    throw new UnsupportedOperationException("Not yet implemented.");
+  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  public Result download(Http.Request request, long programId, long applicationId) {
+    try {
+      ProgramDefinition program = programService.getProgramDefinition(programId);
+      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      throw new UnsupportedOperationException("Not yet implemented.");
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public Result show(long programId, long applicationId) {
+  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  public Result show(Http.Request request, long programId, long applicationId) {
+    try {
+      ProgramDefinition program = programService.getProgramDefinition(programId);
+      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    }
     Optional<Application> applicationMaybe =
         this.applicationRepository.getApplication(applicationId).toCompletableFuture().join();
     if (!applicationMaybe.isPresent()) {
@@ -98,8 +115,14 @@ public class AdminApplicationController extends Controller {
             answers));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public Result index(long programId) {
+  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  public Result index(Http.Request request, long programId) {
+    try {
+      ProgramDefinition program = programService.getProgramDefinition(programId);
+      checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    }
     try {
       ImmutableList<Application> applications = programService.getProgramApplications(programId);
       return ok(applicationListView.render(programId, applications));

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -56,13 +56,8 @@ public class AdminProgramController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result index(Request request) {
-    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
-    if (profile.isEmpty()) {
-      // Should be impossible - can't be a UAT_ADMIN without a profile - but worth
-      // checking just in case.
-      return unauthorized();
-    }
-    return ok(listView.render(this.service.getActiveAndDraftPrograms(), request, profile.get()));
+    Optional<UatProfile> profileMaybe = profileUtils.currentUserProfile(request);
+    return ok(listView.render(this.service.getActiveAndDraftPrograms(), request, profileMaybe));
   }
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -3,8 +3,11 @@ package controllers.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
+import auth.ProfileUtils;
+import auth.UatProfile;
 import controllers.CiviFormController;
 import forms.ProgramForm;
+import java.util.Optional;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
@@ -31,6 +34,7 @@ public class AdminProgramController extends CiviFormController {
   private final ProgramEditView editView;
   private final FormFactory formFactory;
   private final VersionRepository versionRepository;
+  private final ProfileUtils profileUtils;
 
   @Inject
   public AdminProgramController(
@@ -39,18 +43,26 @@ public class AdminProgramController extends CiviFormController {
       ProgramNewOneView newOneView,
       ProgramEditView editView,
       VersionRepository versionRepository,
+      ProfileUtils profileUtils,
       FormFactory formFactory) {
     this.service = checkNotNull(service);
     this.listView = checkNotNull(listView);
     this.newOneView = checkNotNull(newOneView);
     this.editView = checkNotNull(editView);
     this.versionRepository = checkNotNull(versionRepository);
+    this.profileUtils = checkNotNull(profileUtils);
     this.formFactory = checkNotNull(formFactory);
   }
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result index(Request request) {
-    return ok(listView.render(this.service.getActiveAndDraftPrograms(), request));
+    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+    if (profile.isEmpty()) {
+      // Should be impossible - can't be a UAT_ADMIN without a profile - but worth
+      // checking just in case.
+      return unauthorized();
+    }
+    return ok(listView.render(this.service.getActiveAndDraftPrograms(), request, profile.get()));
   }
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)

--- a/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminController.java
@@ -1,0 +1,42 @@
+package controllers.admin;
+
+import auth.Authorizers;
+import auth.ProfileUtils;
+import auth.UatProfile;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import controllers.CiviFormController;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.pac4j.play.java.Secure;
+import play.mvc.Http;
+import play.mvc.Result;
+import services.program.ActiveAndDraftPrograms;
+import services.program.ProgramService;
+import views.admin.programs.ProgramAdministratorProgramListView;
+
+public class ProgramAdminController extends CiviFormController {
+  private final ProgramAdministratorProgramListView listView;
+  private final ProgramService programService;
+  private final ProfileUtils profileUtils;
+
+  @Inject
+  public ProgramAdminController(
+      ProgramAdministratorProgramListView listView,
+      ProgramService programService,
+      ProfileUtils profileUtils) {
+    this.listView = Preconditions.checkNotNull(listView);
+    this.programService = Preconditions.checkNotNull(programService);
+    this.profileUtils = Preconditions.checkNotNull(profileUtils);
+  }
+
+  @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
+  public Result index(Http.Request request) {
+    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+    profile.get();
+    ImmutableList<String> administeredPrograms =
+        profile.get().getAccount().join().getAdministeredProgramNames();
+    ActiveAndDraftPrograms activeAndDraftPrograms = this.programService.getActiveAndDraftPrograms();
+    return ok(listView.render(activeAndDraftPrograms, administeredPrograms));
+  }
+}

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -24,6 +24,7 @@ public class Account extends BaseModel {
 
   @ManyToOne private TrustedIntermediaryGroup memberOfGroup;
   @ManyToOne private TrustedIntermediaryGroup managedByGroup;
+  private boolean globalAdmin;
 
   // This must be a mutable collection so we can add to the list later.
   @DbArray private List<String> adminOf = new ArrayList<>();
@@ -71,7 +72,21 @@ public class Account extends BaseModel {
   }
 
   public ImmutableList<String> getAdministeredProgramNames() {
+    if (this.adminOf == null) {
+      return ImmutableList.of();
+    }
     return ImmutableList.copyOf(this.adminOf);
+  }
+
+  public void setGlobalAdmin(boolean isGlobalAdmin) {
+    this.globalAdmin = isGlobalAdmin;
+    if (this.globalAdmin) {
+      this.adminOf.clear();
+    }
+  }
+
+  public boolean getGlobalAdmin() {
+    return globalAdmin;
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -78,6 +78,10 @@ public class Account extends BaseModel {
     return ImmutableList.copyOf(this.adminOf);
   }
 
+  /**
+   * Set whether or not the user is a global admin. If they are a global admin, they are cleared of
+   * any program-admin role.
+   */
   public void setGlobalAdmin(boolean isGlobalAdmin) {
     this.globalAdmin = isGlobalAdmin;
     if (this.globalAdmin) {

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -94,6 +94,9 @@ public class Account extends BaseModel {
    * programs.
    */
   public void addAdministeredProgram(ProgramDefinition program) {
+    if (this.adminOf == null) {
+      this.adminOf = new ArrayList<>();
+    }
     if (!this.adminOf.contains(program.adminName())) {
       this.adminOf.add(program.adminName());
     }

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -172,7 +172,8 @@ public class SecurityModule extends AbstractModule {
     client.setName("AdClient");
     client.setCallbackUrl(baseUrl + "/callback");
     client.setProfileCreator(
-        new AdfsProfileAdapter(config, client, profileFactory, applicantRepositoryProvider));
+        new AdfsProfileAdapter(
+            config, client, profileFactory, this.configuration, applicantRepositoryProvider));
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     return client;
   }

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
 import org.pac4j.core.authorization.authorizer.RequireAllRolesAuthorizer;
+import org.pac4j.core.authorization.authorizer.RequireAnyRoleAuthorizer;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.config.Config;
@@ -41,8 +42,6 @@ import org.pac4j.play.http.PlayHttpActionAdapter;
 import org.pac4j.play.store.PlayCookieSessionStore;
 import org.pac4j.play.store.ShiroAesDataEncrypter;
 import play.Environment;
-import play.libs.concurrent.HttpExecutionContext;
-import repository.DatabaseExecutionContext;
 import repository.UserRepository;
 
 public class SecurityModule extends AbstractModule {
@@ -102,13 +101,6 @@ public class SecurityModule extends AbstractModule {
   @Singleton
   protected GuestClient guestClient(ProfileFactory profileFactory) {
     return new GuestClient(profileFactory);
-  }
-
-  @Provides
-  @Singleton
-  protected ProfileFactory provideProfileFactory(
-      DatabaseExecutionContext dbContext, HttpExecutionContext httpContext) {
-    return new ProfileFactory(dbContext, httpContext);
   }
 
   @Provides
@@ -219,6 +211,10 @@ public class SecurityModule extends AbstractModule {
         new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()));
     config.addAuthorizer(
         Authorizers.TI.toString(), new RequireAllRolesAuthorizer(Roles.ROLE_TI.toString()));
+    config.addAuthorizer(
+        Authorizers.ANY_ADMIN.toString(),
+        new RequireAnyRoleAuthorizer(
+            Roles.ROLE_UAT_ADMIN.toString(), Roles.ROLE_PROGRAM_ADMIN.toString()));
 
     config.setHttpActionAdapter(PlayHttpActionAdapter.INSTANCE);
     return config;

--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -139,14 +139,17 @@ public class ProgramRepository {
         executionContext.current());
   }
 
+  public ImmutableList<Account> getProgramAdministrators(String programName) {
+    return ImmutableList.copyOf(
+        ebeanServer.find(Account.class).where().arrayContains("admin_of", programName).findList());
+  }
+
   public ImmutableList<Account> getProgramAdministrators(long programId)
       throws ProgramNotFoundException {
     Optional<Program> program = ebeanServer.find(Program.class).setId(programId).findOneOrEmpty();
     if (program.isEmpty()) {
       throw new ProgramNotFoundException(programId);
     }
-    String name = program.get().getProgramDefinition().adminName();
-    return ImmutableList.copyOf(
-        ebeanServer.find(Account.class).where().arrayContains("admin_of", name).findList());
+    return getProgramAdministrators(program.get().getProgramDefinition().adminName());
   }
 }

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -322,7 +322,7 @@ public class UserRepository {
         });
   }
 
-  public ImmutableSet<Account> getUatAdmins() {
+  public ImmutableSet<Account> getGlobalAdmins() {
     return ImmutableSet.copyOf(
         ebeanServer.find(Account.class).where().eq("global_admin", true).findList());
   }

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -6,6 +6,7 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 import auth.UatProfile;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import forms.AddApplicantToTrustedIntermediaryGroupForm;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
@@ -313,11 +314,16 @@ public class UserRepository {
    * @param program the {@link ProgramDefinition} to remove from the given account
    */
   public void removeAdministeredProgram(String accountEmail, ProgramDefinition program) {
-    Optional<Account> maybeAccount = lookupAccount(accountEmail);
-    maybeAccount.ifPresent(
-        account -> {
-          account.removeAdministeredProgram(program);
-          account.save();
-        });
+      Optional<Account> maybeAccount = lookupAccount(accountEmail);
+      maybeAccount.ifPresent(
+              account -> {
+                  account.removeAdministeredProgram(program);
+                  account.save();
+              });
+  }
+
+  public ImmutableSet<Account> getUatAdmins() {
+    return ImmutableSet.copyOf(
+        ebeanServer.find(Account.class).where().eq("global_admin", true).findList());
   }
 }

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -314,12 +314,12 @@ public class UserRepository {
    * @param program the {@link ProgramDefinition} to remove from the given account
    */
   public void removeAdministeredProgram(String accountEmail, ProgramDefinition program) {
-      Optional<Account> maybeAccount = lookupAccount(accountEmail);
-      maybeAccount.ifPresent(
-              account -> {
-                  account.removeAdministeredProgram(program);
-                  account.save();
-              });
+    Optional<Account> maybeAccount = lookupAccount(accountEmail);
+    maybeAccount.ifPresent(
+        account -> {
+          account.removeAdministeredProgram(program);
+          account.save();
+        });
   }
 
   public ImmutableSet<Account> getUatAdmins() {

--- a/universal-application-tool-0.0.1/app/services/role/RoleService.java
+++ b/universal-application-tool-0.0.1/app/services/role/RoleService.java
@@ -31,8 +31,7 @@ public class RoleService {
    * @return an {@link ImmutableSet} of {@link Account}s that are UAT admins.
    */
   public ImmutableSet<Account> getUatAdmins() {
-    // TODO(cdanzi): implement this method
-    return ImmutableSet.of();
+    return userRepository.getUatAdmins();
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/role/RoleService.java
+++ b/universal-application-tool-0.0.1/app/services/role/RoleService.java
@@ -31,8 +31,8 @@ public class RoleService {
    *
    * @return an {@link ImmutableSet} of {@link Account}s that are UAT admins.
    */
-  public ImmutableSet<Account> getUatAdmins() {
-    return userRepository.getUatAdmins();
+  public ImmutableSet<Account> getGlobalAdmins() {
+    return userRepository.getGlobalAdmins();
   }
 
   /**
@@ -57,7 +57,7 @@ public class RoleService {
     ProgramDefinition program = programService.getProgramDefinition(programId);
     // Filter out UAT admins from the list of emails - a UAT admin cannot be a program admin.
     ImmutableSet<String> sysAdminEmails =
-        getUatAdmins().stream()
+        getGlobalAdmins().stream()
             .map(Account::getEmailAddress)
             .filter(address -> !Strings.isNullOrEmpty(address))
             .collect(toImmutableSet());

--- a/universal-application-tool-0.0.1/app/services/role/RoleService.java
+++ b/universal-application-tool-0.0.1/app/services/role/RoleService.java
@@ -3,6 +3,7 @@ package services.role;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -56,7 +57,10 @@ public class RoleService {
     ProgramDefinition program = programService.getProgramDefinition(programId);
     // Filter out UAT admins from the list of emails - a UAT admin cannot be a program admin.
     ImmutableSet<String> sysAdminEmails =
-        getUatAdmins().stream().map(Account::getEmailAddress).collect(toImmutableSet());
+        getUatAdmins().stream()
+            .map(Account::getEmailAddress)
+            .filter(address -> !Strings.isNullOrEmpty(address))
+            .collect(toImmutableSet());
     ImmutableSet.Builder<String> invalidEmailBuilder = ImmutableSet.builder();
     accountEmails.forEach(
         email -> {

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -1,0 +1,141 @@
+package views.admin.programs;
+
+import static j2html.TagCreator.body;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.each;
+import static j2html.TagCreator.h1;
+import static j2html.TagCreator.head;
+import static j2html.TagCreator.p;
+
+import controllers.admin.routes;
+import j2html.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import play.twirl.api.Content;
+import services.program.ActiveAndDraftPrograms;
+import services.program.ProgramDefinition;
+import views.BaseHtmlView;
+import views.admin.AdminLayout;
+import views.components.LinkElement;
+import views.style.ReferenceClasses;
+import views.style.StyleUtils;
+import views.style.Styles;
+
+public class ProgramAdministratorProgramListView extends BaseHtmlView {
+  private final AdminLayout layout;
+
+  @Inject
+  public ProgramAdministratorProgramListView(AdminLayout layout) {
+    this.layout = layout;
+  }
+
+  public Content render(ActiveAndDraftPrograms programs, List<String> authorizedPrograms) {
+    Tag contentDiv =
+        div()
+            .withClasses(Styles.PX_20)
+            .with(
+                h1("Your Programs").withClasses(Styles.MY_4),
+                each(
+                    programs.getProgramNames().stream()
+                        .filter(programName -> authorizedPrograms.contains(programName))
+                        .map(
+                            name ->
+                                this.renderProgramListItem(
+                                    programs.getActiveProgramDefinition(name),
+                                    programs.getDraftProgramDefinition(name)))));
+
+    return layout.render(head(layout.tailwindStyles()), body(contentDiv));
+  }
+
+  public ProgramDefinition getDisplayProgram(
+      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
+    if (draftProgram.isPresent()) {
+      return draftProgram.get();
+    }
+    return activeProgram.get();
+  }
+
+  public Tag renderProgramListItem(
+      Optional<ProgramDefinition> activeProgram, Optional<ProgramDefinition> draftProgram) {
+    String programStatusText = extractProgramStatusText(draftProgram, activeProgram);
+    String lastEditText = "Last updated 2 hours ago."; // TODO: Need to generate this.
+    String viewApplicationsLinkText = "Applications →";
+
+    ProgramDefinition displayProgram = getDisplayProgram(draftProgram, activeProgram);
+
+    String programTitleText = displayProgram.adminName();
+    String programDescriptionText = displayProgram.adminDescription();
+    String blockCountText = "Blocks: " + displayProgram.getBlockCount();
+    String questionCountText = "Questions: " + displayProgram.getQuestionCount();
+
+    Tag topContent =
+        div(
+                div(
+                    p(programStatusText).withClasses(Styles.TEXT_SM, Styles.TEXT_GRAY_700),
+                    div(programTitleText)
+                        .withClasses(
+                            Styles.TEXT_BLACK, Styles.FONT_BOLD, Styles.TEXT_XL, Styles.MB_2)),
+                p().withClasses(Styles.FLEX_GROW),
+                div(p(blockCountText), p(questionCountText))
+                    .withClasses(
+                        Styles.TEXT_RIGHT,
+                        Styles.TEXT_XS,
+                        Styles.TEXT_GRAY_700,
+                        Styles.MR_2,
+                        StyleUtils.applyUtilityClass(StyleUtils.RESPONSIVE_MD, Styles.MR_4)))
+            .withClasses(Styles.FLEX);
+
+    Tag midContent =
+        div(programDescriptionText)
+            .withClasses(
+                Styles.TEXT_GRAY_700,
+                Styles.TEXT_BASE,
+                Styles.MB_8,
+                "line-clamp-3" /* TODO: Add tailwind plugin for line clamping. */);
+
+    Tag bottomContent =
+        div(
+                p(lastEditText).withClasses(Styles.TEXT_GRAY_700, Styles.ITALIC),
+                p().withClasses(Styles.FLEX_GROW),
+                maybeRenderViewApplicationsLink(viewApplicationsLinkText, activeProgram))
+            .withClasses(Styles.FLEX, Styles.TEXT_SM, Styles.W_FULL);
+
+    Tag innerDiv =
+        div(topContent, midContent, bottomContent)
+            .withClasses(
+                Styles.BORDER, Styles.BORDER_GRAY_300, Styles.BG_WHITE, Styles.ROUNDED, Styles.P_4);
+
+    return div(innerDiv)
+        .withClasses(
+            ReferenceClasses.ADMIN_PROGRAM_CARD, Styles.W_FULL, Styles.SHADOW_LG, Styles.MB_4);
+  }
+
+  private String extractProgramStatusText(
+      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
+    if (draftProgram.isPresent() && activeProgram.isPresent()) {
+      return "Active, with draft";
+    } else if (draftProgram.isPresent()) {
+      return "Draft";
+    } else if (activeProgram.isPresent()) {
+      return "Active";
+    }
+    throw new IllegalArgumentException("Program neither active nor draft.");
+  }
+
+  Tag maybeRenderViewApplicationsLink(String text, Optional<ProgramDefinition> activeProgram) {
+    if (activeProgram.isPresent()) {
+      String viewApplicationsLink =
+          routes.AdminApplicationController.index(activeProgram.get().id()).url();
+
+      return new LinkElement()
+          .setId("program-view-apps-link-" + activeProgram.get().id())
+          .setHref(viewApplicationsLink)
+          .setText(text)
+          .setStyles(Styles.MR_2)
+          .asAnchorText();
+    } else {
+      return div();
+    }
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -33,7 +33,8 @@ public final class ProgramIndexView extends BaseHtmlView {
     this.layout = layout;
   }
 
-  public Content render(ActiveAndDraftPrograms programs, Http.Request request, UatProfile profile) {
+  public Content render(
+      ActiveAndDraftPrograms programs, Http.Request request, Optional<UatProfile> profile) {
     Tag contentDiv =
         div()
             .withClasses(Styles.PX_20)
@@ -89,7 +90,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       Optional<ProgramDefinition> activeProgram,
       Optional<ProgramDefinition> draftProgram,
       Http.Request request,
-      UatProfile profile) {
+      Optional<UatProfile> profile) {
     String programStatusText = extractProgramStatusText(draftProgram, activeProgram);
     String lastEditText = "Last updated 2 hours ago."; // TODO: Need to generate this.
 
@@ -210,11 +211,11 @@ public final class ProgramIndexView extends BaseHtmlView {
   }
 
   private Tag maybeRenderViewApplicationsLink(
-      Optional<ProgramDefinition> activeProgram, UatProfile userProfile) {
-    if (activeProgram.isPresent()) {
+      Optional<ProgramDefinition> activeProgram, Optional<UatProfile> userProfile) {
+    if (activeProgram.isPresent() && userProfile.isPresent()) {
       boolean userIsAuthorized = true;
       try {
-        userProfile.checkProgramAuthorization(activeProgram.get().adminName()).join();
+        userProfile.get().checkProgramAuthorization(activeProgram.get().adminName()).join();
       } catch (CompletionException e) {
         userIsAuthorized = false;
       }

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -56,6 +56,7 @@ adfs.client_id = ${?ADFS_CLIENT_ID}
 adfs.secret = ${?ADFS_SECRET}
 adfs.discovery_uri = "https://sts.seattle.gov/adfs/.well-known/openid-configuration"
 adfs.discovery_uri = ${?ADFS_DISCOVERY_URI}
+adfs.admin_group = "ad\\ITD_CiviForm_Admins_Test"
 
 base_url = "http://localhost:9000"
 base_url = ${?BASE_URL}

--- a/universal-application-tool-0.0.1/conf/evolutions/default/25.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/25.sql
@@ -1,0 +1,8 @@
+# --- Add a column to accounts that determines whether an account is a global admin.
+# --- Also ensure that no global admins can be program admins.
+
+# --- !Ups
+alter table accounts add column global_admin boolean default false constraint ck_account_admin CHECK(admin_of is null or array_length(admin_of, 1) = 0 or global_admin = false);
+
+# --- !Downs
+alter table accounts drop column global_admin;

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -64,10 +64,10 @@ GET     /admin/tiDash                      controllers.ti.TrustedIntermediaryCon
 POST    /admin/tiGroups/:id/addApplicant   controllers.ti.TrustedIntermediaryController.addApplicant(id: Long, request: Request)
 
 # Controller for admins only, related to applications
-GET     /admin/programs/:programId/applications                           controllers.admin.AdminApplicationController.index(programId: Long)
-GET     /admin/programs/:programId/applications/all                       controllers.admin.AdminApplicationController.downloadAll(programId: Long)
-GET     /admin/programs/:programId/applications/:applicationId            controllers.admin.AdminApplicationController.show(programId: Long, applicationId: Long)
-GET     /admin/programs/:programId/applications/:applicationId/download   controllers.admin.AdminApplicationController.download(programId: Long, applicationId: Long)
+GET     /admin/programs/:programId/applications                           controllers.admin.AdminApplicationController.index(request: Request, programId: Long)
+GET     /admin/programs/:programId/applications/all                       controllers.admin.AdminApplicationController.downloadAll(request: Request, programId: Long)
+GET     /admin/programs/:programId/applications/:applicationId            controllers.admin.AdminApplicationController.show(request: Request, programId: Long, applicationId: Long)
+GET     /admin/programs/:programId/applications/:applicationId/download   controllers.admin.AdminApplicationController.download(request: Request, programId: Long, applicationId: Long)
 
 GET     /demo/new                   controllers.J2HtmlDemoController.newOne(request: Request)
 POST    /demo                       controllers.J2HtmlDemoController.create(request: Request)
@@ -88,6 +88,9 @@ GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit       
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/review                 controllers.applicant.ApplicantProgramBlocksController.review(request: Request, applicantId: Long, programId: Long, blockId: String)
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview   controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview              controllers.applicant.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
+
+# Methods for program admins
+GET     /programAdmin       controllers.admin.ProgramAdminController.index(request: Request)
 
 # Deep-link methods
 GET     /programs/:programName      controllers.applicant.DeepLinkController.programByName(request: Request, programName: String)


### PR DESCRIPTION
### Description
This adds the view for admins (program and global) to view / download applications.

It also does all the auth plumbing.  the rule is that if there are any admins assigned to a program, global admins are not able to view applications.  If there are no admins assigned to a program, global admins are the fallback - they can view the applications.

Global admin state is extracted from ADFS membership in a particular group.  That group is currently configured to be the TEST version of the city's ADFS group for admins, but we'll swap it to prod (in prod) shortly before go-live.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)