### PR TITLE
Fixed our docker base image

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-slim AS stage1
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage1
 
 # sbt
 
@@ -38,7 +38,7 @@ RUN cd $PROJECT_HOME/$PROJECT_NAME && npm install && \
 
 # This is a common trick to shrink container sizes.  we just throw away all that build stuff and use only the jars
 # we built with sbt dist.
-FROM adoptopenjdk/openjdk11:alpine-slim AS stage2
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage2
 COPY --from=stage1 /usr/src/universal-application-tool-0.0.1/target/universal/universal-application-tool-0.0.1.zip /civiform.zip
 RUN apk add bash nodejs npm
 RUN unzip /civiform.zip; chmod +x /universal-application-tool-0.0.1/bin/universal-application-tool


### PR DESCRIPTION
### Description
`adoptopenjdk/openjdk11:alpine-slim` updates frequently and is unstable, i.e. it broke us today terribly, change to a fixed version

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

