### PR TITLE
YAML doesn't escape backslashes the same way as JSON.

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -13,9 +13,9 @@ Mappings:
       sender: noreply@staging.seattle.civiform.com
   AdminGroup:
     prod:
-      group: ad\\ITD_CiviForm_Admins
+      group: ad\ITD_CiviForm_Admins
     staging:
-      group: ad\\ITD_CiviForm_Admins_Test
+      group: ad\ITD_CiviForm_Admins_Test
 Parameters:
   Environment:
     Type: String


### PR DESCRIPTION
### Description
See long conversation in #prod-issues starting with https://civiform.slack.com/archives/C02022VFNCF/p1621273583148200.

Tested in staging, works there.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
