### PR TITLE
Slight style improvements to "select a language" page

### DIFF
--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -31,7 +31,7 @@ public enum MessageKey {
   CONTENT_GET_BENEFITS("content.benefits"),
   CONTENT_NO_CATEGORY("content.noCategory"),
   CONTENT_PLEASE_SIGN_IN("content.pleaseCreateAccount"),
-  CONTENT_SELECT_LANGUAGE("content.selectLanguage"),
+  CONTENT_SELECT_LANGUAGE("label.selectLanguage"),
   ENUMERATOR_BUTTON_ADD_ENTITY("button.addEntity"),
   ENUMERATOR_BUTTON_REMOVE_ENTITY("button.removeEntity"),
   ENUMERATOR_PLACEHOLDER_ENTITY_NAME("placeholder.entityName"),

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantInformationView.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
-import static j2html.TagCreator.p;
 
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.routes;
@@ -22,6 +21,7 @@ import services.MessageKey;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.components.SelectWithLabel;
+import views.style.ApplicantStyles;
 
 /**
  * Provides a form for selecting an applicant's preferred language. Note that we cannot use Play's
@@ -49,10 +49,16 @@ public class ApplicantInformationView extends BaseHtmlView {
             .withMethod(Http.HttpVerbs.POST)
             .with(makeCsrfTokenInputTag(request))
             .with(selectLanguageDropdown(messages))
-            .with(submitButton(messages.at(MessageKey.BUTTON_UNTRANSLATED_SUBMIT.getKeyName())));
+            .with(
+                submitButton(messages.at(MessageKey.BUTTON_UNTRANSLATED_SUBMIT.getKeyName()))
+                    .withClasses(ApplicantStyles.BUTTON_SELECT_LANGUAGE));
 
     HtmlBundle bundle =
-        layout.getBundle().setTitle("Applicant information").addMainContent(formContent);
+        layout
+            .getBundle()
+            .setTitle("Applicant information")
+            .addMainStyles(ApplicantStyles.MAIN_APPLICANT_INFO)
+            .addMainContent(formContent);
     return layout.renderWithNav(request, userName, messages, bundle);
   }
 
@@ -61,6 +67,7 @@ public class ApplicantInformationView extends BaseHtmlView {
         new SelectWithLabel()
             .setId("select-language")
             .setFieldName("locale")
+            .setLabelText(messages.at(MessageKey.CONTENT_SELECT_LANGUAGE.getKeyName()))
             .setOptions(
                 // An option consists of the language (localized to that language - for example,
                 // this would display 'Español' for es-US), and the value is the ISO code.
@@ -71,9 +78,7 @@ public class ApplicantInformationView extends BaseHtmlView {
                                 formatLabel(locale), locale.toLanguageTag()))
                     .collect(toImmutableList()));
 
-    return div()
-        .with(p(messages.at(MessageKey.CONTENT_SELECT_LANGUAGE.getKeyName())))
-        .with(languageSelect.getContainer());
+    return div().with(languageSelect.getContainer());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -5,6 +5,9 @@ public final class ApplicantStyles {
   public static final String BODY =
       StyleUtils.joinStyles(BODY_BG_COLOR, Styles.H_FULL, Styles.W_FULL);
 
+  public static final String MAIN_APPLICANT_INFO =
+      StyleUtils.joinStyles(
+          Styles.W_5_6, StyleUtils.responsiveSmall(Styles.W_1_3), Styles.MX_AUTO, Styles.MY_8);
   public static final String MAIN_PROGRAM_APPLICATION =
       StyleUtils.joinStyles(
           Styles.W_5_6,
@@ -95,6 +98,8 @@ public final class ApplicantStyles {
       StyleUtils.joinStyles(
           BUTTON_BASE_OUTLINE, Styles.UPPERCASE, Styles.FONT_SEMIBOLD, Styles.W_MIN, Styles.PX_8);
 
+  public static final String BUTTON_SELECT_LANGUAGE =
+      StyleUtils.joinStyles(BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE, Styles.MX_AUTO);
   public static final String BUTTON_PROGRAM_APPLY =
       StyleUtils.joinStyles(BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_SM, Styles.MX_AUTO);
   public static final String BUTTON_BLOCK_NEXT =

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -17,7 +17,7 @@
 button.logout=Logout
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
-content.selectLanguage=Please select your preferred language from the following:
+label.selectLanguage=Please select your preferred language.
 
 # NO TRANSLATION NEEDED - this appears before applicants select their preferred language, so we always use the default.
 button.untranslatedSubmit=Submit


### PR DESCRIPTION
* Put the select label in the actual label - this is good for a11y, connecting the form field label with the form input.
* Added some padding
* Updated button style

### Screenshots

Mobile
![Screen Shot 2021-05-20 at 4 49 33 PM](https://user-images.githubusercontent.com/5732310/119063033-fca27f80-b98c-11eb-8dff-bf52041fa35f.png)

Desktop
![Screen Shot 2021-05-20 at 4 49 45 PM](https://user-images.githubusercontent.com/5732310/119063048-00ce9d00-b98d-11eb-91d4-84d1cf2f209f.png)

