### PR TITLE
My current best theory for the root cause of the 401s earlier today.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -104,6 +104,10 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
     // we need to slighly abuse the notion of a resource retriever.  We create our
     // own modified resource retriever which has access to the required token.
 
+    if (((OidcCredentials) cred).getAccessToken() == null) {
+      return;
+    }
+
     // Note that there would normally be a significant thread-safety issue here - but
     // we actually don't need to match up signing key tokens with actual tokens, because
     // any valid token is sufficient.
@@ -113,9 +117,6 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
           @Override
           public Map<String, List<String>> getHeaders() {
             Map<String, List<String>> headers = super.getHeaders();
-            if (((OidcCredentials) cred).getAccessToken() == null) {
-              return headers;
-            }
             if (headers == null) {
               headers = new HashMap<>();
             }


### PR DESCRIPTION
### Description
It's not a _great_ theory, but it would explain the transience.  One thread can affect the resource retriever used by another thread here - as noted by the comment about thread safety - but one thing I forgot to consider was that if an invalid redirect happened, we might not have the creds we expected and so might break the resource retriever.

Even if wrong, it should be safe anyway.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
