### PR TITLE
Log ADFS attributes for debug

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -36,6 +36,8 @@ public class AdfsProfileAdapter extends UatProfileAdapter {
   @Override
   protected ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile) {
     JSONArray groups = oidcProfile.getAttribute("group", JSONArray.class);
+    System.out.println(oidcProfile.getAttributes());
+    System.out.println(groups);
     if (groups.contains(this.adminGroupName)) {
       profile
           .getAccount()


### PR DESCRIPTION
### Description
Prod instance is returning null pointer when we get group. This print all attributes ADFS returns in prod.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
