### PR TITLE
Enables Google Analytics measurement ID to be defined in containers.yaml

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -65,6 +65,9 @@ Parameters:
   DomainName:
     Description: The domain name to use as the base URL.
     Type: String
+  MeasurementId:
+    Description: The Google Analytics measurement ID.
+    Type: String
 Resources:
   ecscluster:
     Type: AWS::ECS::Cluster

--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -147,6 +147,8 @@ Resources:
               Value: !FindInMap [AdminGroup, !Ref Environment, group]
             - Name: BASE_URL
               Value: !Sub "https://${DomainName}"
+            - Name: MEASUREMENT_ID
+              Value: !Sub "https://${MeasurementId}"
           Cpu: 1024
           Memory: 8192
           PortMappings:

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -4,8 +4,10 @@ Mappings:
   Container:
     prod:
       Domain: civiform.seattle.gov
+      MeasurementId: G-HXM0Y35TGE
     staging:
       Domain: staging.seattle.civiform.com
+      MeasurementId: G-HXM0Y35TGE
   DNS:
     prod:
       # The city's DNS is configured as a CNAME to this address.
@@ -101,6 +103,7 @@ Resources:
         ContainerSecurityGroup: !GetAtt 'SecurityGroups.Outputs.ContainerGroup'
         S3BucketName: !GetAtt 'Filestore.Outputs.bucketname'
         DomainName: !FindInMap [Container, !Ref Environment, Domain]
+        MeasurementId: !FindInMap [Container, !Ref Environment, MeasurementId]
         Environment: !Ref Environment
         S3TaskRole: !FindInMap [S3TaskRoles, !Ref Environment, role]
   Monitoring:

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlLayout.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlLayout.java
@@ -2,8 +2,8 @@ package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.document;
-import com.typesafe.config.Config;
 
+import com.typesafe.config.Config;
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;
 import j2html.tags.Tag;

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlLayout.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlLayout.java
@@ -2,6 +2,7 @@ package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.document;
+import com.typesafe.config.Config;
 
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;
@@ -20,15 +21,16 @@ import views.components.ToastMessage;
  */
 public class BaseHtmlLayout extends BaseHtmlView {
   private static final String TAILWIND_COMPILED_FILENAME = "tailwind";
-  private static final String TRACKING_TAG_ID = "G-HXM0Y35TGE";
   private static final String BANNER_TEXT =
       "Do not enter actual or personal data in this demo site";
 
   public final ViewUtils viewUtils;
+  public final String measurementId;
 
   @Inject
-  public BaseHtmlLayout(ViewUtils viewUtils) {
+  public BaseHtmlLayout(ViewUtils viewUtils, Config configuration) {
     this.viewUtils = checkNotNull(viewUtils);
+    this.measurementId = checkNotNull(configuration).getString("measurement_id");
   }
 
   /** Returns HTTP content of type "text/html". */
@@ -56,7 +58,7 @@ public class BaseHtmlLayout extends BaseHtmlView {
   }
 
   public Tag headContent(String... titlestr) {
-    return viewUtils.makeHead(TAILWIND_COMPILED_FILENAME, TRACKING_TAG_ID, titlestr);
+    return viewUtils.makeHead(TAILWIND_COMPILED_FILENAME, measurementId, titlestr);
   }
 
   protected static class HtmlResponseContent implements Content {

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -7,6 +7,8 @@ import static j2html.TagCreator.main;
 import static j2html.TagCreator.nav;
 import static j2html.TagCreator.span;
 
+import com.typesafe.config.Config;
+
 import controllers.admin.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;
@@ -22,8 +24,8 @@ import views.style.Styles;
 public class AdminLayout extends BaseHtmlLayout {
 
   @Inject
-  public AdminLayout(ViewUtils viewUtils) {
-    super(viewUtils);
+  public AdminLayout(ViewUtils viewUtils, Config configuration) {
+    super(viewUtils, configuration);
   }
 
   private ContainerTag renderNavBar() {

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -8,7 +8,6 @@ import static j2html.TagCreator.nav;
 import static j2html.TagCreator.span;
 
 import com.typesafe.config.Config;
-
 import controllers.admin.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
@@ -8,6 +8,8 @@ import static j2html.TagCreator.header;
 import static j2html.TagCreator.nav;
 import static j2html.TagCreator.span;
 
+import com.typesafe.config.Config;
+
 import auth.ProfileUtils;
 import auth.Roles;
 import auth.UatProfile;
@@ -31,8 +33,8 @@ public class ApplicantLayout extends BaseHtmlLayout {
   private final ProfileUtils profileUtils;
 
   @Inject
-  public ApplicantLayout(ViewUtils viewUtils, ProfileUtils profileUtils) {
-    super(viewUtils);
+  public ApplicantLayout(ViewUtils viewUtils, Config configuration, ProfileUtils profileUtils) {
+    super(viewUtils, configuration);
     this.profileUtils = checkNotNull(profileUtils);
   }
 

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
@@ -8,11 +8,10 @@ import static j2html.TagCreator.header;
 import static j2html.TagCreator.nav;
 import static j2html.TagCreator.span;
 
-import com.typesafe.config.Config;
-
 import auth.ProfileUtils;
 import auth.Roles;
 import auth.UatProfile;
+import com.typesafe.config.Config;
 import controllers.ti.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -62,6 +62,9 @@ adfs.admin_group = ${?ADFS_GLOBAL_ADMIN_GROUP}
 base_url = "http://localhost:9000"
 base_url = ${?BASE_URL}
 
+measurement_id = "G-HXM0Y35TGE"
+measurement_id = ${?MEASUREMENT_ID}
+
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
 # ~~~~~


### PR DESCRIPTION
### Description
Enable Google Analytics measurement ID to be defined in containers.yaml

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1100 