### PR TITLE
Enable ability to breakglass access AWS database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ RUNNING_PID
 node_modules
 bundle.js
 tailwind.css
+*.pem

--- a/bin/breakglass-db-access
+++ b/bin/breakglass-db-access
@@ -1,17 +1,21 @@
 #! /bin/bash
 
+set -e
+
 export AWS_DEFAULT_REGION=us-west-2
 TIMESTAMP=$(date +%s)
+ENVIRONMENT=staging
+STAGING_DB_PASSWORD_ID=arn:aws:secretsmanager:us-west-2:405662711265:secret:staging-databasepassword-rh1wfF
 
 VPC_ID=$(aws ec2 describe-vpcs \
-    --filters Name=tag:Name,Values=staging.civiform.vpc \
+    --filters Name=tag:Name,Values=$ENVIRONMENT.civiform.vpc \
     --query 'Vpcs[0].VpcId' \
-    --output text) && echo "Staging VPC ID: $VPC_ID"
+    --output text) && echo "$ENVIRONMENT VPC ID: $VPC_ID"
 
 # Create a new security group and allow my IP for inbound
 SG_ID=$(aws ec2 create-security-group \
-    --group-name staging.civiform-emergencyaccess.sg \
-    --description "My staging emergency access security group" \
+    --group-name $ENVIRONMENT.civiform-emergencyaccess-$TIMESTAMP.sg \
+    --description "My $ENVIRONMENT emergency access security group" \
     --vpc-id $VPC_ID \
     --query 'GroupId' \
     --output text) && echo "Created a new security group (ID: $SG_ID) for emergency access"
@@ -25,7 +29,7 @@ aws ec2 authorize-security-group-ingress \
 
 # Allow the new security group to access DB
 DBSG_ID=$(aws ec2 describe-security-groups \
-    --filters Name=vpc-id,Values=$VPC_ID Name=group-name,Values=staging.civiform-db.sg \
+    --filters Name=vpc-id,Values=$VPC_ID Name=group-name,Values=$ENVIRONMENT.civiform-db.sg \
     --query 'SecurityGroups[0].GroupId' \
     --output text) && echo "Authorize emergency access to DB security group (ID: $DBSG_ID)"
 aws ec2 authorize-security-group-ingress \
@@ -36,7 +40,7 @@ aws ec2 authorize-security-group-ingress \
 
 # Create a new key pair for my EC2 instance
 echo "Creating a new key pair for launching an EC2 instance"
-KEY_NAME=CiviFormEmergencyKeyPair$TIMESTAMP
+KEY_NAME=CiviFormEmergencyKeyPair$TIMESTAMP$ENVIRONMENT
 KEY_FILE=$KEY_NAME.pem
 aws ec2 create-key-pair \
     --key-name $KEY_NAME \
@@ -47,7 +51,7 @@ echo "Private key is stored locally as $KEY_FILE"
 
 # Find the subnet to launch the instance into
 SUBNET_ID=$(aws ec2 describe-subnets \
-    --filters Name=vpc-id,Values=$VPC_ID Name=tag:Name,Values=staging.public-az1.subnet \
+    --filters Name=vpc-id,Values=$VPC_ID Name=tag:Name,Values=$ENVIRONMENT.public-az1.subnet \
     --query 'Subnets[0].SubnetId' \
     --output text) && echo "Found public subnet (ID: $SUBNET_ID) to launch the instance into"
 
@@ -63,7 +67,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --output text) && \
     echo "Created EC2 instance (ID: $INSTANCE_ID) and waiting for it to be ready. This may take 3-5 minutes."
 aws ec2 create-tags --resources $INSTANCE_ID \
-    --tags Key=Name,Value=MyEmergencyDBAccessInstance$TIMESTAMP
+    --tags Key=Name,Value=MyEmergencyDBAccessInstance$TIMESTAMP$ENVIRONMENT
 
 # Wait until the instance is available for connection
 until aws ec2 wait instance-status-ok --instance-ids $INSTANCE_ID; do :; done
@@ -74,13 +78,13 @@ INSTANCE_IPADDRESS=$(aws ec2 describe-instances \
 
 # Find the DB address
 DB_ADDRESS=$(aws rds describe-db-instances \
-    --db-instance-identifier staging-civiform-postgres-db \
+    --db-instance-identifier $ENVIRONMENT-civiform-postgres-db \
     --query 'DBInstances[0].Endpoint.Address' \
     --output text) && echo "DB address: $DB_ADDRESS"
 
 # Get the DB password
 DB_PASSWORD=$(aws secretsmanager get-secret-value \
-    --secret-id arn:aws:secretsmanager:us-west-2:405662711265:secret:staging-databasepassword-rh1wfF \
+    --secret-id $STAGING_DB_PASSWORD_ID \
     --query 'SecretString' \
     --output text)
 

--- a/bin/breakglass-db-access
+++ b/bin/breakglass-db-access
@@ -1,0 +1,118 @@
+#! /bin/bash
+
+export AWS_DEFAULT_REGION=us-west-2
+TIMESTAMP=$(date +%s)
+
+VPC_ID=$(aws ec2 describe-vpcs \
+    --filters Name=tag:Name,Values=staging.civiform.vpc \
+    --query 'Vpcs[0].VpcId' \
+    --output text) && echo "Staging VPC ID: $VPC_ID"
+
+# Create a new security group and allow my IP for inbound
+SG_ID=$(aws ec2 create-security-group \
+    --group-name staging.civiform-emergencyaccess.sg \
+    --description "My staging emergency access security group" \
+    --vpc-id $VPC_ID \
+    --query 'GroupId' \
+    --output text) && echo "Created a new security group (ID: $SG_ID) for emergency access"
+MY_IPADDRESS=$(curl -s https://checkip.amazonaws.com) && \
+    echo "Authorize my IP ($MY_IPADDRESS) to access the security group"
+aws ec2 authorize-security-group-ingress \
+    --group-id $SG_ID \
+    --protocol tcp \
+    --port 22 \
+    --cidr $MY_IPADDRESS/32
+
+# Allow the new security group to access DB
+DBSG_ID=$(aws ec2 describe-security-groups \
+    --filters Name=vpc-id,Values=$VPC_ID Name=group-name,Values=staging.civiform-db.sg \
+    --query 'SecurityGroups[0].GroupId' \
+    --output text) && echo "Authorize emergency access to DB security group (ID: $DBSG_ID)"
+aws ec2 authorize-security-group-ingress \
+    --group-id $DBSG_ID \
+    --protocol tcp \
+    --port 0-65535 \
+    --source-group $SG_ID
+
+# Create a new key pair for my EC2 instance
+echo "Creating a new key pair for launching an EC2 instance"
+KEY_NAME=CiviFormEmergencyKeyPair$TIMESTAMP
+KEY_FILE=$KEY_NAME.pem
+aws ec2 create-key-pair \
+    --key-name $KEY_NAME \
+    --query 'KeyMaterial' \
+    --output text > $KEY_FILE
+chmod 400 $KEY_FILE
+echo "Private key is stored locally as $KEY_FILE"
+
+# Find the subnet to launch the instance into
+SUBNET_ID=$(aws ec2 describe-subnets \
+    --filters Name=vpc-id,Values=$VPC_ID Name=tag:Name,Values=staging.public-az1.subnet \
+    --query 'Subnets[0].SubnetId' \
+    --output text) && echo "Found public subnet (ID: $SUBNET_ID) to launch the instance into"
+
+# Launch a small ubuntu VM
+INSTANCE_ID=$(aws ec2 run-instances \
+    --image-id ami-03d5c68bab01f3496 \
+    --count 1 \
+    --instance-type t2.micro \
+    --key-name $KEY_NAME \
+    --security-group-ids $SG_ID \
+    --subnet-id $SUBNET_ID \
+    --query 'Instances[0].InstanceId' \
+    --output text) && \
+    echo "Created EC2 instance (ID: $INSTANCE_ID) and waiting for it to be ready. This may take 3-5 minutes."
+aws ec2 create-tags --resources $INSTANCE_ID \
+    --tags Key=Name,Value=MyEmergencyDBAccessInstance$TIMESTAMP
+
+# Wait until the instance is available for connection
+until aws ec2 wait instance-status-ok --instance-ids $INSTANCE_ID; do :; done
+INSTANCE_IPADDRESS=$(aws ec2 describe-instances \
+    --instance-ids $INSTANCE_ID \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text) && echo "Instance public IP: $INSTANCE_IPADDRESS"
+
+# Find the DB address
+DB_ADDRESS=$(aws rds describe-db-instances \
+    --db-instance-identifier staging-civiform-postgres-db \
+    --query 'DBInstances[0].Endpoint.Address' \
+    --output text) && echo "DB address: $DB_ADDRESS"
+
+# Get the DB password
+DB_PASSWORD=$(aws secretsmanager get-secret-value \
+    --secret-id arn:aws:secretsmanager:us-west-2:405662711265:secret:staging-databasepassword-rh1wfF \
+    --query 'SecretString' \
+    --output text)
+
+# Connect to the instance, install psql, and connect to DB
+echo "Connecting to the database"
+ssh -q -o UserKnownHostsFile=/dev/null \
+    -o StrictHostKeyChecking=no \
+    -o IdentitiesOnly=yes \
+    -t -i $KEY_FILE \
+    ubuntu@$INSTANCE_IPADDRESS \
+    "yes | sudo apt-get update > /dev/null; \
+        yes | sudo apt-get install postgresql-client > /dev/null; \
+        PGPASSWORD='$DB_PASSWORD' psql -h $DB_ADDRESS -d postgres -U civiform"
+
+# Terminate the instance
+echo "Terminating the instance"
+aws ec2 terminate-instances --instance-ids $INSTANCE_ID
+
+# Delete the emergency key pair
+echo "Removing key pair"
+aws ec2 delete-key-pair --key-name $KEY_NAME
+rm -f $KEY_FILE
+
+# Remove the emergency security group from DB security group
+echo "Revoke access to DB security group"
+aws ec2 revoke-security-group-ingress \
+    --group-id $DBSG_ID \
+    --protocol tcp \
+    --port 0-65535 \
+    --source-group $SG_ID
+
+# Remove the emergency security group
+echo "Removing the emergency security group"
+until aws ec2 wait instance-terminated --instance-ids $INSTANCE_ID; do :; done
+aws ec2 delete-security-group --group-id $SG_ID


### PR DESCRIPTION
### Description
- The database is in private subnets so we need to create an EC2 instance in a public subnet and relay our access to it
- We create a new security group allowing only our own IP and attach it to the DB security group ingress
- Create a new key pair for the EC2 instance and store private key locally
- Launch the instance in the public subnet with the new security group, wait for it, and connect to it
- Install `psql` client in the new instance and use it to access the database
- Clean up everything after the access
- The script connects to staging right now, not prod

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

