### PR TITLE
Add a regex for \$this and \$this.parent etc etc to highlight it in preview.ts

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
@@ -26,7 +26,7 @@ class PreviewController {
       textInput.addEventListener('input', PreviewController.onTextChanged, false);
       let text = (<HTMLInputElement>textInput).value;
       if (text.length > 0) {
-        PreviewController.setChildrenTextNodes(PreviewController.QUESTION_TEXT_CLASS, text);
+        PreviewController.setTextAndHighlightEnumeratorReferences(PreviewController.QUESTION_TEXT_CLASS, text);
       }
     }
     const helpTextInput =
@@ -35,7 +35,7 @@ class PreviewController {
       helpTextInput.addEventListener('input', PreviewController.onHelpTextChanged, false);
       let helpText = (<HTMLInputElement>helpTextInput).value;
       if (helpText.length > 0) {
-        PreviewController.setChildrenTextNodes(PreviewController.QUESTION_HELP_TEXT_CLASS, helpText);
+        PreviewController.setTextAndHighlightEnumeratorReferences(PreviewController.QUESTION_HELP_TEXT_CLASS, helpText);
       }
     }
     const enumeratorSelector = document.getElementById(PreviewController.QUESTION_ENUMERATOR_INPUT_ID);
@@ -67,7 +67,7 @@ class PreviewController {
       text = PreviewController.DEFAULT_QUESTION_TEXT;
     }
 
-    PreviewController.setChildrenTextNodes(
+    PreviewController.setTextAndHighlightEnumeratorReferences(
       PreviewController.QUESTION_TEXT_CLASS,
       text);
   }
@@ -78,7 +78,7 @@ class PreviewController {
       text = PreviewController.DEFAULT_QUESTION_HELP_TEXT;
     }
 
-    PreviewController.setChildrenTextNodes(
+    PreviewController.setTextAndHighlightEnumeratorReferences(
       PreviewController.QUESTION_HELP_TEXT_CLASS,
       text);
   }
@@ -110,7 +110,7 @@ class PreviewController {
    * This will only work when the selected div is only supposed to contain
    * text and has no other child nodes.
    */
-  static setChildrenTextNodes(selector: string, text: string) {
+  static setTextAndHighlightEnumeratorReferences(selector: string, text: string) {
     const previewDiv = document.querySelector(selector);
     const pieces = text.split(PreviewController.THIS_REGEX);
 

--- a/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
@@ -15,8 +15,7 @@ class PreviewController {
   static readonly DEFAULT_QUESTION_HELP_TEXT = "Sample question help text";
   static readonly DEFAULT_ENTITY_TYPE = "Sample repeated entity type";
 
-  static readonly THIS_REGEX = /(\$this(\.parent)*)/g;
-  static readonly THIS_REPLACEMENT_STRING = '<span class="bg-yellow-300">$1</span>';
+  static readonly THIS_REGEX = /(\$this(?:\.parent)*)/g;
 
   constructor() {
     const textInput =
@@ -25,7 +24,7 @@ class PreviewController {
       textInput.addEventListener('input', PreviewController.onTextChanged, false);
       let text = (<HTMLInputElement>textInput).value;
       if (text.length > 0) {
-        PreviewController.setTextContent(PreviewController.QUESTION_TEXT_CLASS, text);
+        PreviewController.setChildrenTextNodes(PreviewController.QUESTION_TEXT_CLASS, text);
       }
     }
     const helpTextInput =
@@ -34,7 +33,7 @@ class PreviewController {
       helpTextInput.addEventListener('input', PreviewController.onHelpTextChanged, false);
       let helpText = (<HTMLInputElement>helpTextInput).value;
       if (helpText.length > 0) {
-        PreviewController.setTextContent(PreviewController.QUESTION_HELP_TEXT_CLASS, helpText);
+        PreviewController.setChildrenTextNodes(PreviewController.QUESTION_HELP_TEXT_CLASS, helpText);
       }
     }
     const enumeratorSelector = document.getElementById(PreviewController.QUESTION_ENUMERATOR_INPUT_ID);
@@ -66,7 +65,7 @@ class PreviewController {
       text = PreviewController.DEFAULT_QUESTION_TEXT;
     }
 
-    PreviewController.setTextContent(
+    PreviewController.setChildrenTextNodes(
       PreviewController.QUESTION_TEXT_CLASS,
       text);
   }
@@ -77,7 +76,7 @@ class PreviewController {
       text = PreviewController.DEFAULT_QUESTION_HELP_TEXT;
     }
 
-    PreviewController.setTextContent(
+    PreviewController.setChildrenTextNodes(
       PreviewController.QUESTION_HELP_TEXT_CLASS,
       text);
   }
@@ -101,11 +100,34 @@ class PreviewController {
       "Add " + entityType);
   }
 
+  /**
+   * Sets the child nodes of the selected div as text or span nodes.
+   * This will highlight text matching PreviewController.THIS_REGEX
+   * in span nodes.
+   *
+   * This will only work when the selected div is only supposed to contain
+   * text and has no other child nodes.
+   */
+  static setChildrenTextNodes(selector: string, text: string) {
+    const previewDiv = document.querySelector(selector);
+    const pieces = text.split(PreviewController.THIS_REGEX);
+
+    previewDiv.innerHTML = "";
+    pieces.forEach(piece => {
+      if (piece.match(PreviewController.THIS_REGEX)) {
+        const thisSpan = document.createElement("span");
+        thisSpan.classList.add("bg-yellow-300");
+        thisSpan.textContent = piece;
+        previewDiv.appendChild(thisSpan);
+      } else {
+        previewDiv.appendChild(document.createTextNode(piece));
+      }})
+  }
+
   static setTextContent(selector: string, text: string) {
     const previewDiv = document.querySelector(selector);
-    text = text.replace(PreviewController.THIS_REGEX, PreviewController.THIS_REPLACEMENT_STRING);
     if (previewDiv) {
-      previewDiv.innerHTML = text;
+      previewDiv.textContent = text;
     }
   }
 

--- a/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
@@ -15,6 +15,8 @@ class PreviewController {
   static readonly DEFAULT_QUESTION_HELP_TEXT = "Sample question help text";
   static readonly DEFAULT_ENTITY_TYPE = "Sample repeated entity type";
 
+  // This regex is used to match $this and $this.parent (etc) strings so we can
+  // highlight them in the question preview.
   static readonly THIS_REGEX = /(\$this(?:\.parent)*)/g;
 
   constructor() {

--- a/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/preview.ts
@@ -15,6 +15,9 @@ class PreviewController {
   static readonly DEFAULT_QUESTION_HELP_TEXT = "Sample question help text";
   static readonly DEFAULT_ENTITY_TYPE = "Sample repeated entity type";
 
+  static readonly THIS_REGEX = /(\$this(\.parent)*)/g;
+  static readonly THIS_REPLACEMENT_STRING = '<span class="bg-yellow-300">$1</span>';
+
   constructor() {
     const textInput =
       document.getElementById(PreviewController.QUESTION_TEXT_INPUT_ID);
@@ -100,8 +103,9 @@ class PreviewController {
 
   static setTextContent(selector: string, text: string) {
     const previewDiv = document.querySelector(selector);
+    text = text.replace(PreviewController.THIS_REGEX, PreviewController.THIS_REPLACEMENT_STRING);
     if (previewDiv) {
-      previewDiv.textContent = text;
+      previewDiv.innerHTML = text;
     }
   }
 


### PR DESCRIPTION
### Description
Add regex `/(\$this(\.parent)*)/g` and use it to highlight matching strings in the preview text and help text divs. It does not use `innerHTML` so raw html won't get rendered.

![image](https://user-images.githubusercontent.com/12072571/118894611-710bee80-b8b9-11eb-9323-930dbd5a4e44.png)

### Issue(s)
Fixes #1198 
