### PR TITLE
Around 10 am today, our docker builds started failing.

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -39,8 +39,8 @@ RUN cd $PROJECT_HOME/$PROJECT_NAME && npm install && \
 # This is a common trick to shrink container sizes.  we just throw away all that build stuff and use only the jars
 # we built with sbt dist.
 FROM adoptopenjdk/openjdk11:alpine-slim AS stage2
-COPY --from=stage1 /usr/src/universal-application-tool-0.0.1/target/universal/universal-application-tool-0.0.1.zip ./civiform.zip
+COPY --from=stage1 /usr/src/universal-application-tool-0.0.1/target/universal/universal-application-tool-0.0.1.zip /civiform.zip
 RUN apk add bash nodejs npm
-RUN unzip ./civiform.zip; chmod +x ./universal-application-tool-0.0.1/bin/universal-application-tool
+RUN unzip /civiform.zip; chmod +x /universal-application-tool-0.0.1/bin/universal-application-tool
 
-CMD ["./universal-application-tool-0.0.1/bin/universal-application-tool"]
+CMD ["/universal-application-tool-0.0.1/bin/universal-application-tool", "-Dconfig.file=/universal-application-tool-0.0.1/conf/application.conf"]


### PR DESCRIPTION
### Description
we have no root cause for this, but it seemed to be related to finding application.conf.
a search of the internet suggests that play's many mechanisms for building a
distributable version of an application often fail to find application.conf.
We don't know why it failed in this case, but the play docs recommend providing
the config.file parameter on the command line just in case.  It happens to work.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
