### PR TITLE
Admins aren't meant to access all applicants anymore.

### DIFF
--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -12,12 +12,12 @@ describe('applicant security', () => {
     await endSession(browser);
   });
 
-  it('admin can access applicant pages', async () => {
+  it('admin cannot access applicant pages', async () => {
     const { browser, page } = await startSession();
 
     await loginAsAdmin(page);
     const response = await gotoEndpoint(page, '/applicants/1234567/programs');
-    expect(response.status()).toBe(200);
+    expect(response.status()).toBe(401);
 
     await endSession(browser);
   });

--- a/universal-application-tool-0.0.1/app/auth/UatProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfile.java
@@ -110,10 +110,6 @@ public class UatProfile {
   }
 
   public CompletableFuture<Void> checkAuthorization(long applicantId) {
-    if (isUatAdmin()) {
-      return CompletableFuture.completedFuture(null);
-    }
-
     return getAccount()
         .thenApplyAsync(
             account ->

--- a/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
+++ b/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
@@ -1,8 +1,10 @@
 package auth;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
+import java.util.concurrent.CompletionException;
 import models.Account;
 import models.Applicant;
 import org.junit.Before;
@@ -19,11 +21,16 @@ public class UatProfileTest extends WithPostgresContainer {
   }
 
   @Test
-  public void checkAuthorization_admin_passesForAnyId() {
+  public void checkAuthorization_admin_failsForApplicantId() {
     UatProfileData data = profileFactory.createNewAdmin();
     UatProfile profile = profileFactory.wrapProfileData(data);
 
-    profile.checkAuthorization(1234L).join();
+    try {
+      profile.checkAuthorization(1234L).join();
+      fail("Should not have successfully authorized admin.");
+    } catch (CompletionException e) {
+      // pass.
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description
Remove the permission for admins to access all applicant's pages.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
