### PR TITLE
Allow an admin to add program admins before they have logged in

### DIFF
--- a/browser-test/src/admin_program_admins.test.ts
+++ b/browser-test/src/admin_program_admins.test.ts
@@ -1,0 +1,32 @@
+import { startSession, loginAsAdmin, AdminPrograms, endSession } from './support'
+
+describe('manage program admins', () => {
+  it('add program admins', async () => {
+    const { browser, page } = await startSession();
+
+    await loginAsAdmin(page);
+    const adminPrograms = new AdminPrograms(page);
+
+    const programName = 'add program admins';
+    await adminPrograms.addProgram(programName);
+
+    // Add two program admins and save
+    await adminPrograms.gotoManageProgramAdminsPage(programName);
+    await page.click('#add-program-admin-button');
+    await page.fill('input:above(#add-program-admin-button)', 'test@test.com');
+    await page.click('#add-program-admin-button');
+    await page.fill('input:above(#add-program-admin-button)', 'other@test.com');
+    await page.click('text=Save');
+
+    // Go to manage program admins again
+    await adminPrograms.expectAdminProgramsPage();
+    await adminPrograms.gotoManageProgramAdminsPage(programName);
+
+    // Assert that the two emails we added are present.
+    // Use input:visible to get the first visible input, since the template is hidden.
+    expect(await page.getAttribute('input:visible', 'value')).toContain('test@test.com');
+    expect(await page.getAttribute('input:above(#add-program-admin-button)', 'value')).toContain('other@test.com');
+
+    await endSession(browser);
+  })
+})

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -63,6 +63,13 @@ export class AdminPrograms {
     await this.expectProgramManageTranslationsPage();
   }
 
+  async gotoManageProgramAdminsPage(programName: string) {
+    await this.gotoAdminProgramsPage();
+    await this.expectDraftProgram(programName);
+    await this.page.click(this.selectWithinProgramCard(programName, 'DRAFT', ':text("Manage Admins")'));
+    await this.expectManageProgramAdminsPage();
+  }
+
   async expectDraftProgram(programName: string) {
     expect(await this.page.innerText(`div.border:has(:text("${programName}"), :text("DRAFT"))`)).not.toContain('New Version');
   }
@@ -81,6 +88,10 @@ export class AdminPrograms {
 
   async expectProgramManageTranslationsPage() {
     expect(await this.page.innerText('h1')).toContain('Manage Program Translations');
+  }
+
+  async expectManageProgramAdminsPage() {
+    expect(await this.page.innerText('h1')).toContain('Manage Admins for Program');
   }
 
   async expectProgramBlockEditPage(programName: string = '') {

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -281,18 +281,23 @@ public class UserRepository {
   }
 
   /**
-   * Adds the given program as an administered program by the given account. Does nothing if the
-   * account does not exist.
+   * Adds the given program as an administered program by the given account. If the account does not
+   * exist, this will create a new account for the given email, so that when a user with that email
+   * signs in for the first time they will be a program admin.
    *
    * @param accountEmail the email of the account that will administer the given program
    * @param program the {@link ProgramDefinition} to add to this given account
    */
   public void addAdministeredProgram(String accountEmail, ProgramDefinition program) {
     Optional<Account> maybeAccount = lookupAccount(accountEmail);
-    maybeAccount.ifPresent(
-        account -> {
-          account.addAdministeredProgram(program);
-          account.save();
-        });
+    Account account =
+        maybeAccount.orElseGet(
+            () -> {
+              Account a = new Account();
+              a.setEmailAddress(accountEmail);
+              return a;
+            });
+    account.addAdministeredProgram(program);
+    account.save();
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/UserRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/UserRepositoryTest.java
@@ -102,12 +102,24 @@ public class UserRepositoryTest extends WithPostgresContainer {
   }
 
   @Test
-  public void addAdministeredProgram_succeeds() {
+  public void addAdministeredProgram_existingAccount_succeeds() {
     String email = "email@email.com";
     Account account = new Account();
     account.setEmailAddress(email);
     account.save();
 
+    String programName = "name";
+    ProgramDefinition program = ProgramBuilder.newDraftProgram(programName).buildDefinition();
+
+    repo.addAdministeredProgram(email, program);
+
+    assertThat(repo.lookupAccount(email).get().getAdministeredProgramNames())
+        .containsOnly(programName);
+  }
+
+  @Test
+  public void addAdministeredProgram_missingAccount_createsNewAccountForEmail() {
+    String email = "test@test.com";
     String programName = "name";
     ProgramDefinition program = ProgramBuilder.newDraftProgram(programName).buildDefinition();
 


### PR DESCRIPTION
### Description
1. If an account for a given email address is not present, we create a new one. This allows the CiviForm admin to designate program admins before those PAs have logged in for the first time (i.e. they do not have an account yet)
2. Adds a browser test to verify we can add admins and they will still be there when we view them again

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1051 
