### PR TITLE
Don't throw a runtime exception when a multi-option question has no options

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -81,12 +81,11 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   private ImmutableSet<Locale> getSupportedOptionLocales(ImmutableList<QuestionOption> options) {
-    QuestionOption firstOption = Iterables.getFirst(options, null);
-
-    if (firstOption == null) {
-      throw new RuntimeException("Must have at least one option in MultiOptionQuestionDefinition");
+    if (options.isEmpty()) {
+      return ImmutableSet.of();
     }
 
+    QuestionOption firstOption = Iterables.getFirst(options, null);
     ImmutableSet<Locale> locales = firstOption.optionText().locales();
 
     options.forEach(

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -196,14 +196,28 @@ public abstract class QuestionDefinition {
     if (questionText.hasEmptyTranslation()) {
       errors.add(CiviFormError.of("Question text cannot be blank"));
     }
-    if (getQuestionType().equals(QuestionType.ENUMERATOR)
-        && ((EnumeratorQuestionDefinition) this).getEntityType().hasEmptyTranslation()) {
-      errors.add(CiviFormError.of("Enumerator question must have specified entity type"));
+    if (getQuestionType().equals(QuestionType.ENUMERATOR)) {
+      EnumeratorQuestionDefinition enumeratorQuestionDefinition =
+          (EnumeratorQuestionDefinition) this;
+      if (enumeratorQuestionDefinition.getEntityType().hasEmptyTranslation()) {
+        errors.add(CiviFormError.of("Enumerator question must have specified entity type"));
+      }
     }
     if (isRepeated() && !questionTextAndHelpTextContainsRepeatedEntityNameFormatString()) {
       errors.add(
           CiviFormError.of(
               "Repeated questions must reference '$this' in the text and help text (if present)"));
+    }
+    if (getQuestionType().isMultiOptionType()) {
+      MultiOptionQuestionDefinition multiOptionQuestionDefinition =
+          (MultiOptionQuestionDefinition) this;
+      if (multiOptionQuestionDefinition.getOptions().isEmpty()) {
+        errors.add(CiviFormError.of("Multi-option questions must have at least one option"));
+      }
+      if (multiOptionQuestionDefinition.getOptions().stream()
+          .anyMatch(option -> option.optionText().hasEmptyTranslation())) {
+        errors.add(CiviFormError.of("Multi-option questions cannot have blank options"));
+      }
     }
     return errors.build();
   }

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -3,6 +3,7 @@ package services.question.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
@@ -12,6 +13,7 @@ import org.junit.runner.RunWith;
 import services.CiviFormError;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
+import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.AddressQuestionDefinition.AddressValidationPredicates;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
@@ -412,6 +414,36 @@ public class QuestionDefinitionTest {
             LocalizedStrings.of(Locale.US, ""),
             LocalizedStrings.empty());
     assertThat(question.validate()).containsOnly(CiviFormError.of("Question text cannot be blank"));
+  }
+
+  @Test
+  public void validate_multiOptionQuestion_withoutOptions_returnsError() {
+    QuestionDefinition question =
+        new CheckboxQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "test",
+            LocalizedStrings.withDefaultValue("test"),
+            LocalizedStrings.empty(),
+            ImmutableList.of(),
+            MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create());
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option questions must have at least one option"));
+  }
+
+  @Test
+  public void validate_multiOptionQuestion_withBlankOption_returnsError() {
+    QuestionDefinition question =
+        new CheckboxQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "test",
+            LocalizedStrings.withDefaultValue("test"),
+            LocalizedStrings.empty(),
+            ImmutableList.of(QuestionOption.create(1L, LocalizedStrings.withDefaultValue(""))),
+            MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create());
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option questions cannot have blank options"));
   }
 
   @Test


### PR DESCRIPTION
### Description
Admins were being sent a 500 if they didn't add options to multi option questions.

Now they get a validation toast if a multi-option question has no options, or it has blank ones.