### PR TITLE
Set question entity type when builder a question definition from a question definition.

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -43,6 +43,12 @@ public class QuestionDefinitionBuilder {
     questionType = definition.getQuestionType();
     validationPredicatesString = definition.getValidationPredicatesAsString();
 
+    if (definition.getQuestionType().equals(QuestionType.ENUMERATOR)) {
+      EnumeratorQuestionDefinition enumeratorQuestionDefinition =
+          (EnumeratorQuestionDefinition) definition;
+      entityType = enumeratorQuestionDefinition.getEntityType();
+    }
+
     if (definition.getQuestionType().isMultiOptionType()) {
       MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
       questionOptions = multiOption.getOptions();
@@ -224,6 +230,8 @@ public class QuestionDefinitionBuilder {
         return new RadioButtonQuestionDefinition(
             id, name, enumeratorId, description, questionText, questionHelpText, questionOptions);
       case ENUMERATOR:
+        // This shouldn't happen, but protects us in case there are enumerator questions in the prod
+        // database that don't have entity type specified.
         if (entityType == null || entityType.isEmpty()) {
           entityType =
               LocalizedStrings.withDefaultValue(EnumeratorQuestionDefinition.DEFAULT_ENTITY_TYPE);

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionBuilderTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionBuilderTest.java
@@ -73,4 +73,24 @@ public class QuestionDefinitionBuilderTest {
     assertThat(enumerator.getEntityType().getDefault())
         .isEqualTo(EnumeratorQuestionDefinition.DEFAULT_ENTITY_TYPE);
   }
+
+  @Test
+  public void builder_withEnumeratorQuestion_keepsEntityType() throws Exception {
+    QuestionDefinition questionDefinition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.ENUMERATOR)
+            .setName("")
+            .setDescription("")
+            .setEnumeratorId(Optional.of(123L))
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setEntityType(LocalizedStrings.withDefaultValue("household member"))
+            .build();
+
+    EnumeratorQuestionDefinition enumerator =
+        (EnumeratorQuestionDefinition) new QuestionDefinitionBuilder(questionDefinition).build();
+
+    assertThat(enumerator.getEntityType().isEmpty()).isFalse();
+    assertThat(enumerator.getEntityType().getDefault()).isEqualTo("household member");
+  }
 }


### PR DESCRIPTION
### Description
Enumerator question's entity type was being lost during a `QuestionService.update(QuestionDefinition)` because the `QuestionDefinitionBuilder(QuestionDefinition)` constructor was not using the input `QuestionDefinition`'s entity type.  

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
