### PR TITLE
Feature 665 - Export repeated data in CSVs

### DIFF
--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -37,7 +37,7 @@ describe('normal application flow', () => {
 
     await adminPrograms.viewApplications(programName);
     const csvContent = await adminPrograms.getCsv();
-    expect(csvContent).toContain('sarah,COLUMN_EMPTY,smith');
+    expect(csvContent).toContain('sarah,,smith');
     await endSession(browser);
   })
 })

--- a/universal-application-tool-0.0.1/app/services/applicant/AnswerData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/AnswerData.java
@@ -26,6 +26,12 @@ public abstract class AnswerData {
   /** The {@link models.Question} id this is an answer for. */
   public abstract long questionId();
 
+  /**
+   * Whether this is an answer for an {@link services.question.types.QuestionType#ENUMERATOR}
+   * question.
+   */
+  public abstract boolean isEnumeratorAnswer();
+
   /** The localized question text */
   public abstract String questionText();
 
@@ -51,6 +57,8 @@ public abstract class AnswerData {
     public abstract Builder setBlockId(String blockId);
 
     public abstract Builder setQuestionId(long questionId);
+
+    public abstract Builder setIsEnumeratorAnswer(boolean isEnumeratorAnswer);
 
     public abstract Builder setQuestionText(String questionText);
 

--- a/universal-application-tool-0.0.1/app/services/applicant/AnswerData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/AnswerData.java
@@ -23,12 +23,14 @@ public abstract class AnswerData {
   /** The {@link Block} id for where this question resides within the current program. */
   public abstract String blockId();
 
-  /** The {@link models.Question} id this is an answer for. */
-  public abstract long questionId();
+  /** The index of the {@link models.Question} this is an answer for in the block it appeared in. */
+  public abstract int questionIndex();
 
   /**
    * Whether this is an answer for an {@link services.question.types.QuestionType#ENUMERATOR}
    * question.
+   *
+   * <p>The Administrators don't use answers to enumerator questions in the views.
    */
   public abstract boolean isEnumeratorAnswer();
 
@@ -56,7 +58,7 @@ public abstract class AnswerData {
 
     public abstract Builder setBlockId(String blockId);
 
-    public abstract Builder setQuestionId(long questionId);
+    public abstract Builder setQuestionIndex(int questionIndex);
 
     public abstract Builder setIsEnumeratorAnswer(boolean isEnumeratorAnswer);
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -24,6 +24,7 @@ import services.Path;
 import services.applicant.question.Scalar;
 import services.program.PathNotInBlockException;
 import services.program.ProgramDefinition;
+import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.exceptions.UnsupportedScalarTypeException;
 import services.question.types.ScalarType;
@@ -76,9 +77,14 @@ public class ApplicantServiceImpl implements ApplicantService {
   @Override
   public CompletionStage<ReadOnlyApplicantProgramService> getReadOnlyApplicantProgramService(
       Application application) {
-    return CompletableFuture.completedFuture(
-        new ReadOnlyApplicantProgramServiceImpl(
-            application.getApplicantData(), application.getProgram().getProgramDefinition()));
+    try {
+      return CompletableFuture.completedFuture(
+          new ReadOnlyApplicantProgramServiceImpl(
+              application.getApplicantData(),
+              programService.getProgramDefinition(application.getProgram().id)));
+    } catch (ProgramNotFoundException e) {
+      throw new RuntimeException("Cannot find a program that has applications for it.", e);
+    }
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -205,7 +205,9 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
     ImmutableList<Block> blocks = getAllBlocks();
     for (Block block : blocks) {
-      for (ApplicantQuestion question : block.getQuestions()) {
+      ImmutableList<ApplicantQuestion> questions = block.getQuestions();
+      for (int questionIndex = 0; questionIndex < questions.size(); questionIndex++) {
+        ApplicantQuestion question = questions.get(questionIndex);
         String questionText = question.getQuestionText();
         String answerText = question.errorsPresenter().getAnswerString();
         Optional<Long> timestamp = question.getLastUpdatedTimeMetadata();
@@ -216,7 +218,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
             AnswerData.builder()
                 .setProgramId(programDefinition.id())
                 .setBlockId(block.getId())
-                .setQuestionId(question.getQuestionDefinition().getId())
+                .setQuestionIndex(questionIndex)
                 .setIsEnumeratorAnswer(question.getQuestionDefinition().isEnumerator())
                 .setQuestionText(questionText)
                 .setAnswerText(answerText)

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -217,6 +217,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
                 .setProgramId(programDefinition.id())
                 .setBlockId(block.getId())
                 .setQuestionId(question.getQuestionDefinition().getId())
+                .setIsEnumeratorAnswer(question.getQuestionDefinition().isEnumerator())
                 .setQuestionText(questionText)
                 .setAnswerText(answerText)
                 .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))

--- a/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
+++ b/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
@@ -11,6 +11,8 @@ import org.apache.commons.csv.CSVPrinter;
 import services.program.Column;
 
 public class CsvExporter {
+  private final String EMPTY_VALUE = "COLUMN_EMPTY";
+
   private boolean wroteHeaders;
   private ImmutableList<Column> columns;
 
@@ -29,6 +31,10 @@ public class CsvExporter {
     }
   }
 
+  protected ImmutableList<Column> getColumns() {
+    return columns;
+  }
+
   /**
    * The CSV exporter will write the headers on first call to services.export(). It does not store
    * the writer between calls. Since it is intended for many applications, this function is intended
@@ -39,12 +45,12 @@ public class CsvExporter {
 
     this.writeHeadersOnFirstExport(printer);
 
-    for (Column column : this.columns) {
+    for (Column column : getColumns()) {
       switch (column.columnType()) {
         case APPLICANT:
           Optional<String> value =
               application.getApplicantData().readAsString(column.jsonPath().orElseThrow());
-          printer.print(value.orElse("COLUMN_EMPTY"));
+          printer.print(value.orElse(EMPTY_VALUE));
           break;
         case ID:
           printer.print(application.id);

--- a/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
+++ b/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
@@ -11,7 +11,7 @@ import org.apache.commons.csv.CSVPrinter;
 import services.program.Column;
 
 public class CsvExporter {
-  private final String EMPTY_VALUE = "COLUMN_EMPTY";
+  private final String EMPTY_VALUE = "";
 
   private boolean wroteHeaders;
   private ImmutableList<Column> columns;

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -84,7 +84,7 @@ public class ExporterService {
    * applications. This means if one application had a question repeated for N repeated entities,
    * then there would be N columns for each of that question's scalars.
    */
-  private CsvExportConfig generateDefaultCsvConfig(long programId) {
+  CsvExportConfig generateDefaultCsvConfig(long programId) {
     ImmutableList<Application> applications;
     try {
       applications = programService.getProgramApplications(programId);

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -463,7 +463,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     assertThat(result.get(2).answerText()).isEqualTo("123 Rhode St.\nSeattle, WA, 12345");
 
     // Check single and multi select answers
-    assertThat(result.get(3).questionId()).isEqualTo(singleSelectQuestionDefinition.getId());
+    assertThat(result.get(3).questionIndex()).isEqualTo(3);
     assertThat(result.get(3).scalarAnswersInDefaultLocale())
         .containsExactly(
             new AbstractMap.SimpleEntry<>(
@@ -471,7 +471,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                     .join(singleSelectQuestionDefinition.getQuestionPathSegment())
                     .join(Scalar.SELECTION),
                 "winter"));
-    assertThat(result.get(4).questionId()).isEqualTo(multiSelectQuestionDefinition.getId());
+    assertThat(result.get(4).questionIndex()).isEqualTo(4);
     assertThat(result.get(4).scalarAnswersInDefaultLocale())
         .containsExactly(
             new AbstractMap.SimpleEntry<>(
@@ -481,10 +481,10 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                 "toaster, pepper grinder"));
 
     // check enumerator and repeated answers
-    assertThat(result.get(5).questionId()).isEqualTo(enumeratorQuestionDefinition.getId());
+    assertThat(result.get(5).questionIndex()).isEqualTo(0);
     assertThat(result.get(5).scalarAnswersInDefaultLocale())
         .containsExactly(new AbstractMap.SimpleEntry<>(enumeratorPath, "enum one\nenum two"));
-    assertThat(result.get(6).questionId()).isEqualTo(repeatedQuestionDefinition.getId());
+    assertThat(result.get(6).questionIndex()).isEqualTo(0);
     assertThat(result.get(6).scalarAnswersInDefaultLocale())
         .containsExactlyEntriesOf(
             ImmutableMap.of(
@@ -503,7 +503,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                     .join(repeatedQuestionDefinition.getQuestionPathSegment())
                     .join(Scalar.LAST_NAME),
                 "last"));
-    assertThat(result.get(7).questionId()).isEqualTo(repeatedQuestionDefinition.getId());
+    assertThat(result.get(7).questionIndex()).isEqualTo(0);
     assertThat(result.get(7).scalarAnswersInDefaultLocale())
         .containsExactlyEntriesOf(
             ImmutableMap.of(

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -226,6 +226,10 @@ public class ProgramBuilder {
       return this;
     }
 
+    public BlockBuilder withQuestions(Question... questions) {
+      return withQuestions(ImmutableList.copyOf(questions));
+    }
+
     public BlockBuilder withQuestions(ImmutableList<Question> questions) {
       ImmutableList<ProgramQuestionDefinition> pqds =
           questions.stream()


### PR DESCRIPTION
### Description
Update the CSV exporter to handle repeated answers.

NOTE: the CSV will not include answers to enumerator questions. The entity names picked by the applicant shouldn't matter to the admins.

### Screenshot
![image](https://user-images.githubusercontent.com/12072571/117739045-4c758f80-b1b2-11eb-9fa5-11951a904cfc.png)

### Issue(s)
Progress towards #665