### PR TITLE
Don't set `id` in `FieldWithLabel` if it wasn't explicitly set

### DIFF
--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -180,15 +180,12 @@ public class FieldWithLabel {
       fieldTag.withValue(this.fieldValue);
     }
 
-    // Need to assign an ID in order to properly associate the label with this input field.
-    if (Strings.isNullOrEmpty(this.id)) this.id = this.fieldName;
-
     fieldTag
         .withClasses(
             StyleUtils.joinStyles(
                 BaseStyles.INPUT,
                 fieldErrors.isEmpty() ? "" : BaseStyles.FORM_FIELD_ERROR_BORDER_COLOR))
-        .withCondId(!Strings.isNullOrEmpty(this.id), this.id)
+        .withCondId(!this.id.isEmpty(), this.id)
         .withName(this.fieldName)
         .condAttr(this.disabled, "disabled", "true")
         .withCondPlaceholder(!Strings.isNullOrEmpty(this.placeholderText), this.placeholderText)
@@ -200,7 +197,7 @@ public class FieldWithLabel {
 
     ContainerTag labelTag =
         label()
-            .condAttr(shouldSetLabelForAttr(), Attr.FOR, this.id)
+            .condAttr(!this.id.isEmpty(), Attr.FOR, this.id)
             .withClasses(labelText.isEmpty() ? "" : BaseStyles.INPUT_LABEL)
             .withText(labelText);
 
@@ -222,7 +219,7 @@ public class FieldWithLabel {
             BaseStyles.CHECKBOX_LABEL,
             BaseStyles.FORM_FIELD_MARGIN_BOTTOM,
             labelText.isEmpty() ? Styles.W_MIN : "")
-        .condAttr(shouldSetLabelForAttr(), Attr.FOR, this.id)
+        .condAttr(!this.id.isEmpty(), Attr.FOR, this.id)
         .with(fieldTag.withClasses(BaseStyles.CHECKBOX))
         .withText(this.labelText);
   }
@@ -233,9 +230,5 @@ public class FieldWithLabel {
             fieldErrors.isEmpty()
                 ? ""
                 : StyleUtils.joinStyles(BaseStyles.FORM_ERROR_TEXT, Styles.P_1));
-  }
-
-  private boolean shouldSetLabelForAttr() {
-    return !this.id.isEmpty() && !this.labelText.isEmpty();
   }
 }


### PR DESCRIPTION
### Description
This fixes a potential bug that I introduced in a previous PR.

### The fix
The `id` attribute is no longer defaults to the `name` attribute, and `for` is only set if the `id` attribute is specified.

### The bug
Before this PR, if no ID was set on a `FieldWithLabel`, then `FieldWithLabel` tried to be clever by setting the `id` to whatever the `name` was. At the same time, the `id` was used to register the `for` attribute on the `label`.

The problem was If the caller of `FieldWithLabel` had set the same `name` for multiple fields in the same page (and not set unique IDs for them), then multiple fields would have the same `id`, and then clicking the label of one might end up triggering another field. Normally, having more than one field with the same `name` doesn't make sense, but this is how form binding works for arrays in Play's Form framework (e.g., for checkboxes).

### The reason this is OK
The reason this fix works is because a recent PR updated this component so that all its `input` elements (whether text or checkbox, etc), are wrapped by the `label` field. So the click target area automatically includes the label, without needing the `for` attribute. 

We still set the `for` attribute if we can (if the caller explicitly set an `id`).
