### PR TITLE
Display URLs correctly in program view.

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -126,6 +126,10 @@ export class AdminPrograms {
     await this.page.click('#add-block-button');
 
     await this.page.fill('textarea', blockDescription);
+    // Tab away to enable the update-block button - this is flaky in tests since
+    // playwright fills these in without emitting the usual keypress events.
+    await this.page.press('textarea', 'Tab');
+    await this.page.screenshot({path: 'tmp/filled.png', fullPage: true});
     await this.page.click('#update-block-button');
 
     for (const questionName of questionNames) {

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -1,19 +1,29 @@
 package views;
 
+import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.text;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.urls.Url;
+import com.linkedin.urls.detection.UrlDetector;
+import com.linkedin.urls.detection.UrlDetectorOptions;
 import j2html.TagCreator;
 import j2html.tags.ContainerTag;
+import j2html.tags.DomContent;
 import j2html.tags.Tag;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.i18n.Messages;
 import play.mvc.Http;
 import services.applicant.ValidationErrorMessage;
@@ -29,6 +39,7 @@ import views.style.Styles;
  * rendered.
  */
 public abstract class BaseHtmlView {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseHtmlView.class);
 
   public static Tag renderHeader(String headerText, String... additionalClasses) {
     return h1(headerText).withClasses(Styles.MB_4, StyleUtils.joinStyles(additionalClasses));
@@ -77,5 +88,36 @@ public abstract class BaseHtmlView {
   protected String renderDateTime(Instant time) {
     LocalDateTime datetime = LocalDateTime.ofInstant(time, ZoneId.of("America/Los_Angeles"));
     return datetime.format(DateTimeFormatter.ofPattern("yyyy/MM/dd 'at' h:mm a"));
+  }
+
+  protected ImmutableList<DomContent> createLinksAndEscapeText(String content) {
+    List<Url> urls = new UrlDetector(content, UrlDetectorOptions.Default).detect();
+    ImmutableList.Builder<DomContent> contentBuilder = ImmutableList.builder();
+    for (Url url : urls) {
+      int index = content.indexOf(url.getOriginalUrl());
+      // Find where this URL is in the text.
+      if (index == -1) {
+        LOG.error(
+            String.format(
+                "Detected URL %s not present in actual content, %s.",
+                url.getOriginalUrl(), content));
+        continue;
+      }
+      if (index > 0) {
+        // If it's not at the beginning, add the text from before the URL.
+        contentBuilder.add(text(content.substring(0, index)));
+      }
+      // Add the URL.
+      contentBuilder.add(
+          a().withText(url.getOriginalUrl())
+              .withHref(url.getFullUrl())
+              .withClasses(Styles.OPACITY_75));
+      content = content.substring(index + url.getOriginalUrl().length());
+    }
+    // If there's content leftover, add it.
+    if (!Strings.isNullOrEmpty(content)) {
+      contentBuilder.add(text(content));
+    }
+    return contentBuilder.build();
   }
 }

--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -9,6 +9,7 @@ import static j2html.attributes.Attr.HREF;
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.routes;
 import j2html.tags.ContainerTag;
+import j2html.tags.DomContent;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -111,11 +112,13 @@ public class ProgramIndexView extends BaseHtmlView {
             .withId(baseId + "-title")
             .withClasses(Styles.TEXT_LG, Styles.FONT_SEMIBOLD)
             .withText(program.localizedName().getOrDefault(preferredLocale));
+    ImmutableList<DomContent> descriptionContent =
+        createLinksAndEscapeText(program.localizedDescription().getOrDefault(preferredLocale));
     ContainerTag description =
         div()
             .withId(baseId + "-description")
             .withClasses(Styles.TEXT_XS, Styles.MY_2)
-            .withText(program.localizedDescription().getOrDefault(preferredLocale));
+            .with(descriptionContent);
 
     ContainerTag externalLink =
         new LinkElement()

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -72,6 +72,9 @@ lazy val root = (project in file("."))
 
       // Slugs for deeplinking.
       "com.github.slugify" % "slugify" % "2.5",
+
+      // Url detector for program descriptions.
+      "com.linkedin.urls" % "url-detector" % "0.1.17"
     ),
     javacOptions ++= Seq(
       "-encoding", "UTF-8",

--- a/universal-application-tool-0.0.1/test/views/BaseHtmlViewTest.java
+++ b/universal-application-tool-0.0.1/test/views/BaseHtmlViewTest.java
@@ -2,7 +2,10 @@ package views;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import j2html.tags.DomContent;
 import j2html.tags.Tag;
+import j2html.tags.Text;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,6 +23,21 @@ public class BaseHtmlViewTest {
     Tag result = testImpl.submitButton("text contents");
 
     assertThat(result.render()).isEqualTo("<button type=\"submit\">text contents</button>");
+  }
+
+  @Test
+  public void urlsRenderCorrectly() {
+    ImmutableList<DomContent> content =
+        testImpl.createLinksAndEscapeText("hello google.com http://internet.website");
+    assertThat(content).hasSize(4);
+    assertThat(content.get(0).render()).isEqualTo(new Text("hello ").render());
+    assertThat(content.get(1).render())
+        .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
+    assertThat(content.get(2).render()).isEqualTo(new Text(" ").render());
+    assertThat(content.get(3).render())
+        .isEqualTo(
+            "<a href=\"http://internet.website/\""
+                + " class=\"opacity-75\">http://internet.website</a>");
   }
 
   private static class TestImpl extends BaseHtmlView {}


### PR DESCRIPTION
### Description
Extract urls, use their exact text (but their expanded url) using the normal linkedin library that does this exact thing we want.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #886.