### PR TITLE
Standardize the way questions are rendered

### DIFF
--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -27,7 +27,7 @@ describe('normal application flow', () => {
 
     // Applicant fills out first application block.
     await applicantQuestions.answerNameQuestion('sarah', 'smith');
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Application submits answers from review page.
     await applicantQuestions.submitFromReviewPage(programName);

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -49,18 +49,18 @@ describe('normal application flow', () => {
     await applicantQuestions.answerAddressQuestion('1234 St', 'Unit B', 'Sim', 'Ames', '54321');
     await applicantQuestions.answerNameQuestion('Queen', 'Hearts', 'of');
     await applicantQuestions.answerRadioButtonQuestion('two');
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Applicant fills out second application block.
     await applicantQuestions.answerDropdownQuestion('banana');
     await applicantQuestions.answerCheckboxQuestion(['cherry', 'pine']);
     await applicantQuestions.answerNumberQuestion('42');
     await applicantQuestions.answerTextQuestion('some text');
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Applicant fills out third application block.
     await applicantQuestions.answerFileUploadQuestion('file key');
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Applicant submits answers from review page.
     await applicantQuestions.submitFromReviewPage(programName);

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -69,36 +69,36 @@ describe('End to end enumerator test', () => {
 
     // Fill in name question
     await applicantQuestions.answerNameQuestion("first name", "last name");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Put in two things in the enumerator question
     await applicantQuestions.addEnumeratorAnswer("enum one");
     await applicantQuestions.addEnumeratorAnswer("enum two");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // FIRST REPEATED ENTITY
     // Answer name
     await applicantQuestions.answerNameQuestion("enum one first", "enum one last");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Put nothing in the first nested enumerator
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // SECOND REPEATED ENTITY
     // Answer name
     await applicantQuestions.answerNameQuestion("enum two first", "enum two last");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Put two things in the second nested enumerator
     await applicantQuestions.addEnumeratorAnswer("thing one");
     await applicantQuestions.addEnumeratorAnswer("thing two");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Answer two nested repeated text questions
     await applicantQuestions.answerTextQuestion("hello");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
     await applicantQuestions.answerTextQuestion("world");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Make sure the enumerator answers are in the review page
     expect(await page.innerText("#application-summary")).toContain("first name");
@@ -116,7 +116,7 @@ describe('End to end enumerator test', () => {
     await page.click('.cf-applicant-summary-row:has(div:has-text("enumerator-ete-question")) a:has-text("Edit")');
     await applicantQuestions.deleteEnumeratorEntity("enum one");
     await applicantQuestions.deleteEnumeratorEntity("enum two");
-    await applicantQuestions.saveAndContinue();
+    await applicantQuestions.clickNext();
 
     // Make sure there are no enumerators or repeated things in the review page
     expect(await page.innerText("#application-summary")).toContain("first name");

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -64,8 +64,8 @@ export class ApplicantQuestions {
     await this.page.click(`.cf-application-card:has-text("${programName}") .cf-apply-button`);
   }
 
-  async saveAndContinue() {
-    await this.page.click('text="Save and continue"');
+  async clickNext() {
+    await this.page.click('text="Next"');
   }
 
   async submitFromReviewPage(programName: string) {

--- a/universal-application-tool-0.0.1/app/assets/javascripts/radio.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/radio.ts
@@ -23,8 +23,7 @@ class RadioController {
         const container = radio.closest(RadioController.radioOptionClass);
         const radioChecked = (radio as HTMLInputElement).checked;
         if (container) {
-          container.classList.toggle("bg-blue-100", radioChecked);
-          container.classList.toggle("border-blue-400", radioChecked);
+          container.classList.toggle("border-seattleBlue", radioChecked);
         }
       }
     );
@@ -48,8 +47,7 @@ class RadioController {
             checkCount += isChecked ? 1 : 0;
             const radioContainer = radioButton.closest(RadioController.radioOptionClass);
             if (radioContainer) {
-              radioContainer.classList.toggle("bg-blue-100", isChecked);
-              radioContainer.classList.toggle("border-blue-400", isChecked);
+              radioContainer.classList.toggle("border-seattleBlue", isChecked);
             }
           }
           // If this is a checkbox we need to check or uncheck the "None selected" option.

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -77,33 +77,15 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     return getBlockAfter(block.getId());
   }
 
-  private int getBlockIndex(String blockId) {
-    ImmutableList<Block> blocks = getAllBlocks();
+  @Override
+  public int getBlockIndex(String blockId) {
+    ImmutableList<Block> allBlocks = getAllBlocks();
 
-    int blockIndex = -1;
-    for (int i = 0; i < blocks.size() && blockIndex == -1; i++) {
-      if (blocks.get(i).getId().equals(blockId)) {
-        blockIndex = i;
-      }
+    for (int i = 0; i < allBlocks.size(); i++) {
+      if (allBlocks.get(i).getId().equals(blockId)) return i;
     }
 
-    return blockIndex;
-  }
-
-  @Override
-  public int getCompletionPercent(String blockId) {
-    double blockCount = getAllBlocks().size();
-
-    // If there aren't any blocks then I guess we're done.
-    if (blockCount == 0) return 100;
-
-    double blockIndex = getBlockIndex(blockId);
-
-    // If the block doesn't exist then return 0.
-    if (blockIndex == -1) return 0;
-
-    // Add 1 to the block index for 1-based indexing.
-    return (int) (((blockIndex + 1) / blockCount) * 100.0);
+    return -1;
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -77,15 +77,33 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     return getBlockAfter(block.getId());
   }
 
-  @Override
-  public int getBlockIndex(String blockId) {
-    ImmutableList<Block> allBlocks = getAllBlocks();
+  private int getBlockIndex(String blockId) {
+    ImmutableList<Block> blocks = getAllBlocks();
 
-    for (int i = 0; i < allBlocks.size(); i++) {
-      if (allBlocks.get(i).getId().equals(blockId)) return i;
+    int blockIndex = -1;
+    for (int i = 0; i < blocks.size() && blockIndex == -1; i++) {
+      if (blocks.get(i).getId().equals(blockId)) {
+        blockIndex = i;
+      }
     }
 
-    return -1;
+    return blockIndex;
+  }
+
+  @Override
+  public int getCompletionPercent(String blockId) {
+    double blockCount = getAllBlocks().size();
+
+    // If there aren't any blocks then I guess we're done.
+    if (blockCount == 0) return 100;
+
+    double blockIndex = getBlockIndex(blockId);
+
+    // If the block doesn't exist then return 0.
+    if (blockIndex == -1) return 0;
+
+    // Add 1 to the block index for 1-based indexing.
+    return (int) (((blockIndex + 1) / blockCount) * 100.0);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -3,6 +3,7 @@ package services.applicant.question;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -10,6 +11,7 @@ import javax.annotation.Nullable;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
+import services.applicant.ValidationErrorMessage;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
@@ -97,6 +99,10 @@ public class ApplicantQuestion {
     } catch (InvalidQuestionTypeException | UnsupportedQuestionTypeException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
+    return errorsPresenter().getQuestionErrors();
   }
 
   public boolean hasErrors() {

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -34,17 +34,17 @@ public abstract class BaseHtmlView {
     return h1(headerText).withClasses(Styles.MB_4, StyleUtils.joinStyles(additionalClasses));
   }
 
-  protected static ContainerTag fieldErrors(
+  public static ContainerTag fieldErrors(
       Messages messages, ImmutableSet<ValidationErrorMessage> errors) {
     return div(each(errors, error -> div(error.getMessage(messages))))
         .withClasses(BaseStyles.FORM_ERROR_TEXT);
   }
 
-  protected static Tag button(String textContents) {
+  public static Tag button(String textContents) {
     return TagCreator.button(text(textContents)).withType("button");
   }
 
-  protected static Tag button(String id, String textContents) {
+  public static Tag button(String id, String textContents) {
     return button(textContents).withId(id);
   }
 

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -37,7 +37,7 @@ public abstract class BaseHtmlView {
   public static ContainerTag fieldErrors(
       Messages messages, ImmutableSet<ValidationErrorMessage> errors) {
     return div(each(errors, error -> div(error.getMessage(messages))))
-        .withClasses(BaseStyles.FORM_ERROR_TEXT);
+        .withClasses(BaseStyles.FORM_ERROR_TEXT_BASE);
   }
 
   public static Tag button(String textContents) {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -1,6 +1,11 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+<<<<<<< HEAD
+=======
+import static j2html.TagCreator.body;
+import static j2html.TagCreator.div;
+>>>>>>> 1cd88e9 (Add some basic Block styles for heading and margins)
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
@@ -26,6 +31,8 @@ import views.components.ToastMessage;
 import views.questiontypes.ApplicantQuestionRendererFactory;
 import views.questiontypes.ApplicantQuestionRendererParams;
 import views.questiontypes.EnumeratorQuestionRenderer;
+import views.style.ApplicantStyles;
+import views.style.Styles;
 
 public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
@@ -40,6 +47,14 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
   }
 
   public Content render(Params params) {
+    Tag blockHeading =
+            div().with(h1(params.block().getName()).withClasses(ApplicantStyles.BLOCK_HEADING));
+    Tag blockFormDiv = div(renderBlockWithSubmitForm(params)).withClasses(Styles.MY_8);
+    Tag blockDiv =
+            div()
+                    .with(blockHeading)
+                    .with(blockFormDiv)
+                    .withClasses(Styles.MY_8, Styles.W_1_3, Styles.M_AUTO);
     HtmlBundle bundle =
         layout
             .getBundle()
@@ -47,8 +62,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
             .addMainContent(
                 layout.renderHeader(
                     getPercentComplete(params.blockIndex(), params.totalBlockCount())),
-                h1(params.block().getName()),
-                renderBlockWithSubmitForm(params));
+                blockHeading,
+                blockDiv);
 
     if (!params.preferredLanguageSupported()) {
       bundle.addMainContent(
@@ -118,7 +133,9 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
             each(
                 params.block().getQuestions(),
                 question -> renderQuestion(question, rendererParams)))
-        .with(submitButton(params.messages().at(MessageKey.BUTTON_NEXT_BLOCK.getKeyName())));
+        .with(
+            submitButton(params.messages().at(MessageKey.BUTTON_NEXT_BLOCK.getKeyName()))
+                .withClasses(ApplicantStyles.BUTTON_BLOCK_NEXT));
   }
 
   private Tag renderFileUploadBlockSubmitForm(Params params) {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -43,14 +43,12 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
   }
 
   public Content render(Params params) {
-    Tag blockHeading =
-        div().with(h1(params.block().getName()).withClasses(ApplicantStyles.BLOCK_HEADING));
-    Tag blockFormDiv = div(renderBlockWithSubmitForm(params)).withClasses(Styles.MY_8);
     Tag blockDiv =
         div()
-            .with(blockHeading)
-            .with(blockFormDiv)
+            .with(h1(params.block().getName()).withClasses(ApplicantStyles.BLOCK_HEADING))
+            .with(div(renderBlockWithSubmitForm(params)).withClasses(Styles.MY_8))
             .withClasses(Styles.MY_8, Styles.W_1_3, Styles.M_AUTO);
+
     HtmlBundle bundle =
         layout
             .getBundle()
@@ -58,7 +56,6 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
             .addMainContent(
                 layout.renderHeader(
                     getPercentComplete(params.blockIndex(), params.totalBlockCount())),
-                blockHeading,
                 blockDiv);
 
     if (!params.preferredLanguageSupported()) {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -1,11 +1,7 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-<<<<<<< HEAD
-=======
-import static j2html.TagCreator.body;
 import static j2html.TagCreator.div;
->>>>>>> 1cd88e9 (Add some basic Block styles for heading and margins)
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
@@ -48,13 +44,13 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
   public Content render(Params params) {
     Tag blockHeading =
-            div().with(h1(params.block().getName()).withClasses(ApplicantStyles.BLOCK_HEADING));
+        div().with(h1(params.block().getName()).withClasses(ApplicantStyles.BLOCK_HEADING));
     Tag blockFormDiv = div(renderBlockWithSubmitForm(params)).withClasses(Styles.MY_8);
     Tag blockDiv =
-            div()
-                    .with(blockHeading)
-                    .with(blockFormDiv)
-                    .withClasses(Styles.MY_8, Styles.W_1_3, Styles.M_AUTO);
+        div()
+            .with(blockHeading)
+            .with(blockFormDiv)
+            .withClasses(Styles.MY_8, Styles.W_1_3, Styles.M_AUTO);
     HtmlBundle bundle =
         layout
             .getBundle()

--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -141,7 +141,7 @@ public class ProgramIndexView extends BaseHtmlView {
         a().attr(HREF, applyUrl)
             .withText(messages.at(MessageKey.BUTTON_APPLY.getKeyName()))
             .withId(baseId + "-apply")
-            .withClasses(ReferenceClasses.APPLY_BUTTON, ApplicantStyles.PROGRAM_APPLY_BUTTON);
+            .withClasses(ReferenceClasses.APPLY_BUTTON, ApplicantStyles.BUTTON_PROGRAM_APPLY);
 
     ContainerTag applyDiv =
         div(applyButton).withClasses(Styles.ABSOLUTE, Styles.BOTTOM_6, Styles.W_FULL);

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -240,6 +240,6 @@ public class FieldWithLabel {
         .withClasses(
             fieldErrors.isEmpty()
                 ? ""
-                : StyleUtils.joinStyles(BaseStyles.FORM_ERROR_TEXT, Styles.P_1));
+                : StyleUtils.joinStyles(BaseStyles.FORM_ERROR_TEXT_XS, Styles.P_1));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 
 import j2html.tags.Tag;
@@ -8,17 +7,13 @@ import play.i18n.Messages;
 import services.MessageKey;
 import services.applicant.question.AddressQuestion;
 import services.applicant.question.ApplicantQuestion;
-import views.BaseHtmlView;
 import views.components.FieldWithLabel;
-import views.style.ReferenceClasses;
 import views.style.Styles;
 
-public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
 
   public AddressQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
@@ -26,72 +21,50 @@ public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQu
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            div()
-                .withClasses(Styles.ROUNDED, Styles.BG_OPACITY_50, Styles.PT_2, Styles.PB_4)
-                .with(
-                    /** First line of address entry: Address line 1 AKA street address */
-                    FieldWithLabel.input()
-                        .setFieldName(addressQuestion.getStreetPath().toString())
-                        .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_STREET.getKeyName()))
-                        .setPlaceholderText(
-                            messages.at(MessageKey.ADDRESS_PLACEHOLDER_STREET.getKeyName()))
-                        .setValue(addressQuestion.getStreetValue().orElse(""))
-                        .setFieldErrors(messages, addressQuestion.getStreetErrors())
-                        .getContainer()
-                        .withClasses(Styles.MY_2, Styles.PT_2),
-                    /** Second line of address entry: Address line 2 AKA apartment, unit, etc. */
-                    FieldWithLabel.input()
-                        .setFieldName(addressQuestion.getLine2Path().toString())
-                        .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_LINE_2.getKeyName()))
-                        .setPlaceholderText(
-                            messages.at(MessageKey.ADDRESS_PLACEHOLDER_LINE_2.getKeyName()))
-                        .setValue(addressQuestion.getLine2Value().orElse(""))
-                        .getContainer()
-                        .withClasses(Styles.MY_2, Styles.PT_2),
-                    /** Third line of address entry: City, State, Zip */
-                    div()
-                        .withClasses(Styles.FLEX, Styles.FLEX_ROW)
-                        .with(
-                            FieldWithLabel.input()
-                                .setFieldName(addressQuestion.getCityPath().toString())
-                                .setLabelText(
-                                    messages.at(MessageKey.ADDRESS_LABEL_CITY.getKeyName()))
-                                .setValue(addressQuestion.getCityValue().orElse(""))
-                                .setFieldErrors(messages, addressQuestion.getCityErrors())
-                                .getContainer()
-                                .withClasses(Styles.P_1, Styles.PT_2, Styles.PL_0, Styles.W_1_2),
-                            FieldWithLabel.input()
-                                .setFieldName(addressQuestion.getStatePath().toString())
-                                .setLabelText(
-                                    messages.at(MessageKey.ADDRESS_LABEL_STATE.getKeyName()))
-                                .setValue(addressQuestion.getStateValue().orElse(""))
-                                .setFieldErrors(messages, addressQuestion.getStateErrors())
-                                .getContainer()
-                                .withClasses(Styles.P_1, Styles.PT_2, Styles.W_1_4),
-                            FieldWithLabel.input()
-                                .setFieldName(addressQuestion.getZipPath().toString())
-                                .setLabelText(
-                                    messages.at(MessageKey.ADDRESS_LABEL_ZIPCODE.getKeyName()))
-                                .setValue(addressQuestion.getZipValue().orElse(""))
-                                .setFieldErrors(messages, addressQuestion.getZipErrors())
-                                .getContainer()
-                                .withClasses(Styles.P_1, Styles.PT_2, Styles.PR_0, Styles.W_1_4)),
-                    fieldErrors(messages, addressQuestion.getQuestionErrors())
-                        .withClasses(
-                            Styles.ML_2, Styles.TEXT_XS, Styles.TEXT_RED_600, Styles.FONT_BOLD)));
+    Tag addressQuestionFormContent =
+        div()
+            .with(
+                /** First line of address entry: Address line 1 AKA street address */
+                FieldWithLabel.input()
+                    .setFieldName(addressQuestion.getStreetPath().toString())
+                    .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_STREET.getKeyName()))
+                    .setPlaceholderText(
+                        messages.at(MessageKey.ADDRESS_PLACEHOLDER_STREET.getKeyName()))
+                    .setValue(addressQuestion.getStreetValue().orElse(""))
+                    .setFieldErrors(messages, addressQuestion.getStreetErrors())
+                    .getContainer(),
+                /** Second line of address entry: Address line 2 AKA apartment, unit, etc. */
+                FieldWithLabel.input()
+                    .setFieldName(addressQuestion.getLine2Path().toString())
+                    .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_LINE_2.getKeyName()))
+                    .setPlaceholderText(
+                        messages.at(MessageKey.ADDRESS_PLACEHOLDER_LINE_2.getKeyName()))
+                    .setValue(addressQuestion.getLine2Value().orElse(""))
+                    .getContainer(),
+                /** Third line of address entry: City, State, Zip */
+                div()
+                    .withClasses(Styles.GRID, Styles.GRID_COLS_3, Styles.GAP_2)
+                    .with(
+                        FieldWithLabel.input()
+                            .setFieldName(addressQuestion.getCityPath().toString())
+                            .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_CITY.getKeyName()))
+                            .setValue(addressQuestion.getCityValue().orElse(""))
+                            .setFieldErrors(messages, addressQuestion.getCityErrors())
+                            .getContainer(),
+                        FieldWithLabel.input()
+                            .setFieldName(addressQuestion.getStatePath().toString())
+                            .setLabelText(messages.at(MessageKey.ADDRESS_LABEL_STATE.getKeyName()))
+                            .setValue(addressQuestion.getStateValue().orElse(""))
+                            .setFieldErrors(messages, addressQuestion.getStateErrors())
+                            .getContainer(),
+                        FieldWithLabel.input()
+                            .setFieldName(addressQuestion.getZipPath().toString())
+                            .setLabelText(
+                                messages.at(MessageKey.ADDRESS_LABEL_ZIPCODE.getKeyName()))
+                            .setValue(addressQuestion.getZipValue().orElse(""))
+                            .setFieldErrors(messages, addressQuestion.getZipErrors())
+                            .getContainer()));
+
+    return renderInternal(messages, addressQuestionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -1,8 +1,67 @@
 package views.questiontypes;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import play.i18n.Messages;
+import services.applicant.question.ApplicantQuestion;
+import views.BaseHtmlView;
+import views.style.ApplicantStyles;
+import views.style.ReferenceClasses;
+import views.style.Styles;
 
-public interface ApplicantQuestionRenderer {
+public abstract class ApplicantQuestionRenderer {
 
-  Tag render(ApplicantQuestionRendererParams params);
+  final ApplicantQuestion question;
+
+  public ApplicantQuestionRenderer(ApplicantQuestion question) {
+    this.question = checkNotNull(question);
+  }
+
+  public abstract Tag render(ApplicantQuestionRendererParams params);
+
+  Tag renderInternal(Messages messages, Tag questionFormContent) {
+    return renderInternal(messages, questionFormContent, true);
+  }
+
+  /**
+   * Renders an applicant question's text, help text, errors, and the given form content.
+   *
+   * <p>In some cases, like text questions and number questions, the question errors are rendered in
+   * the form content, so we offer the ability to specify whether or not this method should render
+   * the question errors here.
+   */
+  Tag renderInternal(
+      Messages messages, Tag questionFormContent, boolean shouldDisplayQuestionErrors) {
+
+    ContainerTag questionTextDiv =
+        div()
+            // Question text
+            .with(
+                div()
+                    .withClasses(
+                        ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT)
+                    .withText(question.getQuestionText()))
+            // Question help text
+            .with(
+                div()
+                    .withClasses(
+                        ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
+                        ApplicantStyles.QUESTION_HELP_TEXT)
+                    .withText(question.getQuestionHelpText()))
+            .withClasses(Styles.MB_4);
+
+    if (shouldDisplayQuestionErrors) {
+      // Question error text
+      questionTextDiv.with(BaseHtmlView.fieldErrors(messages, question.getQuestionErrors()));
+    }
+
+    return div()
+        .withId(question.getContextualizedPath().toString())
+        .withClasses(Styles.MX_AUTO, Styles.MB_8)
+        .with(questionTextDiv)
+        .with(questionFormContent);
+  }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.input;
@@ -12,55 +11,44 @@ import j2html.tags.Tag;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.MultiSelectQuestion;
 import services.question.LocalizedQuestionOption;
-import views.BaseHtmlView;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 import views.style.Styles;
 
-public class CheckboxQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
 
   public CheckboxQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
   public Tag render(ApplicantQuestionRendererParams params) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16, BaseStyles.FORM_FIELD_MARGIN_BOTTOM)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT, Styles.TEXT_3XL)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            input() // Hidden input that's always selected to allow for clearing mutli-select data.
-                .withType("checkbox")
-                .withName(multiOptionQuestion.getSelectionPathAsArray())
-                .withValue("")
-                .condAttr(!multiOptionQuestion.hasValue(), Attr.CHECKED, "")
-                .withClasses(ReferenceClasses.RADIO_DEFAULT, Styles.HIDDEN),
-            fieldErrors(params.messages(), multiOptionQuestion.getQuestionErrors()),
-            each(
-                multiOptionQuestion.getOptions(),
-                option ->
-                    renderCheckboxQuestion(
-                        multiOptionQuestion.getSelectionPathAsArray(),
-                        option,
-                        multiOptionQuestion.optionIsSelected(option))));
+    Tag checkboxQuestionFormContent =
+        div()
+            // Hidden input that's always selected to allow for clearing mutli-select data.
+            .with(
+                input()
+                    .withType("checkbox")
+                    .withName(multiOptionQuestion.getSelectionPathAsArray())
+                    .withValue("")
+                    .condAttr(!multiOptionQuestion.hasValue(), Attr.CHECKED, "")
+                    .withClasses(ReferenceClasses.RADIO_DEFAULT, Styles.HIDDEN))
+            .with(
+                each(
+                    multiOptionQuestion.getOptions(),
+                    option ->
+                        renderCheckboxOption(
+                            multiOptionQuestion.getSelectionPathAsArray(),
+                            option,
+                            multiOptionQuestion.optionIsSelected(option))));
+
+    return renderInternal(params.messages(), checkboxQuestionFormContent);
   }
 
-  private Tag renderCheckboxQuestion(
+  private Tag renderCheckboxOption(
       String selectionPath, LocalizedQuestionOption option, boolean isSelected) {
     String id = "checkbox-" + question.getContextualizedPath() + "-" + option.id();
     ContainerTag labelTag =
@@ -68,8 +56,7 @@ public class CheckboxQuestionRenderer extends BaseHtmlView implements ApplicantQ
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
                 BaseStyles.CHECKBOX_LABEL,
-                isSelected ? Styles.BG_BLUE_100 : "",
-                isSelected ? Styles.BORDER_BLUE_500 : "")
+                isSelected ? BaseStyles.BORDER_SEATTLE_BLUE : "")
             .with(
                 input()
                     .withId(id)

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.option;
@@ -10,17 +9,12 @@ import j2html.tags.Tag;
 import java.util.AbstractMap;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.SingleSelectQuestion;
-import views.BaseHtmlView;
 import views.components.SelectWithLabel;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
-public class DropdownQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
 
   public DropdownQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
@@ -42,22 +36,8 @@ public class DropdownQuestionRenderer extends BaseHtmlView implements ApplicantQ
       select.setValue(String.valueOf(singleSelectQuestion.getSelectedOptionId().get()));
     }
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.W_MAX)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            select.getContainer(),
-            fieldErrors(params.messages(), singleSelectQuestion.getQuestionErrors())
-                .withClasses(Styles.ML_2, Styles.TEXT_XS, Styles.TEXT_RED_600, Styles.FONT_BOLD));
+    Tag dropdownQuestionFormContent = div().with(select.getContainer());
+
+    return renderInternal(params.messages(), dropdownQuestionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 import static views.style.ReferenceClasses.ENUMERATOR_EXISTING_DELETE_BUTTON;
@@ -25,7 +24,7 @@ import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 import views.style.Styles;
 
-public class EnumeratorQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
+public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
 
   private static final String ENUMERATOR_FIELDS_ID = "enumerator-fields";
   private static final String ADD_ELEMENT_BUTTON_ID = "enumerator-field-add-button";
@@ -38,10 +37,8 @@ public class EnumeratorQuestionRenderer extends BaseHtmlView implements Applican
   public static final String ENUMERATOR_FIELD_CLASSES =
       StyleUtils.joinStyles(ReferenceClasses.ENUMERATOR_FIELD, Styles.FLEX, Styles.MB_4);
 
-  private final ApplicantQuestion question;
-
   public EnumeratorQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
@@ -61,26 +58,19 @@ public class EnumeratorQuestionRenderer extends BaseHtmlView implements Applican
               Optional.of(entityNames.get(index)),
               Optional.of(index)));
     }
-    return div()
-        .withClasses(Styles.MX_AUTO, Styles.W_MAX)
-        .with(
-            hiddenDeleteInputTemplate(),
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            enumeratorFields,
-            button(
-                ADD_ELEMENT_BUTTON_ID,
-                messages.at(
-                    MessageKey.ENUMERATOR_BUTTON_ADD_ENTITY.getKeyName(), localizedEntityType)),
-            fieldErrors(messages, enumeratorQuestion.getQuestionErrors()));
+
+    Tag enumeratorQuestionFormContent =
+        div()
+            .with(hiddenDeleteInputTemplate())
+            .with(enumeratorFields)
+            .with(
+                BaseHtmlView.button(
+                    ADD_ELEMENT_BUTTON_ID,
+                    messages.at(
+                        MessageKey.ENUMERATOR_BUTTON_ADD_ENTITY.getKeyName(),
+                        localizedEntityType)));
+
+    return renderInternal(messages, enumeratorQuestionFormContent);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 
@@ -13,12 +12,10 @@ import views.BaseHtmlView;
 import views.style.ReferenceClasses;
 import views.style.Styles;
 
-public class FileUploadQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
 
   public FileUploadQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
@@ -40,7 +37,7 @@ public class FileUploadQuestionRenderer extends BaseHtmlView implements Applican
                     Styles.MB_2)
                 .withText(question.getQuestionHelpText()),
             fileUploadFields(params),
-            fieldErrors(params.messages(), fileUploadQuestion.getQuestionErrors()));
+            BaseHtmlView.fieldErrors(params.messages(), fileUploadQuestion.getQuestionErrors()));
   }
 
   private ContainerTag fileUploadFields(ApplicantQuestionRendererParams params) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -6,11 +6,7 @@ import static j2html.TagCreator.input;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import services.applicant.question.ApplicantQuestion;
-import services.applicant.question.FileUploadQuestion;
 import services.aws.SignedS3UploadRequest;
-import views.BaseHtmlView;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
 public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
 
@@ -20,24 +16,7 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
 
   @Override
   public Tag render(ApplicantQuestionRendererParams params) {
-    FileUploadQuestion fileUploadQuestion = question.createFileUploadQuestion();
-
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.W_MAX)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            fileUploadFields(params),
-            BaseHtmlView.fieldErrors(params.messages(), fileUploadQuestion.getQuestionErrors()));
+    return renderInternal(params.messages(), fileUploadFields(params));
   }
 
   private ContainerTag fileUploadFields(ApplicantQuestionRendererParams params) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 
 import j2html.tags.Tag;
@@ -8,17 +7,12 @@ import play.i18n.Messages;
 import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.NameQuestion;
-import views.BaseHtmlView;
 import views.components.FieldWithLabel;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
-public class NameQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class NameQuestionRenderer extends ApplicantQuestionRenderer {
 
   public NameQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
@@ -26,40 +20,29 @@ public class NameQuestionRenderer extends BaseHtmlView implements ApplicantQuest
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            div()
-                .with(
-                    FieldWithLabel.input()
-                        .setFieldName(nameQuestion.getFirstNamePath().toString())
-                        .setLabelText(messages.at(MessageKey.NAME_LABEL_FIRST.getKeyName()))
-                        .setValue(nameQuestion.getFirstNameValue().orElse(""))
-                        .setFieldErrors(messages, nameQuestion.getFirstNameErrors())
-                        .getContainer())
-                .with(
-                    FieldWithLabel.input()
-                        .setFieldName(nameQuestion.getMiddleNamePath().toString())
-                        .setLabelText(messages.at(MessageKey.NAME_LABEL_MIDDLE.getKeyName()))
-                        .setValue(nameQuestion.getMiddleNameValue().orElse(""))
-                        .getContainer())
-                .with(
-                    FieldWithLabel.input()
-                        .setFieldName(nameQuestion.getLastNamePath().toString())
-                        .setLabelText(messages.at(MessageKey.NAME_LABEL_LAST.getKeyName()))
-                        .setValue(nameQuestion.getLastNameValue().orElse(""))
-                        .setFieldErrors(messages, nameQuestion.getLastNameErrors())
-                        .getContainer()));
+    Tag nameQuestionFormContent =
+        div()
+            .with(
+                FieldWithLabel.input()
+                    .setFieldName(nameQuestion.getFirstNamePath().toString())
+                    .setLabelText(messages.at(MessageKey.NAME_LABEL_FIRST.getKeyName()))
+                    .setValue(nameQuestion.getFirstNameValue().orElse(""))
+                    .setFieldErrors(messages, nameQuestion.getFirstNameErrors())
+                    .getContainer())
+            .with(
+                FieldWithLabel.input()
+                    .setFieldName(nameQuestion.getMiddleNamePath().toString())
+                    .setLabelText(messages.at(MessageKey.NAME_LABEL_MIDDLE.getKeyName()))
+                    .setValue(nameQuestion.getMiddleNameValue().orElse(""))
+                    .getContainer())
+            .with(
+                FieldWithLabel.input()
+                    .setFieldName(nameQuestion.getLastNamePath().toString())
+                    .setLabelText(messages.at(MessageKey.NAME_LABEL_LAST.getKeyName()))
+                    .setValue(nameQuestion.getLastNameValue().orElse(""))
+                    .setFieldErrors(messages, nameQuestion.getLastNameErrors())
+                    .getContainer());
+
+    return renderInternal(messages, nameQuestionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
@@ -1,23 +1,17 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 
 import j2html.tags.Tag;
 import java.util.OptionalLong;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.NumberQuestion;
-import views.BaseHtmlView;
 import views.components.FieldWithLabel;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
-public class NumberQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
 
   public NumberQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
@@ -25,28 +19,17 @@ public class NumberQuestionRenderer extends BaseHtmlView implements ApplicantQue
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =
-        FieldWithLabel.number().setFieldName(numberQuestion.getNumberPath().toString());
+        FieldWithLabel.number()
+            .setFieldName(numberQuestion.getNumberPath().toString())
+            .setFieldErrors(params.messages(), numberQuestion.getQuestionErrors());
     if (numberQuestion.getNumberValue().isPresent()) {
       // TODO: [Refactor] Oof! Converting Optional<Long> to OptionalLong.
       OptionalLong value = OptionalLong.of(numberQuestion.getNumberValue().orElse(0L));
       numberField.setValue(value);
     }
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            numberField.getContainer(),
-            fieldErrors(params.messages(), numberQuestion.getQuestionErrors()));
+    Tag numberQuestionFormContent = div().with(numberField.getContainer());
+
+    return renderInternal(params.messages(), numberQuestionFormContent, false);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -1,6 +1,5 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.input;
@@ -12,49 +11,36 @@ import j2html.tags.Tag;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.SingleSelectQuestion;
 import services.question.LocalizedQuestionOption;
-import views.BaseHtmlView;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 import views.style.Styles;
 
-public class RadioButtonQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
 
   public RadioButtonQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
   public Tag render(ApplicantQuestionRendererParams params) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16, BaseStyles.FORM_FIELD_MARGIN_BOTTOM)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT, Styles.TEXT_3XL)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            fieldErrors(params.messages(), singleOptionQuestion.getQuestionErrors()),
-            each(
-                singleOptionQuestion.getOptions(),
-                option ->
-                    renderSingleRadioOption(
-                        singleOptionQuestion.getSelectionPath().toString(),
-                        option,
-                        singleOptionQuestion.optionIsSelected(option))));
+    Tag radioQuestionFormContent =
+        div()
+            .with(
+                each(
+                    singleOptionQuestion.getOptions(),
+                    option ->
+                        renderRadioOption(
+                            singleOptionQuestion.getSelectionPath().toString(),
+                            option,
+                            singleOptionQuestion.optionIsSelected(option))));
+
+    return renderInternal(params.messages(), radioQuestionFormContent);
   }
 
-  private Tag renderSingleRadioOption(
+  private Tag renderRadioOption(
       String selectionPath, LocalizedQuestionOption option, boolean checked) {
     String id = option.optionText().replaceAll("\\s+", "_");
 
@@ -63,8 +49,7 @@ public class RadioButtonQuestionRenderer extends BaseHtmlView implements Applica
             .withClasses(
                 ReferenceClasses.RADIO_OPTION,
                 BaseStyles.RADIO_LABEL,
-                checked ? Styles.BG_BLUE_100 : "",
-                checked ? Styles.BORDER_BLUE_500 : "")
+                checked ? BaseStyles.BORDER_SEATTLE_BLUE : "")
             .with(
                 input()
                     .withId(id)

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -1,48 +1,27 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.div;
-
 import j2html.tags.Tag;
-import play.i18n.Messages;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.TextQuestion;
-import views.BaseHtmlView;
 import views.components.FieldWithLabel;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
-public class TextQuestionRenderer extends BaseHtmlView implements ApplicantQuestionRenderer {
-
-  private final ApplicantQuestion question;
+public class TextQuestionRenderer extends ApplicantQuestionRenderer {
 
   public TextQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
+    super(question);
   }
 
   @Override
   public Tag render(ApplicantQuestionRendererParams params) {
-    Messages messages = params.messages();
     TextQuestion textQuestion = question.createTextQuestion();
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            FieldWithLabel.input()
-                .setFieldName(textQuestion.getTextPath().toString())
-                .setValue(textQuestion.getTextValue().orElse(""))
-                .setFieldErrors(messages, textQuestion.getQuestionErrors())
-                .getContainer());
+    Tag questionFormContent =
+        FieldWithLabel.input()
+            .setFieldName(textQuestion.getTextPath().toString())
+            .setValue(textQuestion.getTextValue().orElse(""))
+            .setFieldErrors(params.messages(), textQuestion.getQuestionErrors())
+            .getContainer();
+
+    return renderInternal(params.messages(), questionFormContent, false);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -10,7 +10,7 @@ public final class ApplicantStyles {
   public static final String QUESTION_TEXT =
       StyleUtils.joinStyles(Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.FONT_BOLD, Styles.MB_2);
   public static final String QUESTION_HELP_TEXT =
-      StyleUtils.joinStyles(Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.MB_4);
+      StyleUtils.joinStyles(Styles.TEXT_BLACK, Styles.TEXT_XL);
 
   public static final String BLOCK_HEADING =
       StyleUtils.joinStyles(Styles.TEXT_3XL, Styles.TEXT_BLACK, Styles.FONT_BOLD);

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -8,11 +8,12 @@ public final class ApplicantStyles {
   public static final String LOGO_STYLE = StyleUtils.joinStyles(Styles.TEXT_2XL);
 
   public static final String QUESTION_TEXT =
-      StyleUtils.joinStyles(
-          Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.FONT_BOLD, Styles.MB_2);
+      StyleUtils.joinStyles(Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.FONT_BOLD, Styles.MB_2);
   public static final String QUESTION_HELP_TEXT =
       StyleUtils.joinStyles(Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.MB_4);
 
+  public static final String BLOCK_HEADING =
+      StyleUtils.joinStyles(Styles.TEXT_3XL, Styles.TEXT_BLACK, Styles.FONT_BOLD);
   public static final String BUTTON_BLOCK_NEXT =
       StyleUtils.joinStyles(
           BaseStyles.BG_SEATTLE_BLUE,

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -1,12 +1,28 @@
 package views.style;
 
 public final class ApplicantStyles {
-  public static final String BODY_BG_COLOR = Styles.BG_WHITE;
-
+  public static final String BODY_BG_COLOR = BaseStyles.BG_CIVIFORM_WHITE;
   public static final String BODY =
       StyleUtils.joinStyles(BODY_BG_COLOR, Styles.H_FULL, Styles.W_FULL);
 
   public static final String LOGO_STYLE = StyleUtils.joinStyles(Styles.TEXT_2XL);
+
+  public static final String QUESTION_TEXT =
+      StyleUtils.joinStyles(
+          Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.FONT_BOLD, Styles.MB_2);
+  public static final String QUESTION_HELP_TEXT =
+      StyleUtils.joinStyles(Styles.TEXT_BLACK, Styles.TEXT_XL, Styles.MB_4);
+
+  public static final String BUTTON_BLOCK_NEXT =
+      StyleUtils.joinStyles(
+          BaseStyles.BG_SEATTLE_BLUE,
+          Styles.TEXT_WHITE,
+          Styles.FONT_SEMIBOLD,
+          Styles.TEXT_LG,
+          Styles.UPPERCASE,
+          Styles.ROUNDED_FULL,
+          Styles.W_36,
+          Styles.FLOAT_RIGHT);
 
   public static final String PROGRAM_CARD =
       StyleUtils.joinStyles(
@@ -20,11 +36,11 @@ public final class ApplicantStyles {
           Styles.SHADOW_MD,
           Styles.BORDER,
           Styles.BORDER_GRAY_200);
-  public static final String PROGRAM_APPLY_BUTTON =
+  public static final String BUTTON_PROGRAM_APPLY =
       StyleUtils.joinStyles(
           Styles.BLOCK,
           Styles.UPPERCASE,
-          Styles.ROUNDED_3XL,
+          Styles.ROUNDED_FULL,
           Styles.PY_2,
           Styles.PX_6,
           Styles.W_MIN,

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -21,7 +21,7 @@ public final class BaseStyles {
   // Form style classes
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
-  public static final String FORM_FIELD_MARGIN_BOTTOM = Styles.MB_4;
+  public static final String FORM_FIELD_MARGIN_BOTTOM = Styles.MB_2;
 
   public static final String FORM_FIELD_BORDER_COLOR = Styles.BORDER_GRAY_300;
   public static final String FORM_FIELD_ERROR_BORDER_COLOR = Styles.BORDER_RED_600;
@@ -29,8 +29,10 @@ public final class BaseStyles {
   public static final String FORM_LABEL_TEXT_COLOR = Styles.TEXT_GRAY_600;
 
   public static final String FORM_ERROR_TEXT_COLOR = Styles.TEXT_RED_600;
-  public static final String FORM_ERROR_TEXT =
+  public static final String FORM_ERROR_TEXT_XS =
       StyleUtils.joinStyles(BaseStyles.FORM_ERROR_TEXT_COLOR, Styles.TEXT_XS);
+  public static final String FORM_ERROR_TEXT_BASE =
+      StyleUtils.joinStyles(BaseStyles.FORM_ERROR_TEXT_COLOR, Styles.TEXT_BASE);
 
   private static final String INPUT_BASE =
       StyleUtils.joinStyles(
@@ -44,11 +46,12 @@ public final class BaseStyles {
           Styles.ROUNDED_LG,
           Styles.W_FULL,
           Styles.BG_WHITE,
-          StyleUtils.focus(BORDER_SEATTLE_BLUE));
+          StyleUtils.focus(BORDER_SEATTLE_BLUE),
+          Styles.TEXT_BLACK,
+          Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT =
-      StyleUtils.joinStyles(INPUT_BASE, Styles.TEXT_LG, Styles.PLACEHOLDER_GRAY_400);
+  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_400);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =
@@ -65,8 +68,7 @@ public final class BaseStyles {
    * text.</label>
    */
   public static final String CHECKBOX_LABEL =
-      StyleUtils.joinStyles(
-          INPUT_BASE, Styles.TEXT_BASE, Styles.ALIGN_MIDDLE, BaseStyles.FORM_LABEL_TEXT_COLOR);
+      StyleUtils.joinStyles(INPUT_BASE, Styles.ALIGN_MIDDLE);
   /** Same as the above but for radio buttons. */
   public static final String RADIO_LABEL = CHECKBOX_LABEL;
 

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -11,10 +11,11 @@ public final class BaseStyles {
   // CiviForm color classes
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
+  public static final String BG_CIVIFORM_WHITE = "bg-civiformWhite";
+
   public static final String BG_SEATTLE_BLUE = "bg-seattleBlue";
-  public static final String BG_CIVIFORM_BLUE_60 = "bg-civiformBlue-60";
-  public static final String BG_CIVIFORM_BLUE_80 = "bg-civiformBlue-80";
-  public static final String BG_CIVIFORM_BLUE_100 = "bg-civiformBlue-100";
+  public static final String TEXT_SEATTLE_BLUE = "text-seattleBlue";
+  public static final String BORDER_SEATTLE_BLUE = "border-seattleBlue";
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
   // Form style classes
@@ -43,7 +44,7 @@ public final class BaseStyles {
           Styles.ROUNDED_LG,
           Styles.W_FULL,
           Styles.BG_WHITE,
-          StyleUtils.focus(Styles.BORDER_BLUE_500));
+          StyleUtils.focus(BORDER_SEATTLE_BLUE));
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT =

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -27,7 +27,7 @@ button.untranslatedSubmit=Submit
 #--------------------------------------------------------------------------#
 
 # The button text for saving the current applicant-entered data and continuing to the next block in the form.
-button.nextBlock=Save and continue
+button.nextBlock=Next
 
 # The aria text on the button used by an applicant to mark an entity for deletion.
 button.ariaLabel.deleteEntity=Delete {0}

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -2,7 +2,7 @@
 
 button.logout=Logout
 button.apply=Apply
-button.nextBlock=Save and continue
+button.nextBlock=Next
 button.deleteEntity=Delete {0}
 toast.localeNotSupported=We're sorry, this program is not fully translated to English.
 toast.programCompleted=Application was already completed.

--- a/universal-application-tool-0.0.1/conf/messages.es-US
+++ b/universal-application-tool-0.0.1/conf/messages.es-US
@@ -2,7 +2,7 @@
 
 button.logout=Cerrar Sesión
 button.apply=Solicitar
-button.nextBlock=Guardar y continuar
+button.nextBlock=Próximo
 button.deleteEntity=Eliminar {0}
 toast.localeNotSupported=Lo siento, este programa no está completamente traducido al español.
 toast.programCompleted=Ya completó esta solicitud

--- a/universal-application-tool-0.0.1/tailwind.config.js
+++ b/universal-application-tool-0.0.1/tailwind.config.js
@@ -11,13 +11,11 @@ module.exports = {
       colors: {
         orange: colors.orange,
         teal: colors.teal,
-        civiformBlue: {
-          60: '#B3D1E3',
-          80: '#72ACDB',
-          100: '#1D5497',
+        civiformWhite: {
+          DEFAULT: '#f8f9fa',
         },
         seattleBlue: {
-          DEFAULT: '#113F9F',
+          DEFAULT: '#113f9f',
         },
       },
     },

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -304,7 +304,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedApplicantPro
         subject.edit(request, applicant.id, program.id, "1").toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("Guardar y continuar");
+    assertThat(contentAsString(result)).contains("Próximo");
   }
 
   @Test


### PR DESCRIPTION
### Description
Previously each question type's renderer was rendering its own question text, help text, and errors. This puts all of that logic in a common `ApplicantQuestionRenderer#renderInternal` method.

Based on Figma mocks. Also slightly improve Block and question error rendering.

### Screenshots
![Screen Shot 2021-05-14 at 4 19 36 PM](https://user-images.githubusercontent.com/5732310/118340326-33315380-b4d0-11eb-81be-35dbd9756a81.png)
![Screen Shot 2021-05-14 at 3 22 07 PM](https://user-images.githubusercontent.com/5732310/118339475-cae17280-b4cd-11eb-8615-5f3535013b45.png)
![Screen Shot 2021-05-14 at 3 51 10 PM](https://user-images.githubusercontent.com/5732310/118339481-ce74f980-b4cd-11eb-8b1c-9e7be3ae2693.png)
![Screen Shot 2021-05-14 at 4 00 57 PM](https://user-images.githubusercontent.com/5732310/118339484-cfa62680-b4cd-11eb-8c75-63108684b100.png)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #1016
