### PR TITLE
Allow admins to configure the entity name for enumerator questions

### DIFF
--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -340,6 +340,8 @@ export class AdminQuestions {
 
     await this.page.selectOption('#question-enumeration-select', { label: enumeratorName });
 
+    await this.page.fill('text=Repeated Entity Type', 'Entity');
+
     await this.page.click('text=Create');
 
     await this.expectAdminQuestionsPage();

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -52,7 +52,7 @@ export class ApplicantQuestions {
   }
 
   async addEnumeratorAnswer(entityName: string) {
-    await this.page.click('button:text("add item")');
+    await this.page.click('button:text("add entity")');
     await this.page.fill('input:above(#enumerator-field-add-button)', entityName)
   }
 

--- a/universal-application-tool-0.0.1/app/forms/EnumeratorQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/EnumeratorQuestionForm.java
@@ -15,7 +15,7 @@ public class EnumeratorQuestionForm extends QuestionForm {
 
   public EnumeratorQuestionForm(EnumeratorQuestionDefinition qd) {
     super(qd);
-    this.entityType = qd.getEntityType().getDefault();
+    this.entityType = qd.getEntityType().isEmpty() ? "" : qd.getEntityType().getDefault();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/forms/EnumeratorQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/EnumeratorQuestionForm.java
@@ -1,19 +1,38 @@
 package forms;
 
+import services.LocalizedStrings;
 import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 
 public class EnumeratorQuestionForm extends QuestionForm {
+  private String entityType;
+
   public EnumeratorQuestionForm() {
     super();
+    this.entityType = "";
   }
 
   public EnumeratorQuestionForm(EnumeratorQuestionDefinition qd) {
     super(qd);
+    this.entityType = qd.getEntityType().getDefault();
   }
 
   @Override
   public QuestionType getQuestionType() {
     return QuestionType.ENUMERATOR;
+  }
+
+  public String getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(String entityType) {
+    this.entityType = entityType;
+  }
+
+  @Override
+  public QuestionDefinitionBuilder getBuilder() {
+    return super.getBuilder().setEntityType(LocalizedStrings.withDefaultValue(this.entityType));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/types/EnumeratorQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/EnumeratorQuestionDefinition.java
@@ -18,6 +18,8 @@ import services.LocalizedStrings;
  */
 public class EnumeratorQuestionDefinition extends QuestionDefinition {
 
+  protected static final String DEFAULT_ENTITY_TYPE = "Item";
+
   private final LocalizedStrings entityType;
 
   public EnumeratorQuestionDefinition(

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -219,8 +219,9 @@ public class QuestionDefinitionBuilder {
         return new RadioButtonQuestionDefinition(
             id, name, enumeratorId, description, questionText, questionHelpText, questionOptions);
       case ENUMERATOR:
-        if (entityType == null) {
-          entityType = LocalizedStrings.empty();
+        if (entityType == null || entityType.isEmpty()) {
+          entityType =
+              LocalizedStrings.withDefaultValue(EnumeratorQuestionDefinition.DEFAULT_ENTITY_TYPE);
         }
         return new EnumeratorQuestionDefinition(
             id, name, enumeratorId, description, questionText, questionHelpText, entityType);

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -8,6 +8,7 @@ import static j2html.TagCreator.label;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import forms.AddressQuestionForm;
+import forms.EnumeratorQuestionForm;
 import forms.MultiOptionQuestionForm;
 import forms.NumberQuestionForm;
 import forms.QuestionForm;
@@ -75,6 +76,11 @@ public class QuestionConfig {
             .addMultiOptionQuestionFields(form)
             .addMultiSelectQuestionValidation(form)
             .getContainer();
+      case ENUMERATOR:
+        return config
+            .setId("enumerator-question-config")
+            .addEnumeratorQuestionConfig((EnumeratorQuestionForm) questionForm)
+            .getContainer();
       case NUMBER:
         return config
             .setId("number-question-config")
@@ -93,7 +99,6 @@ public class QuestionConfig {
             .getContainer();
       case FILEUPLOAD: // fallthrough intended
       case NAME: // fallthrough intended - no options
-      case ENUMERATOR: // fallthrough intended
       default:
         return div();
     }
@@ -131,6 +136,19 @@ public class QuestionConfig {
             .setFieldName("maxLength")
             .setLabelText("Maximum length")
             .setValue(textQuestionForm.getMaxLength())
+            .getContainer());
+    return this;
+  }
+
+  private QuestionConfig addEnumeratorQuestionConfig(
+      EnumeratorQuestionForm enumeratorQuestionForm) {
+    content.with(
+        FieldWithLabel.input()
+            .setId("enumerator-question-entity-type-input")
+            .setFieldName("entityType")
+            .setLabelText("Repeated entity type")
+            .setPlaceholderText("What are we enumerating?")
+            .setValue(enumeratorQuestionForm.getEntityType())
             .getContainer());
     return this;
   }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -67,6 +67,10 @@ public class ApplicantQuestionRendererFactory {
               QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "Sample question option"))));
     }
 
+    if (questionType.equals(QuestionType.ENUMERATOR)) {
+      builder.setEntityType(LocalizedStrings.withDefaultValue("Sample repeated entity type"));
+    }
+
     return builder.build();
   }
 }

--- a/universal-application-tool-0.0.1/test/forms/EnumeratorQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/EnumeratorQuestionFormTest.java
@@ -43,7 +43,7 @@ public class EnumeratorQuestionFormTest {
             "description",
             LocalizedStrings.of(Locale.US, "What is the question text?"),
             LocalizedStrings.empty(),
-            LocalizedStrings.withDefaultValue("entity type"));
+            LocalizedStrings.empty());
 
     EnumeratorQuestionForm form = new EnumeratorQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/universal-application-tool-0.0.1/test/forms/EnumeratorQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/EnumeratorQuestionFormTest.java
@@ -43,7 +43,7 @@ public class EnumeratorQuestionFormTest {
             "description",
             LocalizedStrings.of(Locale.US, "What is the question text?"),
             LocalizedStrings.empty(),
-            LocalizedStrings.empty());
+            LocalizedStrings.withDefaultValue("entity type"));
 
     EnumeratorQuestionForm form = new EnumeratorQuestionForm(originalQd);
     QuestionDefinitionBuilder builder = form.getBuilder();

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionBuilderTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionBuilderTest.java
@@ -39,7 +39,7 @@ public class QuestionDefinitionBuilderTest {
   }
 
   @Test
-  public void builder_enumeratorDefaultsToEmptyEntityType() throws Exception {
+  public void builder_enumeratorWithNull_usesDefaultEntityType() throws Exception {
     QuestionDefinitionBuilder builder =
         new QuestionDefinitionBuilder()
             .setQuestionType(QuestionType.ENUMERATOR)
@@ -51,6 +51,26 @@ public class QuestionDefinitionBuilderTest {
             .setEntityType(null);
 
     EnumeratorQuestionDefinition enumerator = (EnumeratorQuestionDefinition) builder.build();
-    assertThat(enumerator.getEntityType().isEmpty()).isTrue();
+    assertThat(enumerator.getEntityType().isEmpty()).isFalse();
+    assertThat(enumerator.getEntityType().getDefault())
+        .isEqualTo(EnumeratorQuestionDefinition.DEFAULT_ENTITY_TYPE);
+  }
+
+  @Test
+  public void builder_emptyEntityType_usesDefaultEntityType() throws Exception {
+    QuestionDefinitionBuilder builder =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.ENUMERATOR)
+            .setName("")
+            .setDescription("")
+            .setEnumeratorId(Optional.of(123L))
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setEntityType(LocalizedStrings.empty());
+
+    EnumeratorQuestionDefinition enumerator = (EnumeratorQuestionDefinition) builder.build();
+    assertThat(enumerator.getEntityType().isEmpty()).isFalse();
+    assertThat(enumerator.getEntityType().getDefault())
+        .isEqualTo(EnumeratorQuestionDefinition.DEFAULT_ENTITY_TYPE);
   }
 }

--- a/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
+++ b/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
@@ -44,6 +44,10 @@ public class QuestionConfigTest {
     assertThat(QuestionConfig.buildQuestionConfig(new RadioButtonQuestionForm()))
         .toString()
         .contains("single-select-question-config");
+
+    assertThat(QuestionConfig.buildQuestionConfig(new EnumeratorQuestionForm()))
+        .toString()
+        .contains("enumerator-question-config");
   }
 
   @Test
@@ -52,9 +56,6 @@ public class QuestionConfigTest {
         .isEqualTo(DEFAULT_CONFIG);
 
     assertThat(QuestionConfig.buildQuestionConfig(new NameQuestionForm()))
-        .isEqualTo(DEFAULT_CONFIG);
-
-    assertThat(QuestionConfig.buildQuestionConfig(new EnumeratorQuestionForm()))
         .isEqualTo(DEFAULT_CONFIG);
   }
 }


### PR DESCRIPTION
### Description
Allow the admin to configure a custom entity type name for enumerator questions. This adds a field to the question form and pipes it through.
