### PR TITLE
Notify program admins

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -8,7 +8,7 @@ Mappings:
       image: public.ecr.aws/t1q6b4h2/universal-application-tool:latest
   Notifications:
     prod:
-      sender: noreply@seattle.civiform.com
+      sender: civiform-notification@seattle.gov
     staging:
       sender: noreply@staging.seattle.civiform.com
   AdminGroup:

--- a/universal-application-tool-0.0.1/app/services/aws/SimpleEmail.java
+++ b/universal-application-tool-0.0.1/app/services/aws/SimpleEmail.java
@@ -2,6 +2,7 @@ package services.aws;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -46,8 +47,13 @@ public class SimpleEmail {
   }
 
   public void send(String toAddress, String subject, String bodyText) {
+    send(ImmutableList.of(toAddress), subject, bodyText);
+  }
 
-    Destination destination = Destination.builder().toAddresses(toAddress).build();
+  public void send(ImmutableList<String> toAddresses, String subject, String bodyText) {
+
+    Destination destination =
+        Destination.builder().toAddresses(toAddresses.toArray(new String[0])).build();
 
     Body body = Body.builder().text(Content.builder().data(bodyText).build()).build();
 

--- a/universal-application-tool-0.0.1/app/services/aws/SimpleEmail.java
+++ b/universal-application-tool-0.0.1/app/services/aws/SimpleEmail.java
@@ -10,6 +10,8 @@ import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.Environment;
 import play.inject.ApplicationLifecycle;
 import software.amazon.awssdk.services.ses.SesClient;
@@ -18,10 +20,12 @@ import software.amazon.awssdk.services.ses.model.Content;
 import software.amazon.awssdk.services.ses.model.Destination;
 import software.amazon.awssdk.services.ses.model.Message;
 import software.amazon.awssdk.services.ses.model.SendEmailRequest;
+import software.amazon.awssdk.services.ses.model.SesException;
 
 @Singleton
 public class SimpleEmail {
   public static final String AWS_SES_SENDER_CONF_PATH = "aws.ses.sender";
+  private static final Logger LOG = LoggerFactory.getLogger(SimpleEmail.class);
 
   private final String sender;
   private final Client client;
@@ -51,18 +55,22 @@ public class SimpleEmail {
   }
 
   public void send(ImmutableList<String> toAddresses, String subject, String bodyText) {
+    try {
+      Destination destination =
+          Destination.builder().toAddresses(toAddresses.toArray(new String[0])).build();
 
-    Destination destination =
-        Destination.builder().toAddresses(toAddresses.toArray(new String[0])).build();
+      Body body = Body.builder().text(Content.builder().data(bodyText).build()).build();
 
-    Body body = Body.builder().text(Content.builder().data(bodyText).build()).build();
+      Message msg =
+          Message.builder().subject(Content.builder().data(subject).build()).body(body).build();
 
-    Message msg =
-        Message.builder().subject(Content.builder().data(subject).build()).body(body).build();
-
-    SendEmailRequest emailRequest =
-        SendEmailRequest.builder().destination(destination).message(msg).source(sender).build();
-    client.get().sendEmail(emailRequest);
+      SendEmailRequest emailRequest =
+          SendEmailRequest.builder().destination(destination).message(msg).source(sender).build();
+      client.get().sendEmail(emailRequest);
+    } catch (SesException e) {
+      LOG.error(e.toString());
+      e.printStackTrace();
+    }
   }
 
   interface Client {

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -242,4 +242,10 @@ public interface ProgramService {
 
   /** Create a new draft starting from the program specified by `id`. */
   ProgramDefinition newDraftOf(long id) throws ProgramNotFoundException;
+
+  /**
+   * Get the email addresses to send a notification to - the program admins if there are any, or the
+   * global admins if none.
+   */
+  ImmutableList<String> getNotificationEmailAddresses(String programName);
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -202,7 +202,7 @@ public class ProgramServiceImpl implements ProgramService {
   @Override
   public ImmutableList<String> getNotificationEmailAddresses(String programName) {
     ImmutableList<String> explicitProgramAdmins =
-        this.programRepository.getProgramAdministrators(programName).stream()
+        programRepository.getProgramAdministrators(programName).stream()
             .map(Account::getEmailAddress)
             .filter(address -> !Strings.isNullOrEmpty(address))
             .collect(ImmutableList.toImmutableList());
@@ -211,7 +211,7 @@ public class ProgramServiceImpl implements ProgramService {
       return explicitProgramAdmins;
     }
     // Return all the global admins email addresses.
-    return this.userRepository.getGlobalAdmins().stream()
+    return userRepository.getGlobalAdmins().stream()
         .map(Account::getEmailAddress)
         .filter(address -> !Strings.isNullOrEmpty(address))
         .collect(ImmutableList.toImmutableList());


### PR DESCRIPTION
### Description
- Notify real program admins instead of a static mailing list
- Notify global admin if no program admins are configured
- Use @seattle.gov email domain in prod

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#193 
