### PR TITLE
Add ability for admin to translate enumerator entity

### DIFF
--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -104,6 +104,40 @@ describe('Admin can manage translations', () => {
     await endSession(browser);
   });
 
+  it('create an enumerator question and add translations for entity type', async () => {
+    const { browser, page } = await startSession();
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+
+    // Add a new question to be translated
+    const questionName = 'enumerator-translated';
+    await adminQuestions.addEnumeratorQuestion(questionName);
+
+    // Go to the question translation page and add a translation for Spanish
+    await adminQuestions.goToQuestionTranslationPage(questionName);
+    const adminTranslations = new AdminTranslations(page);
+    await adminTranslations.selectLanguage('Spanish');
+    await adminTranslations.editQuestionTranslations('test', 'enumerator', ['family member']);
+
+    // Add the question to a program and publish
+    const adminPrograms = new AdminPrograms(page);
+    const programName = 'spanish question';
+    await adminPrograms.addProgram(programName);
+    await adminPrograms.editProgramBlock(programName, 'block', [questionName]);
+    await adminPrograms.publishProgram(programName);
+    await logout(page);
+
+    // Log in as an applicant and view the translated question
+    await loginAsGuest(page);
+    await selectApplicantLanguage(page, 'Español');
+    const applicantQuestions = new ApplicantQuestions(page);
+    await applicantQuestions.applyProgram(programName);
+
+    expect(await page.innerText('form')).toContain('family member');
+    await endSession(browser);
+  });
+
   it('updating a question does not clobber translations', async () => {
     const { browser, page } = await startSession();
 

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -28,6 +28,11 @@ export class AdminTranslations {
       await optionInputs[index].fill(configText[index]);
     }
 
+    const enumeratorInput = await this.page.$('[name="entityType"');
+    if (enumeratorInput) {
+      await enumeratorInput.fill(configText[0]);
+    }
+
     await this.page.click('#update-localizations-button');
   }
 }

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -28,7 +28,7 @@ export class AdminTranslations {
       await optionInputs[index].fill(configText[index]);
     }
 
-    const enumeratorInput = await this.page.$('[name="entityType"');
+    const enumeratorInput = await this.page.$('[name="entityType"]');
     if (enumeratorInput) {
       await enumeratorInput.fill(configText[0]);
     }

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -7,6 +7,7 @@ import auth.Authorizers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
+import forms.EnumeratorQuestionForm;
 import forms.MultiOptionQuestionForm;
 import forms.QuestionForm;
 import forms.QuestionFormBuilder;
@@ -265,12 +266,29 @@ public class AdminQuestionController extends CiviFormController {
             .updateTranslation(
                 LocalizedStrings.DEFAULT_LOCALE, questionForm.getQuestionHelpText()));
 
+    if (existing.getQuestionType().equals(QuestionType.ENUMERATOR)) {
+      mergeLocalizationsForEntityType(
+          updated,
+          (EnumeratorQuestionDefinition) existing,
+          ((EnumeratorQuestionForm) questionForm).getEntityType());
+    }
+
     if (existing.getQuestionType().isMultiOptionType()) {
       mergeLocalizationsForOptions(
           updated,
           (MultiOptionQuestionDefinition) existing,
           ((MultiOptionQuestionForm) questionForm).getOptions());
     }
+  }
+
+  private void mergeLocalizationsForEntityType(
+      QuestionDefinitionBuilder updated,
+      EnumeratorQuestionDefinition existing,
+      String updatedEntityType) {
+    updated.setEntityType(
+        existing
+            .getEntityType()
+            .updateTranslation(LocalizedStrings.DEFAULT_LOCALE, updatedEntityType));
   }
 
   private void mergeLocalizationsForOptions(

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -246,13 +246,17 @@ public class AdminQuestionController extends CiviFormController {
     QuestionDefinitionBuilder updated = questionForm.getBuilder();
 
     if (existing.isPresent()) {
-      mergeLocalizations(existing.get(), updated, questionForm);
+      updateDefaultLocalizations(existing.get(), updated, questionForm);
     }
 
     return updated;
   }
 
-  private void mergeLocalizations(
+  /**
+   * The edit form can change the default locale's text - we want to only change the default locale
+   * text, instead of overwriting all localizations.
+   */
+  private void updateDefaultLocalizations(
       QuestionDefinition existing, QuestionDefinitionBuilder updated, QuestionForm questionForm) {
     // Instead of overwriting all localizations, we just want to overwrite the one
     // for the default locale (the only one possible to change in the edit form).
@@ -267,21 +271,22 @@ public class AdminQuestionController extends CiviFormController {
                 LocalizedStrings.DEFAULT_LOCALE, questionForm.getQuestionHelpText()));
 
     if (existing.getQuestionType().equals(QuestionType.ENUMERATOR)) {
-      mergeLocalizationsForEntityType(
+      updateDefaultLocalizationForEntityType(
           updated,
           (EnumeratorQuestionDefinition) existing,
           ((EnumeratorQuestionForm) questionForm).getEntityType());
     }
 
     if (existing.getQuestionType().isMultiOptionType()) {
-      mergeLocalizationsForOptions(
+      updateDefaultLocalizationForOptions(
           updated,
           (MultiOptionQuestionDefinition) existing,
           ((MultiOptionQuestionForm) questionForm).getOptions());
     }
   }
 
-  private void mergeLocalizationsForEntityType(
+  /** Update the default locale text for an enumerator question's entity type name. */
+  private void updateDefaultLocalizationForEntityType(
       QuestionDefinitionBuilder updated,
       EnumeratorQuestionDefinition existing,
       String updatedEntityType) {
@@ -291,7 +296,8 @@ public class AdminQuestionController extends CiviFormController {
             .updateTranslation(LocalizedStrings.DEFAULT_LOCALE, updatedEntityType));
   }
 
-  private void mergeLocalizationsForOptions(
+  /** Update the default locale text only for a multi-option question's option text. */
+  private void updateDefaultLocalizationForOptions(
       QuestionDefinitionBuilder updated,
       MultiOptionQuestionDefinition existing,
       List<String> updatedDefaultOptions) {

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionTranslationsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionTranslationsController.java
@@ -2,6 +2,7 @@ package controllers.admin;
 
 import auth.Authorizers;
 import controllers.CiviFormController;
+import forms.translation.EnumeratorQuestionTranslationForm;
 import forms.translation.MultiOptionQuestionTranslationForm;
 import forms.translation.QuestionTranslationForm;
 import java.util.Locale;
@@ -125,8 +126,12 @@ public class AdminQuestionTranslationsController extends CiviFormController {
             .form(MultiOptionQuestionTranslationForm.class)
             .bindFromRequest(request)
             .get();
+      case ENUMERATOR:
+        return formFactory
+            .form(EnumeratorQuestionTranslationForm.class)
+            .bindFromRequest(request)
+            .get();
       case ADDRESS: // fallthrough intended
-      case ENUMERATOR: // fallthrough intended
       case FILEUPLOAD: // fallthrough intended
       case NAME: // fallthrough intended
       case NUMBER: // fallthrough intended

--- a/universal-application-tool-0.0.1/app/forms/translation/EnumeratorQuestionTranslationForm.java
+++ b/universal-application-tool-0.0.1/app/forms/translation/EnumeratorQuestionTranslationForm.java
@@ -1,0 +1,36 @@
+package forms.translation;
+
+import java.util.Locale;
+import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+
+public class EnumeratorQuestionTranslationForm extends QuestionTranslationForm {
+
+  private String entityType;
+
+  public EnumeratorQuestionTranslationForm() {
+    super();
+    this.entityType = "";
+  }
+
+  public String getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(String entityType) {
+    this.entityType = entityType;
+  }
+
+  @Override
+  public QuestionDefinitionBuilder builderWithUpdates(
+      QuestionDefinition toUpdate, Locale updatedLocale) throws UnsupportedQuestionTypeException {
+    QuestionDefinitionBuilder partiallyUpdated = super.builderWithUpdates(toUpdate, updatedLocale);
+
+    return partiallyUpdated.setEntityType(
+        ((EnumeratorQuestionDefinition) toUpdate)
+            .getEntityType()
+            .updateTranslation(updatedLocale, this.entityType));
+  }
+}

--- a/universal-application-tool-0.0.1/app/forms/translation/MultiOptionQuestionTranslationForm.java
+++ b/universal-application-tool-0.0.1/app/forms/translation/MultiOptionQuestionTranslationForm.java
@@ -31,14 +31,13 @@ public class MultiOptionQuestionTranslationForm extends QuestionTranslationForm 
 
   @Override
   public QuestionDefinitionBuilder builderWithUpdates(
-      QuestionDefinition definition, Locale updatedLocale) throws UnsupportedQuestionTypeException {
-    QuestionDefinitionBuilder partiallyUpdated =
-        super.builderWithUpdates(definition, updatedLocale);
+      QuestionDefinition toUpdate, Locale updatedLocale) throws UnsupportedQuestionTypeException {
+    QuestionDefinitionBuilder partiallyUpdated = super.builderWithUpdates(toUpdate, updatedLocale);
     ImmutableList.Builder<QuestionOption> updatedOptionsBuilder = ImmutableList.builder();
 
     // For each current option, add or update translations for the given locale.
     ImmutableList<QuestionOption> currentOptions =
-        ((MultiOptionQuestionDefinition) definition).getOptions();
+        ((MultiOptionQuestionDefinition) toUpdate).getOptions();
 
     for (int i = 0; i < currentOptions.size(); i++) {
       QuestionOption current = currentOptions.get(i);

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -43,6 +43,11 @@ public class QuestionDefinitionBuilder {
     questionType = definition.getQuestionType();
     validationPredicatesString = definition.getValidationPredicatesAsString();
 
+    if (definition.getQuestionType().equals(QuestionType.ENUMERATOR)) {
+      EnumeratorQuestionDefinition enumerator = (EnumeratorQuestionDefinition) definition;
+      entityType = enumerator.getEntityType();
+    }
+
     if (definition.getQuestionType().isMultiOptionType()) {
       MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
       questionOptions = multiOption.getOptions();

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
@@ -13,6 +13,7 @@ import play.mvc.Http;
 import play.twirl.api.Content;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
+import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import views.HtmlBundle;
@@ -84,8 +85,10 @@ public class QuestionTranslationView extends TranslationFormView {
       case RADIO_BUTTON:
         MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) question;
         return multiOptionQuestionFields(multiOption.getOptions(), toUpdate);
+      case ENUMERATOR:
+        EnumeratorQuestionDefinition enumerator = (EnumeratorQuestionDefinition) question;
+        return enumeratorQuestionFields(enumerator.getEntityType(), toUpdate);
       case ADDRESS: // fallthrough intended
-      case ENUMERATOR: // fallthrough intended
       case FILEUPLOAD: // fallthrough intended
       case NAME: // fallthrough intended
       case NUMBER: // fallthrough intended
@@ -131,5 +134,15 @@ public class QuestionTranslationView extends TranslationFormView {
                     .setPlaceholderText("Answer option")
                     .setValue(option.optionText().translations().getOrDefault(toUpdate, "")))
         .collect(toImmutableList());
+  }
+
+  private ImmutableList<FieldWithLabel> enumeratorQuestionFields(
+      LocalizedStrings entityType, Locale toUpdate) {
+    return ImmutableList.of(
+        FieldWithLabel.input()
+            .setFieldName("entityType")
+            .setLabelText(entityType.getDefault())
+            .setPlaceholderText("What are we enumerating?")
+            .setValue(entityType.maybeGet(toUpdate).orElse("")));
   }
 }

--- a/universal-application-tool-0.0.1/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/translation/EnumeratorQuestionTranslationFormTest.java
@@ -1,0 +1,65 @@
+package forms.translation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import java.util.Optional;
+import org.junit.Test;
+import services.LocalizedStrings;
+import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.QuestionDefinition;
+
+public class EnumeratorQuestionTranslationFormTest {
+
+  @Test
+  public void buildsQuestion_newLocale_savesUpdates() throws Exception {
+    QuestionDefinition question =
+        new EnumeratorQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "desc",
+            LocalizedStrings.withDefaultValue("existing"),
+            LocalizedStrings.withDefaultValue("existing"),
+            LocalizedStrings.withDefaultValue("existing"));
+
+    EnumeratorQuestionTranslationForm form = new EnumeratorQuestionTranslationForm();
+    form.setQuestionText("Canadian question text");
+    form.setEntityType("Canadian English");
+
+    EnumeratorQuestionDefinition updated =
+        (EnumeratorQuestionDefinition) form.builderWithUpdates(question, Locale.CANADA).build();
+
+    assertThat(updated.getEntityType())
+        .isEqualTo(LocalizedStrings.of(Locale.US, "existing", Locale.CANADA, "Canadian English"));
+    assertThat(updated.getQuestionText())
+        .isEqualTo(
+            LocalizedStrings.of(Locale.US, "existing", Locale.CANADA, "Canadian question text"));
+  }
+
+  @Test
+  public void buildsQuestion_existingLocale_savesUpdates() throws Exception {
+    QuestionDefinition question =
+        new EnumeratorQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "desc",
+            LocalizedStrings.of(Locale.FRANCE, "existing"),
+            LocalizedStrings.of(Locale.FRANCE, "existing"),
+            LocalizedStrings.of(Locale.FRANCE, "existing"));
+
+    EnumeratorQuestionTranslationForm form = new EnumeratorQuestionTranslationForm();
+    form.setQuestionText("new text translation");
+    form.setQuestionHelpText("new help translation");
+    form.setEntityType("new entity translation");
+
+    EnumeratorQuestionDefinition updated =
+        (EnumeratorQuestionDefinition) form.builderWithUpdates(question, Locale.FRANCE).build();
+
+    assertThat(updated.getEntityType())
+        .isEqualTo(LocalizedStrings.of(Locale.FRANCE, "new entity translation"));
+    assertThat(updated.getQuestionText())
+        .isEqualTo(LocalizedStrings.of(Locale.FRANCE, "new text translation"));
+    assertThat(updated.getQuestionHelpText())
+        .isEqualTo(LocalizedStrings.of(Locale.FRANCE, "new help translation"));
+  }
+}


### PR DESCRIPTION
### Description
1. Allows an admin to localize the enumerator entity type name (i.e. the text that appears as "Add **entity**" and similar)
2. Adds an `EnumeratorQuestionTranslationForm` to capture changes made to the entity name

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

<img width="944" alt="Screen Shot 2021-05-19 at 3 02 11 PM" src="https://user-images.githubusercontent.com/8559046/119052990-4766cc00-b97a-11eb-8f97-109a195ac684.png">

