### PR TITLE
Contextualize applicant question text and help text with its repeated entity

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/RepeatedEntity.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/RepeatedEntity.java
@@ -10,6 +10,9 @@ import services.question.types.EnumeratorQuestionDefinition;
 @AutoValue
 public abstract class RepeatedEntity {
 
+  private static final String REPLACEMENT_STRING = "$this";
+  private static final String REPLACEMENT_PARENT_STRING = "parent";
+
   /**
    * Create all the non-nested repeated entities associated with the enumerator question, with no
    * parent.
@@ -82,5 +85,29 @@ public abstract class RepeatedEntity {
     return parentPath
         .join(enumeratorQuestionDefinition().getQuestionPathSegment())
         .atIndex(index());
+  }
+
+  /**
+   * Contextualize the text with repeated entity names.
+   *
+   * <p>Replaces "$this" with this repeated entity's name. "$this.parent" and "$this.parent.parent"
+   * (ad infinitum) are replaced with the names of the ancestors of this repeated entity.
+   */
+  public String contextualize(String text) {
+    return contextualize(text, REPLACEMENT_STRING);
+  }
+
+  /**
+   * Recursive helper method for {@link #contextualize(String)}.
+   *
+   * <p>Recursively do the parents FIRST, because {@link String#replace} is eager and will replace
+   * "$this" first and mess up "$this.parent".
+   */
+  private String contextualize(String text, String target) {
+    String updatedText =
+        parent()
+            .map(p -> p.contextualize(text, target + "." + REPLACEMENT_PARENT_STRING))
+            .orElse(text);
+    return updatedText.replace(target, entityName());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -54,12 +54,24 @@ public class ApplicantQuestion {
     return questionDefinition.getQuestionType();
   }
 
+  /**
+   * Get the question text localized to the applicant's preferred locale, contextualized with {@link
+   * RepeatedEntity}.
+   */
   public String getQuestionText() {
-    return questionDefinition.getQuestionText().getOrDefault(applicantData.preferredLocale());
+    String text =
+        questionDefinition.getQuestionText().getOrDefault(applicantData.preferredLocale());
+    return repeatedEntity.map(r -> r.contextualize(text)).orElse(text);
   }
 
+  /**
+   * Get the question help text localized to the applicant's preferred locale, contextualized with
+   * {@link RepeatedEntity}.
+   */
   public String getQuestionHelpText() {
-    return questionDefinition.getQuestionHelpText().getOrDefault(applicantData.preferredLocale());
+    String helpText =
+        questionDefinition.getQuestionHelpText().getOrDefault(applicantData.preferredLocale());
+    return repeatedEntity.map(r -> r.contextualize(helpText)).orElse(helpText);
   }
 
   /**

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -283,8 +283,8 @@ public class TestQuestionBank {
             "household members jobs income",
             Optional.of(householdMemberJobs.id),
             "The applicant's household member's job's income",
-            LocalizedStrings.of(Locale.US, "What is the household member's job's income?"),
-            LocalizedStrings.of(Locale.US, "This is sample help text."));
+            LocalizedStrings.of(Locale.US, "What is $this.parent's income at $this?"),
+            LocalizedStrings.of(Locale.US, "What is the monthly income of $this.parent at $this?"));
 
     return maybeSave(definition);
   }


### PR DESCRIPTION
### Description
Question text and help text can be contextualized by the question's repeated entity by using `$this` and `$this.parent` (and `this.parent.parent`, ad infinitum) in the admin-configured strings.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Progress towards #1083