### PR TITLE
Applicants in review will go to the next incomplete block if there is…

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -81,17 +81,22 @@ describe('End to end enumerator test', () => {
     await applicantQuestions.answerNameQuestion("enum one first", "enum one last");
     await applicantQuestions.saveAndContinue();
 
-    // Put nothing in the first nested enumerator
+    // Put one thing in the nested enumerator for enum one
+    await applicantQuestions.addEnumeratorAnswer("enum one's first thing");
     await applicantQuestions.saveAndContinue();
+
+    // Answer the nested repeated question
+    await applicantQuestions.answerTextQuestion("hello world");
+    await applicantQuestions.saveAndContinue()
 
     // SECOND REPEATED ENTITY
     // Answer name
     await applicantQuestions.answerNameQuestion("enum two first", "enum two last");
     await applicantQuestions.saveAndContinue();
 
-    // Put two things in the second nested enumerator
-    await applicantQuestions.addEnumeratorAnswer("thing one");
-    await applicantQuestions.addEnumeratorAnswer("thing two");
+    // Put two things in the nested enumerator for enum two
+    await applicantQuestions.addEnumeratorAnswer("enum two's first thing");
+    await applicantQuestions.addEnumeratorAnswer("enum two's second thing");
     await applicantQuestions.saveAndContinue();
 
     // Answer two nested repeated text questions
@@ -107,8 +112,10 @@ describe('End to end enumerator test', () => {
     expect(await page.innerText("#application-summary")).toContain("enum one last");
     expect(await page.innerText("#application-summary")).toContain("enum two first");
     expect(await page.innerText("#application-summary")).toContain("enum two last");
-    expect(await page.innerText("#application-summary")).toContain("thing one");
-    expect(await page.innerText("#application-summary")).toContain("thing two");
+    expect(await page.innerText("#application-summary")).toContain("enum one's first thing");
+    expect(await page.innerText("#application-summary")).toContain("hello world");
+    expect(await page.innerText("#application-summary")).toContain("enum two's first thing");
+    expect(await page.innerText("#application-summary")).toContain("enum two's second thing");
     expect(await page.innerText("#application-summary")).toContain("hello");
     expect(await page.innerText("#application-summary")).toContain("world");
 
@@ -118,9 +125,33 @@ describe('End to end enumerator test', () => {
     await applicantQuestions.deleteEnumeratorEntity("enum two");
     await applicantQuestions.saveAndContinue();
 
+
     // Make sure there are no enumerators or repeated things in the review page
     expect(await page.innerText("#application-summary")).toContain("first name");
     expect(await page.innerText("#application-summary")).toContain("last name");
+    expect(await page.innerText("#application-summary")).not.toContain("enum one first");
+    expect(await page.innerText("#application-summary")).not.toContain("enum one last");
+    expect(await page.innerText("#application-summary")).not.toContain("enum two first");
+    expect(await page.innerText("#application-summary")).not.toContain("enum two last");
+    expect(await page.innerText("#application-summary")).not.toContain("thing one");
+    expect(await page.innerText("#application-summary")).not.toContain("thing two");
+    expect(await page.innerText("#application-summary")).not.toContain("hello");
+    expect(await page.innerText("#application-summary")).not.toContain("world");
+
+
+    // Go back and add an enumerator answer.
+    await page.click('.cf-applicant-summary-row:has(div:has-text("enumerator-ete-question")) a:has-text("Edit")');
+    await applicantQuestions.addEnumeratorAnswer("enum three");
+    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.answerNameQuestion("enum three first", "enum three last");
+    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.saveAndContinue();
+
+    // Make sure there are no enumerators or repeated things in the review page
+    expect(await page.innerText("#application-summary")).toContain("first name");
+    expect(await page.innerText("#application-summary")).toContain("last name");
+    expect(await page.innerText("#application-summary")).toContain("enum three first");
+    expect(await page.innerText("#application-summary")).toContain("enum three last");
     expect(await page.innerText("#application-summary")).not.toContain("enum one first");
     expect(await page.innerText("#application-summary")).not.toContain("enum one last");
     expect(await page.innerText("#application-summary")).not.toContain("enum two first");

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -253,10 +253,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
 
     if (inReview) {
       // TODO(https://github.com/seattle-uat/civiform/issues/1141): the filter here is because empty
-      // enumerators
-      //  are always incomplete and applicants can get stuck in a review loop if we didn't have this
-      // here.
-      //  This can be removed once #1141 is done.
+      //  enumerators are always incomplete and applicants can get stuck in a review loop if we
+      //  didn't have this here. This can be removed once #1141 is done.
       Optional<String> nextBlockIdMaybe =
           roApplicantProgramService
               .getFirstIncompleteBlock()

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -251,16 +251,39 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           .build())));
     }
 
-    Optional<String> nextBlockIdMaybe =
-        roApplicantProgramService.getBlockAfter(blockId).map(Block::getId);
-    return nextBlockIdMaybe.isEmpty() || inReview
-        ? supplyAsync(
-            () -> redirect(routes.ApplicantProgramReviewController.review(applicantId, programId)))
-        : supplyAsync(
-            () ->
-                redirect(
-                    routes.ApplicantProgramBlocksController.edit(
-                        applicantId, programId, nextBlockIdMaybe.get())));
+    if (inReview) {
+      // TODO(https://github.com/seattle-uat/civiform/issues/1141): the filter here is because empty
+      // enumerators
+      //  are always incomplete and applicants can get stuck in a review loop if we didn't have this
+      // here.
+      //  This can be removed once #1141 is done.
+      Optional<String> nextBlockIdMaybe =
+          roApplicantProgramService
+              .getFirstIncompleteBlock()
+              .map(Block::getId)
+              .filter(nextBlockId -> !nextBlockId.equals(blockId));
+      return nextBlockIdMaybe.isEmpty()
+          ? supplyAsync(
+              () ->
+                  redirect(routes.ApplicantProgramReviewController.review(applicantId, programId)))
+          : supplyAsync(
+              () ->
+                  redirect(
+                      routes.ApplicantProgramBlocksController.review(
+                          applicantId, programId, nextBlockIdMaybe.get())));
+    } else {
+      Optional<String> nextBlockIdMaybe =
+          roApplicantProgramService.getInProgressBlockAfter(blockId).map(Block::getId);
+      return nextBlockIdMaybe.isEmpty()
+          ? supplyAsync(
+              () ->
+                  redirect(routes.ApplicantProgramReviewController.review(applicantId, programId)))
+          : supplyAsync(
+              () ->
+                  redirect(
+                      routes.ApplicantProgramBlocksController.edit(
+                          applicantId, programId, nextBlockIdMaybe.get())));
+    }
   }
 
   private ImmutableMap<String, String> cleanForm(Map<String, String> formData) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -31,11 +31,10 @@ public interface ReadOnlyApplicantProgramService {
   /** Get the block with the given block ID */
   Optional<Block> getBlock(String blockId);
 
-  /** Get the block that comes after the block with the given ID if there is one. */
-  Optional<Block> getBlockAfter(String blockId);
-
-  /** Get the block that comes after the given block if there is one. */
-  Optional<Block> getBlockAfter(Block block);
+  /**
+   * Get the next in-progress block that comes after the block with the given ID if there is one.
+   */
+  Optional<Block> getInProgressBlockAfter(String blockId);
 
   /** Gets the completion percent based on current block index. */
   int getCompletionPercent(String blockId);

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -310,7 +310,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
 
-    Optional<Block> maybeBlock = subject.getBlockAfter("1");
+    Optional<Block> maybeBlock = subject.getInProgressBlockAfter("1");
 
     assertThat(maybeBlock).isPresent();
     assertThat(maybeBlock.get().getId()).isEqualTo("2");
@@ -321,7 +321,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
 
-    Optional<Block> maybeBlock = subject.getBlockAfter("321");
+    Optional<Block> maybeBlock = subject.getInProgressBlockAfter("321");
 
     assertThat(maybeBlock).isEmpty();
   }
@@ -340,7 +340,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                     LocalizedStrings.of(Locale.US, "This program is for testing."))
                 .build());
 
-    Optional<Block> maybeBlock = subject.getBlockAfter("321");
+    Optional<Block> maybeBlock = subject.getInProgressBlockAfter("321");
 
     assertThat(maybeBlock).isEmpty();
   }


### PR DESCRIPTION
… one, instead of always going back to the review page.

### Description
* Refactor the `ReadOnlyApplicantProgramServiceImpl#getBlocks` to take a `Predicate`.
* Change the logic at the end of `ApplicantProgramBlocksController#update` to do something different for `inReview`.
* Rename `getBlockAfter` to `getIncompleteBlockAfter` to be really clear what this method is doing.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1034 