### PR TITLE
Make people the right amount of admin.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -44,6 +44,11 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
+  protected void adaptForRole(UatProfile profile, ImmutableSet<Roles> roles) {
+    // not needed
+  }
+
+  @Override
   public UatProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
     String locale = oidcProfile.getAttribute("user_locale", String.class);
     ImmutableList.Builder<CompletionStage<Void>> dbOperations =

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -5,7 +5,6 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import models.Account;
 import models.Applicant;
-import org.pac4j.core.profile.UserProfile;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.DatabaseExecutionContext;
 import repository.ProgramRepository;
@@ -66,7 +65,7 @@ public class ProfileFactory {
     return wrapProfileData(new UatProfileData(applicant.getAccount().id));
   }
 
-  public UserProfile createNewProgramAdmin() {
+  public UatProfileData createNewProgramAdmin() {
     UatProfileData p = create(Roles.ROLE_PROGRAM_ADMIN);
     wrapProfileData(p)
         .getAccount()

--- a/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
@@ -46,15 +46,19 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
 
   protected abstract ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile);
 
+  protected abstract void adaptForRole(UatProfile profile, ImmutableSet<Roles> roles);
+
   /** Merge the two provided profiles into a new UatProfileData. */
   public UatProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
     String emailAddress = oidcProfile.getAttribute(emailAttributeName(), String.class);
     uatProfile.setEmailAddress(emailAddress).join();
     uatProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
     // Meaning: whatever you signed in with most recently is the role you have.
-    for (Roles role : roles(uatProfile, oidcProfile)) {
+    ImmutableSet<Roles> roles = roles(uatProfile, oidcProfile);
+    for (Roles role : roles) {
       uatProfile.getProfileData().addRole(role.toString());
     }
+    adaptForRole(uatProfile, roles);
     return uatProfile.getProfileData();
   }
 


### PR DESCRIPTION
### Description
Right now you're a global admin as you first log in because we automatically create a new admin account for you.

After this change we don't do that - instead we make the right account for you.

Also a little cleanup.  I never liked that we did mutations during the `getRoles` call, gross - now it's extracted a little.

Thanks to @hmhsu for finding it.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)