### PR TITLE
Make greps for finding missing and weird translations unix compatible.

### DIFF
--- a/bin/list-incomplete-messages
+++ b/bin/list-incomplete-messages
@@ -32,8 +32,8 @@ diff_messages() {
   if [[ ! -z $2 ]]
   then
     echo "Missing translations in $3:";
-    difference="$(diff -BZbw --strip-trailing-cr <(echo "$1") <(echo "$2"))";
-    echo "${difference}" | grep "<" | grep -o "[^<]*" | sed "s/^/    /";
+    difference="$(diff -b --strip-trailing-cr <(echo "$1") <(echo "$2"))";
+    echo "${difference}" | grep "<" | grep -o "[^<][a-zA-Z.]*" | sed "s/^/    /";
 
     extra=$(echo "${difference}" | grep ">" | grep -o "[^>]*");
     if [[ ! -z "${extra}" ]];


### PR DESCRIPTION
Not sure why but unix doesn't like the regex used.

In unix, 
`echo " 1111" | grep -o 1*` doesn't work, but `echo " 1111" | grep -o 11*` does work. :confused: 

So the regex is changed from `[^<]*` to `[^<][a-zA-Z.]*`