### PR TITLE
Help text should be optional when translating

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionTranslationsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionTranslationsController.java
@@ -101,7 +101,10 @@ public class AdminQuestionTranslationsController extends CiviFormController {
                 QuestionDefinition toUpdate = readOnlyQuestionService.getQuestionDefinition(id);
                 QuestionDefinitionBuilder builder = new QuestionDefinitionBuilder(toUpdate);
                 builder.updateQuestionText(updatedLocale, questionText);
-                builder.updateQuestionHelpText(updatedLocale, questionHelpText);
+                // Help text is optional
+                if (!questionHelpText.isBlank()) {
+                  builder.updateQuestionHelpText(updatedLocale, questionHelpText);
+                }
                 QuestionDefinition definitionWithUpdates = builder.build();
                 ErrorAnd<QuestionDefinition, CiviFormError> result =
                     questionService.update(definitionWithUpdates);

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -164,8 +164,13 @@ public abstract class QuestionDefinition {
    * it provides translations for all applicant-visible text in that locale.
    */
   public ImmutableSet<Locale> getSupportedLocales() {
-    return ImmutableSet.copyOf(
-        Sets.intersection(questionText.locales(), questionHelpText.locales()));
+    // Question help text is optional
+    if (questionHelpText.isEmpty()) {
+      return questionText.locales();
+    } else {
+      return ImmutableSet.copyOf(
+          Sets.intersection(questionText.locales(), questionHelpText.locales()));
+    }
   }
 
   /** Get the validation predicates. */

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
@@ -30,33 +30,16 @@ public class QuestionTranslationView extends TranslationFormView {
   }
 
   public Content render(Http.Request request, Locale locale, QuestionDefinition question) {
-    return render(
-        request,
-        locale,
-        question,
-        question.getQuestionText().maybeGet(locale),
-        question.getQuestionHelpText().maybeGet(locale),
-        Optional.empty());
+    return render(request, locale, question, Optional.empty());
   }
 
   public Content renderErrors(
       Http.Request request, Locale locale, QuestionDefinition invalidQuestion, String errors) {
-    return render(
-        request,
-        locale,
-        invalidQuestion,
-        invalidQuestion.getQuestionText().maybeGet(locale),
-        invalidQuestion.getQuestionHelpText().maybeGet(locale),
-        Optional.of(errors));
+    return render(request, locale, invalidQuestion, Optional.of(errors));
   }
 
   private Content render(
-      Http.Request request,
-      Locale locale,
-      QuestionDefinition question,
-      Optional<String> existingQuestionText,
-      Optional<String> existingQuestionHelpText,
-      Optional<String> errors) {
+      Http.Request request, Locale locale, QuestionDefinition question, Optional<String> errors) {
     String formAction =
         controllers.admin.routes.AdminQuestionTranslationsController.update(
                 question.getId(), locale.toLanguageTag())

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import play.i18n.Langs;
 import play.mvc.Http;
 import play.twirl.api.Content;
+import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -65,11 +66,7 @@ public class QuestionTranslationView extends TranslationFormView {
             request,
             locale,
             formAction,
-            formFields(
-                question.getQuestionText().getDefault(),
-                question.getQuestionHelpText().getDefault(),
-                existingQuestionText,
-                existingQuestionHelpText));
+            formFields(locale, question.getQuestionText(), question.getQuestionHelpText()));
 
     String title = "Manage Question Translations";
 
@@ -92,22 +89,27 @@ public class QuestionTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<FieldWithLabel> formFields(
-      String defaultText,
-      String defaultHelpText,
-      Optional<String> questionText,
-      Optional<String> questionHelpText) {
-    return ImmutableList.of(
+      Locale locale, LocalizedStrings questionText, LocalizedStrings helpText) {
+    ImmutableList.Builder<FieldWithLabel> fields = ImmutableList.builder();
+    fields.add(
         FieldWithLabel.input()
             .setId("localize-question-text")
             .setFieldName("questionText")
-            .setLabelText(defaultText)
+            .setLabelText(questionText.getDefault())
             .setPlaceholderText("Question text")
-            .setValue(questionText),
-        FieldWithLabel.input()
-            .setId("localize-question-help-text")
-            .setFieldName("questionHelpText")
-            .setLabelText(defaultHelpText)
-            .setPlaceholderText("Question help text")
-            .setValue(questionHelpText));
+            .setValue(questionText.maybeGet(locale)));
+
+    // Help text is optional - only show if present.
+    if (!helpText.isEmpty()) {
+      fields.add(
+          FieldWithLabel.input()
+              .setId("localize-question-help-text")
+              .setFieldName("questionHelpText")
+              .setLabelText(helpText.getDefault())
+              .setPlaceholderText("Question help text")
+              .setValue(helpText.maybeGet(locale)));
+    }
+
+    return fields.build();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -471,4 +471,24 @@ public class QuestionDefinitionTest {
     assertThat(definition.getSupportedLocales())
         .containsExactly(Locale.US, Locale.forLanguageTag("es-US"));
   }
+
+  @Test
+  public void getSupportedLocales_emptyHelpText_returnsLocalesForQuestionText() {
+    QuestionDefinition definition =
+        new TextQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "test",
+            LocalizedStrings.of(
+                Locale.US,
+                "question?",
+                Locale.forLanguageTag("es-US"),
+                "pregunta",
+                Locale.FRANCE,
+                "question"),
+            LocalizedStrings.empty());
+
+    assertThat(definition.getSupportedLocales())
+        .containsExactly(Locale.US, Locale.forLanguageTag("es-US"), Locale.FRANCE);
+  }
 }


### PR DESCRIPTION
### Description
1. Only shows the help text localization input if there is help text to localize
2. A question is considered to support a locale if
    a. It has help text and both question text and help text support the locale OR
    b. It does not have help text and the question text supports the locale

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1186 
