### PR TITLE
Transactionality of drafts

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -5,6 +5,8 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
+import io.ebean.Transaction;
+import io.ebean.TxScope;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
@@ -48,29 +50,33 @@ public class QuestionRepository {
    * draft if there isn't one.
    */
   public Question updateOrCreateDraft(QuestionDefinition definition) {
-    Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
-    Optional<Question> existingDraft = draftVersion.getQuestionByName(definition.getName());
-    try {
-      if (existingDraft.isPresent()) {
-        Question updatedDraft =
-            new Question(
-                new QuestionDefinitionBuilder(definition).setId(existingDraft.get().id).build());
-        this.updateQuestionSync(updatedDraft);
-        return updatedDraft;
-      } else {
-        Question newDraft =
-            new Question(new QuestionDefinitionBuilder(definition).setId(null).build());
-        insertQuestionSync(newDraft);
-        newDraft.addVersion(draftVersion);
-        newDraft.save();
-        versionRepositoryProvider.get().updateProgramsForNewDraftQuestion(definition.getId());
-        return newDraft;
+    try (Transaction transaction = ebeanServer.beginTransaction(TxScope.requiresNew())) {
+      Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
+      Optional<Question> existingDraft = draftVersion.getQuestionByName(definition.getName());
+      try {
+        if (existingDraft.isPresent()) {
+          Question updatedDraft =
+                  new Question(
+                          new QuestionDefinitionBuilder(definition).setId(existingDraft.get().id).build());
+          this.updateQuestionSync(updatedDraft);
+          transaction.commit();
+          return updatedDraft;
+        } else {
+          Question newDraft =
+                  new Question(new QuestionDefinitionBuilder(definition).setId(null).build());
+          insertQuestionSync(newDraft);
+          newDraft.addVersion(draftVersion);
+          newDraft.save();
+          versionRepositoryProvider.get().updateProgramsForNewDraftQuestion(definition.getId());
+          transaction.commit();
+          return newDraft;
+        }
+      } catch (UnsupportedQuestionTypeException e) {
+        // This should not be able to happen since the provided question definition is inherently
+        // valid.
+        // Throw runtime exception so callers don't have to deal with it.
+        throw new RuntimeException(e);
       }
-    } catch (UnsupportedQuestionTypeException e) {
-      // This should not be able to happen since the provided question definition is inherently
-      // valid.
-      // Throw runtime exception so callers don't have to deal with it.
-      throw new RuntimeException(e);
     }
   }
 

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -50,8 +50,8 @@ public class QuestionRepository {
    * draft if there isn't one.
    */
   public Question updateOrCreateDraft(QuestionDefinition definition) {
+    Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
     try (Transaction transaction = ebeanServer.beginTransaction(TxScope.requiresNew())) {
-      Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
       Optional<Question> existingDraft = draftVersion.getQuestionByName(definition.getName());
       try {
         if (existingDraft.isPresent()) {

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -56,14 +56,14 @@ public class QuestionRepository {
       try {
         if (existingDraft.isPresent()) {
           Question updatedDraft =
-                  new Question(
-                          new QuestionDefinitionBuilder(definition).setId(existingDraft.get().id).build());
+              new Question(
+                  new QuestionDefinitionBuilder(definition).setId(existingDraft.get().id).build());
           this.updateQuestionSync(updatedDraft);
           transaction.commit();
           return updatedDraft;
         } else {
           Question newDraft =
-                  new Question(new QuestionDefinitionBuilder(definition).setId(null).build());
+              new Question(new QuestionDefinitionBuilder(definition).setId(null).build());
           insertQuestionSync(newDraft);
           newDraft.addVersion(draftVersion);
           newDraft.save();

--- a/universal-application-tool-0.0.1/app/repository/VersionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/VersionRepository.java
@@ -129,9 +129,16 @@ public class VersionRepository {
         return newDraftVersion;
       } catch (NonUniqueResultException | SerializableConflictException | RollbackException e) {
         transaction.rollback(e);
+        // We must end the transaction here since we are going to recurse and try again.
+        // We cannot have this transaction on the thread-local transaction stack when that
+        // happens.
         transaction.end();
         return getDraftVersion();
       } finally {
+        // This may come after a prior call to `transaction.end` in the event of a
+        // precondition failure - this is okay, since it a double-call to `end` on
+        // a particular transaction.  Only double calls to ebeanServer.endTransaction
+        // must be avoided.
         transaction.end();
       }
     }

--- a/universal-application-tool-0.0.1/app/repository/VersionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/VersionRepository.java
@@ -113,7 +113,9 @@ public class VersionRepository {
       // are forced to retry.  This is expensive in relative terms, but new drafts
       // are very rare.  It is unlikely this will represent a real performance penalty
       // for any applicant - or even any admin, really.
-      Transaction transaction = ebeanServer.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE));
+      Transaction transaction =
+          ebeanServer.beginTransaction(
+              TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE));
       try {
         Version newDraftVersion = new Version(LifecycleStage.DRAFT);
         ebeanServer.insert(newDraftVersion);


### PR DESCRIPTION
### Description
This creates a new transaction, suspends the one that's pending, and ensures that the pending one is reactivated when we return from this function.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
