### PR TITLE
Temporary fix to #1163 by not allowing name collisions

### DIFF
--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -13,7 +13,7 @@ describe('Create program with enumerator and repeated questions', () => {
     await adminQuestions.addNameQuestion('apc-name');
     await adminQuestions.addTextQuestion('apc-text');
     await adminQuestions.addEnumeratorQuestion('apc-enumerator');
-    await adminQuestions.addTextQuestion('apc-repeated', 'description', 'text', 'helptext', 'apc-enumerator');
+    await adminQuestions.addTextQuestion('apc-repeated', 'description', '\$this text', '\$this help text', 'apc-enumerator');
 
     const programName = 'apc program';
     await adminPrograms.addProgram(programName);

--- a/browser-test/src/admin_program_creation.test.ts
+++ b/browser-test/src/admin_program_creation.test.ts
@@ -13,7 +13,7 @@ describe('Create program with enumerator and repeated questions', () => {
     await adminQuestions.addNameQuestion('apc-name');
     await adminQuestions.addTextQuestion('apc-text');
     await adminQuestions.addEnumeratorQuestion('apc-enumerator');
-    await adminQuestions.addTextQuestion('apc-repeated', 'description', '\$this text', '\$this help text', 'apc-enumerator');
+    await adminQuestions.addTextQuestion('apc-repeated', 'description', 'text', 'helptext', 'apc-enumerator');
 
     const programName = 'apc program';
     await adminPrograms.addProgram(programName);

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -94,7 +94,8 @@ public class QuestionRepository {
     ConflictDetector conflictDetector =
         new ConflictDetector(
             newQuestionDefinition.getEnumeratorId(),
-            newQuestionDefinition.getQuestionPathSegment());
+            newQuestionDefinition.getQuestionPathSegment(),
+            newQuestionDefinition.getName());
     ebeanServer
         .find(Question.class)
         .findEachWhile(question -> !conflictDetector.hasConflict(question));
@@ -105,10 +106,13 @@ public class QuestionRepository {
     private Optional<Question> conflictedQuestion = Optional.empty();
     private final Optional<Long> enumeratorId;
     private final String questionPathSegment;
+    private final String questionName;
 
-    private ConflictDetector(Optional<Long> enumeratorId, String questionPathSegment) {
+    private ConflictDetector(
+        Optional<Long> enumeratorId, String questionPathSegment, String questionName) {
       this.enumeratorId = checkNotNull(enumeratorId);
       this.questionPathSegment = checkNotNull(questionPathSegment);
+      this.questionName = checkNotNull(questionName);
     }
 
     private Optional<Question> getConflictedQuestion() {
@@ -116,11 +120,12 @@ public class QuestionRepository {
     }
 
     private boolean hasConflict(Question question) {
-      if (question.getQuestionDefinition().getEnumeratorId().equals(enumeratorId)
-          && question
-              .getQuestionDefinition()
-              .getQuestionPathSegment()
-              .equals(questionPathSegment)) {
+      if (question.getQuestionDefinition().getName().equals(questionName)
+          || (question.getQuestionDefinition().getEnumeratorId().equals(enumeratorId)
+              && question
+                  .getQuestionDefinition()
+                  .getQuestionPathSegment()
+                  .equals(questionPathSegment))) {
         conflictedQuestion = Optional.of(question);
         return true;
       }

--- a/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
@@ -72,6 +72,20 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
   }
 
   @Test
+  public void findConflictingQuestion_sameName_hasConflict() throws Exception {
+    Question applicantAddress = testQuestionBank.applicantAddress();
+    QuestionDefinition newQuestionDefinition =
+        new QuestionDefinitionBuilder(applicantAddress.getQuestionDefinition())
+            .clearId()
+            .setEnumeratorId(Optional.of(1L))
+            .build();
+
+    Optional<Question> maybeConflict = repo.findConflictingQuestion(newQuestionDefinition);
+
+    assertThat(maybeConflict).contains(applicantAddress);
+  }
+
+  @Test
   public void findConflictingQuestion_sameQuestionPathSegment_hasConflict() throws Exception {
     Question applicantAddress = testQuestionBank.applicantAddress();
     QuestionDefinition newQuestionDefinition =


### PR DESCRIPTION
### Description
This is a stopgap to prevent civiform from breaking by changing `QuestionRepository#findConflictingQuestion` to include questions with question name collisions.

I think we should allow name collisions, but the `ActiveAndDraftQuestions` rely on unique names and we can address that later.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Stopgap for #1163 