### PR TITLE
Remove list all programs

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -37,17 +37,6 @@ public class ProgramRepository {
     this.versionRepository = checkNotNull(versionRepository);
   }
 
-  /** Return all programs in a list. */
-  public CompletionStage<ImmutableList<Program>> listPrograms() {
-    return supplyAsync(
-        () ->
-            new ImmutableList.Builder<Program>()
-                .addAll(versionRepository.get().getActiveVersion().getPrograms())
-                .addAll(versionRepository.get().getDraftVersion().getPrograms())
-                .build(),
-        executionContext);
-  }
-
   public CompletionStage<Optional<Program>> lookupProgram(long id) {
     return supplyAsync(
         () -> ebeanServer.find(Program.class).where().eq("id", id).findOneOrEmpty(),

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -20,20 +20,6 @@ import services.question.types.QuestionDefinition;
 public interface ProgramService {
 
   /**
-   * List all programs.
-   *
-   * @return a list of {@link ProgramDefinition}s
-   */
-  ImmutableList<ProgramDefinition> listProgramDefinitions();
-
-  /**
-   * List all programs asynchronously.
-   *
-   * @return a list of {@link ProgramDefinition}s
-   */
-  CompletionStage<ImmutableList<ProgramDefinition>> listProgramDefinitionsAsync();
-
-  /**
    * Get the definition for a given program.
    *
    * @param id the ID of the program to retrieve

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -44,34 +44,6 @@ public class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
-  public ImmutableList<ProgramDefinition> listProgramDefinitions() {
-    return listProgramDefinitionsAsync().toCompletableFuture().join();
-  }
-
-  @Override
-  public CompletionStage<ImmutableList<ProgramDefinition>> listProgramDefinitionsAsync() {
-    CompletableFuture<ReadOnlyQuestionService> roQuestionServiceFuture =
-        questionService.getReadOnlyQuestionService().toCompletableFuture();
-    CompletableFuture<ImmutableList<Program>> programsFuture =
-        programRepository.listPrograms().toCompletableFuture();
-
-    return CompletableFuture.allOf(roQuestionServiceFuture, programsFuture)
-        .thenApplyAsync(
-            ignore -> {
-              ReadOnlyQuestionService roQuestionService = roQuestionServiceFuture.join();
-              ImmutableList<Program> programs = programsFuture.join();
-
-              return programs.stream()
-                  .map(
-                      program ->
-                          syncProgramDefinitionQuestions(
-                              program.getProgramDefinition(), roQuestionService))
-                  .collect(ImmutableList.toImmutableList());
-            },
-            httpExecutionContext.current());
-  }
-
-  @Override
   public ProgramDefinition getProgramDefinition(long id) throws ProgramNotFoundException {
     try {
       return getProgramDefinitionAsync(id).toCompletableFuture().join();

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -2,9 +2,7 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import io.ebean.DB;
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import models.Account;
@@ -17,27 +15,12 @@ import services.program.ProgramNotFoundException;
 public class ProgramRepositoryTest extends WithPostgresContainer {
 
   private ProgramRepository repo;
+  private VersionRepository versionRepo;
 
   @Before
   public void setupProgramRepository() {
     repo = instanceOf(ProgramRepository.class);
-  }
-
-  @Test
-  public void listPrograms_empty() {
-    List<Program> allPrograms = repo.listPrograms().toCompletableFuture().join();
-
-    assertThat(allPrograms).isEmpty();
-  }
-
-  @Test
-  public void listPrograms() {
-    Program one = resourceCreator.insertActiveProgram("one");
-    Program two = resourceCreator.insertActiveProgram("two");
-
-    ImmutableList<Program> allPrograms = repo.listPrograms().toCompletableFuture().join();
-
-    assertThat(allPrograms).containsExactly(one, two);
+    versionRepo = instanceOf(VersionRepository.class);
   }
 
   @Test
@@ -72,7 +55,7 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
         .execute();
 
     Program found =
-        repo.listPrograms().toCompletableFuture().join().stream()
+        versionRepo.getActiveVersion().getPrograms().stream()
             .filter(
                 program -> program.getProgramDefinition().adminName().equals("Old Schema Entry"))
             .findFirst()

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -42,81 +42,6 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void listProgramDefinitions_hasNoResults() {
-    ImmutableList<ProgramDefinition> programDefinitions = ps.listProgramDefinitions();
-
-    assertThat(programDefinitions).isEmpty();
-  }
-
-  @Test
-  public void listProgramDefinitions_hasResults() {
-    ProgramDefinition first = ProgramBuilder.newDraftProgram("first").buildDefinition();
-    ProgramDefinition second = ProgramBuilder.newDraftProgram("second").buildDefinition();
-
-    ImmutableList<ProgramDefinition> programDefinitions = ps.listProgramDefinitions();
-
-    assertThat(programDefinitions).containsExactly(first, second);
-  }
-
-  @Test
-  public void listProgramDefinitions_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = nameQuestion;
-    Program program = ProgramBuilder.newDraftProgram().build();
-    ps.addQuestionsToBlock(program.id, 1L, ImmutableList.of(question.getId()));
-
-    ImmutableList<ProgramDefinition> programDefinitions = ps.listProgramDefinitions();
-
-    QuestionDefinition foundQuestion =
-        programDefinitions
-            .get(0)
-            .blockDefinitions()
-            .get(0)
-            .programQuestionDefinitions()
-            .get(0)
-            .getQuestionDefinition();
-    assertThat(foundQuestion).isInstanceOf(NameQuestionDefinition.class);
-  }
-
-  @Test
-  public void listProgramDefinitionsAsync_hasNoResults() {
-    CompletionStage<ImmutableList<ProgramDefinition>> completionStage =
-        ps.listProgramDefinitionsAsync();
-
-    assertThat(completionStage.toCompletableFuture().join()).isEmpty();
-  }
-
-  @Test
-  public void listProgramDefinitionsAsync_hasResults() {
-    ProgramDefinition first = ProgramBuilder.newDraftProgram("first").buildDefinition();
-    ProgramDefinition second = ProgramBuilder.newDraftProgram("second").buildDefinition();
-
-    CompletionStage<ImmutableList<ProgramDefinition>> completionStage =
-        ps.listProgramDefinitionsAsync();
-
-    assertThat(completionStage.toCompletableFuture().join()).containsExactly(first, second);
-  }
-
-  @Test
-  public void listProgramDefinitionsAsync_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = nameQuestion;
-    ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
-    ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
-
-    ImmutableList<ProgramDefinition> programDefinitions =
-        ps.listProgramDefinitionsAsync().toCompletableFuture().join();
-
-    QuestionDefinition foundQuestion =
-        programDefinitions
-            .get(0)
-            .blockDefinitions()
-            .get(0)
-            .programQuestionDefinitions()
-            .get(0)
-            .getQuestionDefinition();
-    assertThat(foundQuestion).isInstanceOf(NameQuestionDefinition.class);
-  }
-
-  @Test
   public void syncQuestions_constructsAllQuestionDefinitions() throws Exception {
     QuestionDefinition questionOne = nameQuestion;
     QuestionDefinition questionTwo = addressQuestion;
@@ -136,7 +61,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
         .withQuestionDefinition(questionOne)
         .buildDefinition();
 
-    ImmutableList<ProgramDefinition> programDefinitions = ps.listProgramDefinitions();
+    ImmutableList<ProgramDefinition> programDefinitions =
+        ps.getActiveAndDraftPrograms().getDraftPrograms();
 
     QuestionDefinition found = programDefinitions.get(0).getQuestionDefinition(0, 0);
     assertThat(found).isInstanceOf(NameQuestionDefinition.class);
@@ -152,7 +78,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void createProgram_setsId() {
-    assertThat(ps.listProgramDefinitions()).isEmpty();
+    assertThat(ps.getActiveAndDraftPrograms().getActiveSize()).isEqualTo(0);
+    assertThat(ps.getActiveAndDraftPrograms().getDraftSize()).isEqualTo(0);
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition("ProgramService", "description", "name", "description");
@@ -208,7 +135,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     ProgramDefinition found = ps.getProgramDefinition(updatedProgram.id());
 
-    assertThat(ps.listProgramDefinitions()).hasSize(1);
+    assertThat(ps.getActiveAndDraftPrograms().getDraftSize()).isEqualTo(1);
     assertThat(found).isEqualTo(updatedProgram);
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -47,14 +47,14 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     QuestionDefinition questionTwo = addressQuestion;
     QuestionDefinition questionThree = colorQuestion;
 
-    ProgramBuilder.newDraftProgram()
+    ProgramBuilder.newDraftProgram("program1")
         .withBlock()
         .withQuestionDefinition(questionOne)
         .withQuestionDefinition(questionTwo)
         .withBlock()
         .withQuestionDefinition(questionThree)
         .buildDefinition();
-    ProgramBuilder.newDraftProgram()
+    ProgramBuilder.newDraftProgram("program2")
         .withBlock()
         .withQuestionDefinition(questionTwo)
         .withBlock()


### PR DESCRIPTION
### Description
With versioning, list all programs are not useful. Getting all programs regardless versions is at best misleading, if not causing any harm. The method is only used in test so it is safe to remove.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
