### PR TITLE
Update the way we compute "completion percentage"

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -114,8 +114,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             .setInReview(inReview)
                             .setBlockIndex(roApplicantProgramService.getBlockIndex(blockId))
                             .setTotalBlockCount(roApplicantProgramService.getAllBlocks().size())
-                            .setPercentComplete(
-                                roApplicantProgramService.getCompletionPercent(blockId))
                             .setPreferredLanguageSupported(
                                 roApplicantProgramService.preferredLanguageSupported())
                             .setAmazonS3Client(amazonS3Client)
@@ -245,8 +243,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           .setBlock(thisBlockUpdated)
                           .setBlockIndex(roApplicantProgramService.getBlockIndex(blockId))
                           .setTotalBlockCount(roApplicantProgramService.getAllBlocks().size())
-                          .setPercentComplete(
-                              roApplicantProgramService.getCompletionPercent(blockId))
                           .setInReview(inReview)
                           .setPreferredLanguageSupported(
                               roApplicantProgramService.preferredLanguageSupported())

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -112,6 +112,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             .setProgramId(programId)
                             .setBlock(block.get())
                             .setInReview(inReview)
+                            .setBlockIndex(roApplicantProgramService.getBlockIndex(blockId))
+                            .setTotalBlockCount(roApplicantProgramService.getAllBlocks().size())
                             .setPercentComplete(
                                 roApplicantProgramService.getCompletionPercent(blockId))
                             .setPreferredLanguageSupported(
@@ -241,6 +243,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           .setApplicantId(applicantId)
                           .setProgramId(programId)
                           .setBlock(thisBlockUpdated)
+                              .setBlockIndex(roApplicantProgramService.getBlockIndex(blockId))
+                              .setTotalBlockCount(roApplicantProgramService.getAllBlocks().size())
                           .setPercentComplete(
                               roApplicantProgramService.getCompletionPercent(blockId))
                           .setInReview(inReview)

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -40,9 +40,6 @@ public interface ReadOnlyApplicantProgramService {
   /** Returns the index of the given block in the context of all blocks of the program. */
   int getBlockIndex(String blockId);
 
-  /** Gets the completion percent based on the given block's index. */
-  int getCompletionPercent(String blockId);
-
   /** Get the program block with the lowest index that has missing answer data if there is one. */
   Optional<Block> getFirstIncompleteBlock();
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -37,7 +37,10 @@ public interface ReadOnlyApplicantProgramService {
   /** Get the block that comes after the given block if there is one. */
   Optional<Block> getBlockAfter(Block block);
 
-  /** Gets the completion percent based on current block index. */
+  /** Returns the index of the given block in the context of all blocks of the program. */
+  int getBlockIndex(String blockId);
+
+  /** Gets the completion percent based on the given block's index. */
   int getCompletionPercent(String blockId);
 
   /** Get the program block with the lowest index that has missing answer data if there is one. */

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -89,31 +89,6 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
-  public int getCompletionPercent(String blockId) {
-    ImmutableList<Block> blocks = getAllBlocks();
-
-    double blockCount = blocks.size();
-    // If there aren't any blocks then I guess we're done.
-    if (blockCount == 0) {
-      return 100;
-    }
-
-    double blockIndex = getBlockIndex(blockId);
-
-    // If the block doesn't exist then return 0.
-    if (blockIndex == -1) {
-      return 0;
-    }
-
-    // If we're on the first block, move the needle a little.
-    if (blockIndex == 0) {
-      blockIndex = 0.1;
-    }
-
-    return (int) ((blockIndex / blockCount) * 100.0);
-  }
-
-  @Override
   public Optional<Block> getFirstIncompleteBlock() {
     return getInProgressBlocks().stream()
         .filter(block -> !block.isCompleteWithoutErrors())

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import services.LocalizedStrings;
 import services.Path;
 import services.applicant.question.ApplicantQuestion;
@@ -78,6 +80,17 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
+  public int getBlockIndex(String blockId) {
+    ImmutableList<Block> allBlocks = getAllBlocks();
+
+    for (int i = 0; i < allBlocks.size(); i++) {
+      if (allBlocks.get(i).getId().equals(blockId)) return i;
+    }
+
+    return -1;
+  }
+
+  @Override
   public int getCompletionPercent(String blockId) {
     ImmutableList<Block> blocks = getAllBlocks();
 
@@ -87,12 +100,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
       return 100;
     }
 
-    double blockIndex = -1;
-    for (int i = 0; i < blocks.size() && blockIndex == -1; i++) {
-      if (blocks.get(i).getId().equals(blockId)) {
-        blockIndex = i;
-      }
-    }
+    double blockIndex = getBlockIndex(blockId);
 
     // If the block doesn't exist then return 0.
     if (blockIndex == -1) {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -146,47 +146,32 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
     }
 
     abstract boolean inReview();
-
     abstract Http.Request request();
-
     abstract Messages messages();
-
+    abstract int blockIndex();
+    abstract int totalBlockCount();
     abstract int percentComplete();
-
     abstract long applicantId();
-
     abstract long programId();
-
     abstract Block block();
-
     abstract boolean preferredLanguageSupported();
-
     abstract SimpleStorage amazonS3Client();
-
     abstract String baseUrl();
 
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder setRequest(Http.Request request);
-
       public abstract Builder setInReview(boolean inReview);
-
       public abstract Builder setMessages(Messages messages);
-
+      public abstract Builder setBlockIndex(int blockIndex);
+      public abstract Builder setTotalBlockCount(int blockIndex);
       public abstract Builder setPercentComplete(int percentComplete);
-
       public abstract Builder setApplicantId(long applicantId);
-
       public abstract Builder setProgramId(long programId);
-
       public abstract Builder setBlock(Block block);
-
       public abstract Builder setPreferredLanguageSupported(boolean preferredLanguageSupported);
-
       public abstract Builder setAmazonS3Client(SimpleStorage amazonS3Client);
-
       public abstract Builder setBaseUrl(String baseUrl);
-
       public abstract Params build();
     }
   }

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -68,19 +68,16 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
     return layout.renderWithNav(params.request(), params.messages(), bundle);
   }
 
+  /** Returns whole number out of 100 representing the completion percent of this program. */
   private int getPercentComplete(int blockIndex, int totalBlockCount) {
     if (totalBlockCount == 0) return 100;
-
-    // Block doesn't exist.
     if (blockIndex == -1) return 0;
 
-    // TODO: See if I need to cast to doubles.
-
-    // Add one to blockIndex for 1-based indexing.
-    // Add one to totalBlockCount so that even when the applicant is on the last block (but hasn't
-    // yet submitted it),
-    // they're still "in progress". Save 100% for the application review page.
-    return (int) (((blockIndex + 1) / (totalBlockCount + 1)) * 100.0);
+    // Add one to blockIndex for 1-based indexing, so that when applicant is on first block, we show
+    // some amount of progress.
+    // Add one to totalBlockCount so that when applicant is on the last block, we show that they're
+    // still in progress. Save showing "100% completion" for the application review page.
+    return (int) (((blockIndex + 1.0) / (totalBlockCount + 1.0)) * 100.0);
   }
 
   /**
@@ -175,8 +172,6 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
     abstract int totalBlockCount();
 
-    abstract int percentComplete();
-
     abstract long applicantId();
 
     abstract long programId();
@@ -200,8 +195,6 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
       public abstract Builder setBlockIndex(int blockIndex);
 
       public abstract Builder setTotalBlockCount(int blockIndex);
-
-      public abstract Builder setPercentComplete(int percentComplete);
 
       public abstract Builder setApplicantId(long applicantId);
 

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -40,7 +40,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
   }
 
   public Content render(Params params) {
-    ContainerTag headerTag = layout.renderHeader(params.percentComplete());
+    ContainerTag headerTag = layout.renderHeader(getPercentComplete(params.blockIndex(), params.totalBlockCount()));
 
     ContainerTag body =
         body().with(h1(params.block().getName())).with(renderBlockWithSubmitForm(params));
@@ -61,6 +61,20 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
     }
 
     return layout.render(params.request(), params.messages(), headerTag, body);
+  }
+
+  private double getPercentComplete(int blockIndex, int totalBlockCount) {
+    if (totalBlockCount == 0) return 100;
+
+    // Block doesn't exist.
+    if (blockIndex == -1) return 0;
+
+    // TODO: See if I need to cast to doubles.
+
+    // Add one to blockIndex for 1-based indexing.
+    // Add one to totalBlockCount so that even when the applicant is on the last block (but hasn't yet submitted it),
+    // they're still "in progress". Save 100% for the application review page.
+    return (int) (((blockIndex + 1) / (totalBlockCount + 1)) * 100.0);
   }
 
   /**

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -538,6 +538,15 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
   }
 
   @Test
+  public void getBlockIndex() {
+    ReadOnlyApplicantProgramService subject = new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
+
+    assertThat(subject.getBlockIndex("1")).isEqualTo(0);
+    assertThat(subject.getBlockIndex("2")).isEqualTo(1);
+    assertThat(subject.getBlockIndex("not a real block id")).isEqualTo(-1);
+  }
+
+  @Test
   public void getPercentComplete_returnsExpectedNumbers() {
     ReadOnlyApplicantProgramService subject =
         new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -547,16 +547,6 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     assertThat(subject.getBlockIndex("not a real block id")).isEqualTo(-1);
   }
 
-  @Test
-  public void getPercentComplete_returnsExpectedNumbers() {
-    ReadOnlyApplicantProgramService subject =
-        new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition);
-
-    assertThat(subject.getCompletionPercent("1")).isEqualTo(5);
-    assertThat(subject.getCompletionPercent("2")).isEqualTo(50);
-    assertThat(subject.getCompletionPercent("3")).isEqualTo(0);
-  }
-
   private void answerNameQuestion(long programId) {
     Path path = Path.create("applicant.applicant_name");
     QuestionAnswerer.answerNameQuestion(applicantData, path, "Alice", "Middle", "Last");


### PR DESCRIPTION
### Description
* Update the `ReadOnlyApplicantProgramService` interface to provide the index of a block (rather than the percentage, which is more of a UI-oriented detail that can be computed from the index and size of block list)
* Change the formula for computing the percentage. Add one to both the index and the total block count (see code comments for why).

This update will also be useful for showing, e.g, "3 of 10" as shown in the new UX mocks. Will add this UI feature in a separate PR.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

 