### PR TITLE
Require unique entity names

### DIFF
--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -31,6 +31,7 @@ public enum MessageKey {
   ENUMERATOR_BUTTON_ARIA_LABEL_DELETE_ENTITY("button.ariaLabel.deleteEntity"),
   ENUMERATOR_PLACEHOLDER_ENTITY_NAME("placeholder.entityName"),
   ENUMERATOR_VALIDATION_ENTITY_REQUIRED("validation.entityNameRequired"),
+  ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME("validation.duplicateEntityName"),
   LINK_VIEW_APPLICATIONS("link.viewApplications"),
   MULTI_SELECT_VALIDATION_TOO_FEW("validation.tooFewSelections"),
   MULTI_SELECT_VALIDATION_TOO_MANY("validation.tooManySelections"),

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -33,14 +33,24 @@ public class EnumeratorQuestion implements PresentsErrors {
     return ImmutableSet.of();
   }
 
-  /** No blank values are allowed. */
+  /** No blank values are allowed. No duplicated entity names are allowed. */
   @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
-    if (isAnswered() && getEntityNames().stream().anyMatch(String::isBlank)) {
-      return ImmutableSet.of(
+    if (!isAnswered()) {
+      return ImmutableSet.of();
+    }
+
+    ImmutableSet.Builder<ValidationErrorMessage> errorsBuilder = ImmutableSet.builder();
+    ImmutableList<String> entityNames = getEntityNames();
+    if (entityNames.stream().anyMatch(String::isBlank)) {
+      errorsBuilder.add(
           ValidationErrorMessage.create(MessageKey.ENUMERATOR_VALIDATION_ENTITY_REQUIRED));
     }
-    return ImmutableSet.of();
+    if (entityNames.stream().collect(ImmutableSet.toImmutableSet()).size() != entityNames.size()) {
+      errorsBuilder.add(
+          ValidationErrorMessage.create(MessageKey.ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME));
+    }
+    return errorsBuilder.build();
   }
 
   public void assertQuestionType() {

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -106,7 +106,7 @@ button.ariaLabel.deleteEntity=Delete {0}
 validation.entityNameRequired=Please enter a value for each line.
 
 # Validation error that shows when an applicant uses a duplicate entity name
-validation.duplicateEntityName=Please use unique names.
+validation.duplicateEntityName=Please enter a unique value for each line.
 
 # The placeholder text for enumerator fields
 placeholder.entityName=Nickname for {0}

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -105,6 +105,9 @@ button.ariaLabel.deleteEntity=Delete {0}
 # Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Please enter a value for each line.
 
+# Validation error that shows when an applicant uses a duplicate entity name
+validation.duplicateEntityName=Please use unique names.
+
 # The placeholder text for enumerator fields
 placeholder.entityName=Nickname for {0}
 

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -117,7 +117,7 @@ public class EnumeratorQuestionTest extends WithPostgresContainer {
     assertThat(enumeratorQuestion.hasQuestionErrors()).isTrue();
     assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
     assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
-        .isEqualTo("Please use unique names.");
+        .isEqualTo("Please enter a unique value for each line.");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -91,12 +91,33 @@ public class EnumeratorQuestionTest extends WithPostgresContainer {
     EnumeratorQuestion enumeratorQuestion = new EnumeratorQuestion(applicantQuestion);
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
-    assertThat(enumeratorQuestion.getEntityNames()).contains(value);
+    assertThat(enumeratorQuestion.getEntityNames()).containsExactly(value);
     assertThat(enumeratorQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(enumeratorQuestion.hasQuestionErrors()).isTrue();
     assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
     assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
         .isEqualTo("Please enter a value for each line.");
+  }
+
+  @Test
+  public void withDuplicateNames_hasValidationErrors() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            enumeratorQuestionDefinition, applicantData, ApplicantData.APPLICANT_PATH);
+    QuestionAnswerer.answerEnumeratorQuestion(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        ImmutableList.of("hello", "hello"));
+
+    EnumeratorQuestion enumeratorQuestion = new EnumeratorQuestion(applicantQuestion);
+
+    assertThat(enumeratorQuestion.isAnswered()).isTrue();
+    assertThat(enumeratorQuestion.getEntityNames()).containsExactly("hello", "hello");
+    assertThat(enumeratorQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(enumeratorQuestion.hasQuestionErrors()).isTrue();
+    assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
+    assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
+        .isEqualTo("Please use unique names.");
   }
 
   @Test


### PR DESCRIPTION
### Description
Enumerator question validation now makes sure applicant-provided entity names are unique.

![image](https://user-images.githubusercontent.com/12072571/118233815-5106a600-b447-11eb-9b7b-efe59896d6e8.png)
