### PR TITLE
Render a view for managing program admins for a given program

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -57,7 +57,10 @@ function changeUpdateBlockButtonState(event: Event) {
   }
 }
 
-/** In the admin question form - add a new option input for each new question answer option. */
+/**
+ * Copy the specified hidden template and append it to the end of the parent divContainerId,
+ * above the add button (addButtonId).
+ */
 function addNewInput(inputTemplateId: string, addButtonId: string, divContainerId: string) {
   // Copy the answer template and remove ID and hidden properties.
   const newField = document.getElementById(inputTemplateId).cloneNode(true) as HTMLElement;
@@ -72,7 +75,10 @@ function addNewInput(inputTemplateId: string, addButtonId: string, divContainerI
   document.getElementById(divContainerId).insertBefore(newField, button);
 }
 
-/** In the admin question form - remove an answer option input for multi-option questions. */
+/**
+ * Removes an input field and its associated elements, like the remove button. All
+ * elements must be contained in a parent div.
+ */
 function removeInput(event: Event) {
 
   // Get the parent div, which contains the input field and remove button, and remove it.

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -58,22 +58,22 @@ function changeUpdateBlockButtonState(event: Event) {
 }
 
 /** In the admin question form - add a new option input for each new question answer option. */
-function addNewQuestionAnswerOptionForm(event: Event) {
+function addNewInput(inputTemplateId: string, addButtonId: string, divContainerId: string) {
   // Copy the answer template and remove ID and hidden properties.
-  const newField = document.getElementById("multi-option-question-answer-template").cloneNode(true) as HTMLElement;
+  const newField = document.getElementById(inputTemplateId).cloneNode(true) as HTMLElement;
   newField.classList.remove("hidden");
   newField.removeAttribute("id");
 
   // Register the click event handler for the remove button.
-  newField.querySelector("[type=button]").addEventListener("click", removeQuestionOption);
+  newField.querySelector("[type=button]").addEventListener("click", removeInput);
 
   // Find the add option button and insert the new option input field before it.
-  const button = document.getElementById("add-new-option");
-  document.getElementById("question-settings").insertBefore(newField, button);
+  const button = document.getElementById(addButtonId);
+  document.getElementById(divContainerId).insertBefore(newField, button);
 }
 
 /** In the admin question form - remove an answer option input for multi-option questions. */
-function removeQuestionOption(event: Event) {
+function removeInput(event: Event) {
 
   // Get the parent div, which contains the input field and remove button, and remove it.
   const optionDiv = (event.target as Element).parentNode;
@@ -83,7 +83,7 @@ function removeQuestionOption(event: Event) {
 
 /** In the enumerator form - add a new input field for a repeated entity. */
 function addNewEnumeratorField(event: Event) {
-  // Copy the enuemrator field template
+  // Copy the enumerator field template
   const newField = document.getElementById("enumerator-field-template").cloneNode(true) as HTMLElement;
   newField.classList.remove("hidden");
   newField.removeAttribute("id");
@@ -114,16 +114,30 @@ window.addEventListener('load', (event) => {
   // Configure the button on the admin question form to add more answer options
   const questionOptionButton = document.getElementById("add-new-option");
   if (questionOptionButton) {
-    questionOptionButton.addEventListener("click", addNewQuestionAnswerOptionForm);
+    questionOptionButton.addEventListener("click", function() {
+      addNewInput("multi-option-question-answer-template", "add-new-option", "question-settings");
+    });
   }
+
+  // Bind click handler for remove options in multi-option edit view
+  Array.from(document.querySelectorAll('.multi-option-question-field-remove-button')).forEach(
+    el => el.addEventListener("click", removeInput));
+
+  // Configure the button on the manage program admins form to add more email inputs
+  const adminEmailButton = document.getElementById("add-program-admin-button");
+  if (adminEmailButton) {
+    adminEmailButton.addEventListener("click", function() {
+      addNewInput("program-admin-email-template", "add-program-admin-button", "program-admin-emails");
+    });
+  }
+
+  // Bind click handler for removing program admins in the program admin management view
+  Array.from(document.querySelectorAll('.cf-program-admin-remove-button')).forEach(
+    el => el.addEventListener("click", removeInput));
 
   // Configure the button on the enumerator question form to add more enumerator field options
   const enumeratorOptionButton = document.getElementById("enumerator-field-add-button");
   if (enumeratorOptionButton) {
     enumeratorOptionButton.addEventListener("click", addNewEnumeratorField);
   }
-
-  // Bind click handler for remove options in multi-option edit view
-  Array.from(document.querySelectorAll('.multi-option-question-field-remove-button')).forEach(
-    el => el.addEventListener("click", removeQuestionOption));
 });

--- a/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminManagementController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminManagementController.java
@@ -1,40 +1,68 @@
 package controllers.admin;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static play.mvc.Results.badRequest;
 import static play.mvc.Results.notFound;
 import static play.mvc.Results.ok;
 import static play.mvc.Results.redirect;
 
 import auth.Authorizers;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import forms.AddProgramAdminForm;
 import java.util.Optional;
 import javax.inject.Inject;
+import models.Account;
+import models.Program;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
 import play.data.FormFactory;
 import play.mvc.Http;
 import play.mvc.Result;
+import repository.ProgramRepository;
 import services.CiviFormError;
 import services.program.ProgramNotFoundException;
 import services.role.RoleService;
+import views.admin.programs.ManageProgramAdminsView;
 
 public class ProgramAdminManagementController {
 
+  private final ManageProgramAdminsView manageAdminsView;
+  private final ProgramRepository programRepository;
   private final RoleService roleService;
   private final FormFactory formFactory;
 
   @Inject
-  public ProgramAdminManagementController(RoleService roleService, FormFactory formFactory) {
+  public ProgramAdminManagementController(
+      ManageProgramAdminsView manageAdminsView,
+      ProgramRepository programRepository,
+      RoleService roleService,
+      FormFactory formFactory) {
+    this.manageAdminsView = manageAdminsView;
+    this.programRepository = programRepository;
     this.roleService = roleService;
     this.formFactory = formFactory;
   }
 
   /** Displays a form for managing program admins of a given program. */
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
-  public Result edit(long programId) {
-    // TODO: Return a view for editing program admin rights.
-    return ok();
+  public Result edit(Http.Request request, long programId) {
+    Optional<Program> program =
+        programRepository.lookupProgram(programId).toCompletableFuture().join();
+    if (program.isEmpty()) {
+      return notFound(String.format("Program with ID %s was not found", programId));
+    }
+
+    try {
+      ImmutableList<String> programAdmins =
+          programRepository.getProgramAdministrators(programId).stream()
+              .map(Account::getEmailAddress)
+              .collect(toImmutableList());
+      return ok(
+          manageAdminsView.render(request, program.get().getProgramDefinition(), programAdmins));
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.getLocalizedMessage());
+    }
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -74,8 +74,14 @@ public class Account extends BaseModel {
     return ImmutableList.copyOf(this.adminOf);
   }
 
+  /**
+   * If this account does not already administer this program, add it to the list of administered
+   * programs.
+   */
   public void addAdministeredProgram(ProgramDefinition program) {
-    this.adminOf.add(program.adminName());
+    if (!this.adminOf.contains(program.adminName())) {
+      this.adminOf.add(program.adminName());
+    }
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
@@ -18,12 +18,14 @@ import views.BaseHtmlView;
 import views.admin.AdminLayout;
 import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
+import views.style.StyleUtils;
 import views.style.Styles;
 
-/**
- * Renders a form for adding and removing program admins via email for a given program.
- */
+/** Renders a form for adding and removing program admins via email for a given program. */
 public class ManageProgramAdminsView extends BaseHtmlView {
+
+  private static final String EMAIL_FIELD_STYLES =
+      StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_ROW);
 
   private final AdminLayout layout;
 
@@ -42,21 +44,25 @@ public class ManageProgramAdminsView extends BaseHtmlView {
             renderAdminForm(request, program.id(), existingAdminEmails)));
   }
 
-  /** Render a form with inputs for program admin emails. If program admins exist, the input fields will be pre-populated with their email addresses. */
+  /**
+   * Render a form with inputs for program admin emails. If program admins exist, the input fields
+   * will be pre-populated with their email addresses.
+   */
   private ContainerTag renderAdminForm(
       Http.Request request, long programId, ImmutableList<String> existingAdminEmails) {
     ContainerTag emailFields =
         div()
             .withId("program-admin-emails")
+            .withClasses(Styles.ML_4)
             .with(each(existingAdminEmails, email -> adminEmailInput(Optional.of(email))))
-            .with(button("Add admin").withId("add-program-admin-button"));
+            .with(button("Add admin").withId("add-program-admin-button").withClasses(Styles.MY_2));
 
     return form()
         .with(makeCsrfTokenInputTag(request))
         .withAction(routes.ProgramAdminManagementController.update(programId).url())
         .withMethod("POST")
         .with(emailFields)
-        .with(submitButton("Save"));
+        .with(submitButton("Save").withClasses(Styles.MY_4));
   }
 
   private ContainerTag adminEmailInput(Optional<String> existing) {
@@ -65,16 +71,19 @@ public class ManageProgramAdminsView extends BaseHtmlView {
             .setFieldName("adminEmails[]")
             .setPlaceholderText("New admin email")
             .setValue(existing)
-            .getContainer();
-    Tag removeAdminButton = button("Remove").withClasses(ReferenceClasses.PROGRAM_ADMIN_REMOVE_BUTTON);
+            .getContainer()
+            .withClasses(Styles.FLEX, Styles.M_2);
+    Tag removeAdminButton =
+        button("Remove")
+            .withClasses(ReferenceClasses.PROGRAM_ADMIN_REMOVE_BUTTON, Styles.FLEX, Styles.M_2);
 
-    return div().with(input, removeAdminButton);
+    return div().with(input, removeAdminButton).withClasses(EMAIL_FIELD_STYLES);
   }
 
   /** A hidden template for adding and removing admins of a given program. */
   private ContainerTag adminEmailTemplate() {
     return adminEmailInput(Optional.empty())
         .withId("program-admin-email-template")
-        .withClasses(Styles.HIDDEN);
+        .withClasses(Styles.HIDDEN, EMAIL_FIELD_STYLES);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
@@ -26,7 +26,7 @@ public class ManageProgramAdminsView extends BaseHtmlView {
 
   private static final String EMAIL_FIELD_STYLES =
       StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_ROW);
-  private static final String PAGE_TITLE = "Manage Admins for Program: %s";
+  private static final String PAGE_TITLE = "Manage Admins for Program: ";
   private static final String ADD_ADMIN_BUTTON = "Add admin";
   private static final String SUBMIT_BUTTON = "Save";
   private static final String INPUT_PLACEHOLDER = "New admin email";
@@ -48,7 +48,7 @@ public class ManageProgramAdminsView extends BaseHtmlView {
     // Display a form with a list of inputs for adding and removing
     return layout.render(
         body(
-            renderHeader(String.format(PAGE_TITLE, program.adminName())),
+            renderHeader(PAGE_TITLE + program.adminName()),
             adminEmailTemplate(),
             renderAdminForm(request, program.id(), existingAdminEmails)));
   }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
@@ -1,0 +1,80 @@
+package views.admin.programs;
+
+import static j2html.TagCreator.body;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.each;
+import static j2html.TagCreator.form;
+
+import com.google.common.collect.ImmutableList;
+import controllers.admin.routes;
+import j2html.tags.ContainerTag;
+import j2html.tags.Tag;
+import java.util.Optional;
+import javax.inject.Inject;
+import play.mvc.Http;
+import play.twirl.api.Content;
+import services.program.ProgramDefinition;
+import views.BaseHtmlView;
+import views.admin.AdminLayout;
+import views.components.FieldWithLabel;
+import views.style.ReferenceClasses;
+import views.style.Styles;
+
+/**
+ * Renders a form for adding and removing program admins via email for a given program.
+ */
+public class ManageProgramAdminsView extends BaseHtmlView {
+
+  private final AdminLayout layout;
+
+  @Inject
+  public ManageProgramAdminsView(AdminLayout layout) {
+    this.layout = layout;
+  }
+
+  public Content render(
+      Http.Request request, ProgramDefinition program, ImmutableList<String> existingAdminEmails) {
+    // Display a form with a list of inputs for adding and removing
+    return layout.render(
+        body(
+            renderHeader("Manage Admins for Program: " + program.adminName()),
+            adminEmailTemplate(),
+            renderAdminForm(request, program.id(), existingAdminEmails)));
+  }
+
+  /** Render a form with inputs for program admin emails. If program admins exist, the input fields will be pre-populated with their email addresses. */
+  private ContainerTag renderAdminForm(
+      Http.Request request, long programId, ImmutableList<String> existingAdminEmails) {
+    ContainerTag emailFields =
+        div()
+            .withId("program-admin-emails")
+            .with(each(existingAdminEmails, email -> adminEmailInput(Optional.of(email))))
+            .with(button("Add admin").withId("add-program-admin-button"));
+
+    return form()
+        .with(makeCsrfTokenInputTag(request))
+        .withAction(routes.ProgramAdminManagementController.update(programId).url())
+        .withMethod("POST")
+        .with(emailFields)
+        .with(submitButton("Save"));
+  }
+
+  private ContainerTag adminEmailInput(Optional<String> existing) {
+    ContainerTag input =
+        FieldWithLabel.email()
+            .setFieldName("adminEmails[]")
+            .setPlaceholderText("New admin email")
+            .setValue(existing)
+            .getContainer();
+    Tag removeAdminButton = button("Remove").withClasses(ReferenceClasses.PROGRAM_ADMIN_REMOVE_BUTTON);
+
+    return div().with(input, removeAdminButton);
+  }
+
+  /** A hidden template for adding and removing admins of a given program. */
+  private ContainerTag adminEmailTemplate() {
+    return adminEmailInput(Optional.empty())
+        .withId("program-admin-email-template")
+        .withClasses(Styles.HIDDEN);
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
@@ -26,6 +26,15 @@ public class ManageProgramAdminsView extends BaseHtmlView {
 
   private static final String EMAIL_FIELD_STYLES =
       StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_ROW);
+  private static final String PAGE_TITLE = "Manage Admins for Program: %s";
+  private static final String ADD_ADMIN_BUTTON = "Add admin";
+  private static final String SUBMIT_BUTTON = "Save";
+  private static final String INPUT_PLACEHOLDER = "New admin email";
+  private static final String REMOVE_BUTTON = "Remove";
+  private static final String EMAIL_CONTAINER_DIV_ID = "program-admin-emails";
+  private static final String ADD_BUTTON_ID = "add-program-admin-button";
+  private static final String EMAIL_FIELD_NAME = "adminEmails[]";
+  private static final String EMAIL_INPUT_TEMPLATE_ID = "program-admin-email-template";
 
   private final AdminLayout layout;
 
@@ -39,7 +48,7 @@ public class ManageProgramAdminsView extends BaseHtmlView {
     // Display a form with a list of inputs for adding and removing
     return layout.render(
         body(
-            renderHeader("Manage Admins for Program: " + program.adminName()),
+            renderHeader(String.format(PAGE_TITLE, program.adminName())),
             adminEmailTemplate(),
             renderAdminForm(request, program.id(), existingAdminEmails)));
   }
@@ -52,29 +61,29 @@ public class ManageProgramAdminsView extends BaseHtmlView {
       Http.Request request, long programId, ImmutableList<String> existingAdminEmails) {
     ContainerTag emailFields =
         div()
-            .withId("program-admin-emails")
+            .withId(EMAIL_CONTAINER_DIV_ID)
             .withClasses(Styles.ML_4)
             .with(each(existingAdminEmails, email -> adminEmailInput(Optional.of(email))))
-            .with(button("Add admin").withId("add-program-admin-button").withClasses(Styles.MY_2));
+            .with(button(ADD_ADMIN_BUTTON).withId(ADD_BUTTON_ID).withClasses(Styles.MY_2));
 
     return form()
         .with(makeCsrfTokenInputTag(request))
         .withAction(routes.ProgramAdminManagementController.update(programId).url())
         .withMethod("POST")
         .with(emailFields)
-        .with(submitButton("Save").withClasses(Styles.MY_4));
+        .with(submitButton(SUBMIT_BUTTON).withClasses(Styles.MY_4));
   }
 
   private ContainerTag adminEmailInput(Optional<String> existing) {
     ContainerTag input =
         FieldWithLabel.email()
-            .setFieldName("adminEmails[]")
-            .setPlaceholderText("New admin email")
+            .setFieldName(EMAIL_FIELD_NAME)
+            .setPlaceholderText(INPUT_PLACEHOLDER)
             .setValue(existing)
             .getContainer()
             .withClasses(Styles.FLEX, Styles.M_2);
     Tag removeAdminButton =
-        button("Remove")
+        button(REMOVE_BUTTON)
             .withClasses(ReferenceClasses.PROGRAM_ADMIN_REMOVE_BUTTON, Styles.FLEX, Styles.M_2);
 
     return div().with(input, removeAdminButton).withClasses(EMAIL_FIELD_STYLES);
@@ -83,7 +92,7 @@ public class ManageProgramAdminsView extends BaseHtmlView {
   /** A hidden template for adding and removing admins of a given program. */
   private ContainerTag adminEmailTemplate() {
     return adminEmailInput(Optional.empty())
-        .withId("program-admin-email-template")
+        .withId(EMAIL_INPUT_TEMPLATE_ID)
         .withClasses(Styles.HIDDEN, EMAIL_FIELD_STYLES);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -128,7 +128,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                 p().withClasses(Styles.FLEX_GROW),
                 maybeRenderViewApplicationsLink(viewApplicationsLinkText, activeProgram),
                 maybeRenderManageTranslationsLink(draftProgram),
-                maybeRenderEditLink(draftProgram, activeProgram, request))
+                maybeRenderEditLink(draftProgram, activeProgram, request),
+                renderManageProgramAdminsLink(draftProgram, activeProgram))
             .withClasses(Styles.FLEX, Styles.TEXT_SM, Styles.W_FULL);
 
     Tag innerDiv =
@@ -219,5 +220,20 @@ public final class ProgramIndexView extends BaseHtmlView {
     } else {
       return div();
     }
+  }
+
+  Tag renderManageProgramAdminsLink(
+      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
+    // We can use the ID of either, since we just add the program name and not ID to indicate
+    // ownership.
+    long programId =
+        draftProgram.isPresent() ? draftProgram.get().id() : activeProgram.orElseThrow().id();
+    String adminLink = routes.ProgramAdminManagementController.edit(programId).url();
+    return new LinkElement()
+        .setId("manage-program-admin-link-" + programId)
+        .setHref(adminLink)
+        .setText("Manage admins")
+        .setStyles(Styles.MR_2)
+        .asAnchorText();
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -222,7 +222,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     }
   }
 
-  Tag renderManageProgramAdminsLink(
+  private Tag renderManageProgramAdminsLink(
       Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
     // We can use the ID of either, since we just add the program name and not ID to indicate
     // ownership.

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -232,7 +232,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     return new LinkElement()
         .setId("manage-program-admin-link-" + programId)
         .setHref(adminLink)
-        .setText("Manage admins")
+        .setText("Manage Admins →")
         .setStyles(Styles.MR_2)
         .asAnchorText();
   }

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -76,6 +76,9 @@ public class FieldWithLabel {
     Styles.PY_2
   };
 
+  private static final ImmutableSet<String> STRING_TYPES =
+      ImmutableSet.of("text", "checkbox", "date", "email");
+
   protected Tag fieldTag;
   protected String fieldName = "";
   protected String fieldType = "text";
@@ -123,6 +126,11 @@ public class FieldWithLabel {
     return new FieldWithLabel(fieldTag).setFieldType("text");
   }
 
+  public static FieldWithLabel email() {
+    Tag fieldTag = TagCreator.input();
+    return new FieldWithLabel(fieldTag).setFieldType("email");
+  }
+
   public FieldWithLabel setChecked(boolean checked) {
     this.checked = checked;
     return this;
@@ -165,9 +173,7 @@ public class FieldWithLabel {
   }
 
   public FieldWithLabel setValue(String value) {
-    if (!this.fieldType.equals("text")
-        && !this.fieldType.equals("checkbox")
-        && !this.fieldType.equals("date")) {
+    if (!STRING_TYPES.contains(this.fieldType)) {
       throw new RuntimeException(
           String.format(
               "setting a String value is not available on fields of type `%s`", this.fieldType));
@@ -178,7 +184,7 @@ public class FieldWithLabel {
   }
 
   public FieldWithLabel setValue(Optional<String> value) {
-    if (this.fieldType.equals("number")) {
+    if (!STRING_TYPES.contains(this.fieldType)) {
       throw new RuntimeException(
           "setting a String value is not available on fields of type 'number'");
     }

--- a/universal-application-tool-0.0.1/app/views/style/ReferenceClasses.java
+++ b/universal-application-tool-0.0.1/app/views/style/ReferenceClasses.java
@@ -19,6 +19,7 @@ public final class ReferenceClasses {
   public static final String DOWNLOAD_BUTTON = "cf-download-button";
   public static final String ENUMERATOR_FIELD = "cf-enumerator-field";
   public static final String FLOATED_LABEL = "cf-floated";
+  public static final String PROGRAM_ADMIN_REMOVE_BUTTON = "cf-program-admin-remove-button";
   public static final String QUESTION_CONFIG = "cf-question-config";
   public static final String RADIO_DEFAULT = "cf-radio-default";
   public static final String RADIO_INPUT = "cf-radio-input";

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -17,7 +17,7 @@ POST    /admin/programs/publish                                 controllers.admi
 POST    /admin/programs/:programId                              controllers.admin.AdminProgramController.update(request: Request, programId: Long)
 
 # Routes for a UAT admin to manage program admins for a given program.
-GET     /admin/programs/:programId/admins/edit  controllers.admin.ProgramAdminManagementController.edit(programId: Long)
+GET     /admin/programs/:programId/admins/edit  controllers.admin.ProgramAdminManagementController.edit(request: Request, programId: Long)
 POST    /admin/programs/:programId/admins       controllers.admin.ProgramAdminManagementController.update(request: Request, programId: Long)
 
 # Routes for managing program localization

--- a/universal-application-tool-0.0.1/test/models/AccountTest.java
+++ b/universal-application-tool-0.0.1/test/models/AccountTest.java
@@ -34,4 +34,18 @@ public class AccountTest extends WithPostgresContainer {
     Account found = repository.lookupAccount(email).get();
     assertThat(found.getAdministeredProgramNames()).containsExactly("one", "two");
   }
+
+  @Test
+  public void addDuplicateProgram_doesNotAddToList() {
+    Account account = new Account();
+    String programName = "duplicate";
+    ProgramDefinition program = ProgramBuilder.newDraftProgram(programName).buildDefinition();
+
+    account.addAdministeredProgram(program);
+    assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
+
+    // Try to add again.
+    account.addAdministeredProgram(program);
+    assertThat(account.getAdministeredProgramNames()).containsExactly(programName);
+  }
 }

--- a/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
@@ -29,6 +29,13 @@ public class FieldWithLabelTest {
   }
 
   @Test
+  public void createEmail_rendersEmailInput() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.email();
+    assertThat(fieldWithLabel.getContainer().render()).contains("<input");
+    assertThat(fieldWithLabel.getContainer().render()).contains("type=\"email\"");
+  }
+
+  @Test
   public void number_setsNoValueByDefault() {
     FieldWithLabel fieldWithLabel = FieldWithLabel.number();
     assertThat(fieldWithLabel.getContainer().render()).doesNotContain("value");


### PR DESCRIPTION
### Description
1. Adds a "Manage Admins" link on each program card for the CiviForm admin index view
1. Implements `ManageProgramAdminsController#edit`
2. Adds a `ManageProgramAdminsView` that provides email inputs for UAT admins to add or remove program admins on a given program
3. Updates our TypeScript to make the add/remove input functions re-usable

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1051 

<img width="747" alt="Screen Shot 2021-05-10 at 6 29 37 PM" src="https://user-images.githubusercontent.com/8559046/117852683-71164980-b23c-11eb-8272-1ffbb6634a69.png">
