### PR TITLE
switch to mandatory forward secrecy.

### DIFF
--- a/infra/load_balancer.yaml
+++ b/infra/load_balancer.yaml
@@ -78,7 +78,7 @@ Resources:
       LoadBalancerArn: !Ref 'publiclb'
       Port: 443
       Protocol: HTTPS
-      SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+      SslPolicy: ELBSecurityPolicy-FS-1-2-Res-2020-10
       Certificates:
         - CertificateArn: !FindInMap [Certificate, !Ref Environment, CertArn]
   lbtarget:


### PR DESCRIPTION
### Description
At the city's request we are disabling all but the very most secure possible TLS ciphers.

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
