### PR TITLE
Maybe we should try caching this key and fetching it only once per server

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -133,7 +133,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
     }
   }
 
-  private class CredentialedResourceRetriever extends DefaultResourceRetriever {
+  private static class CredentialedResourceRetriever extends DefaultResourceRetriever {
     private final Credentials cred;
 
     public CredentialedResourceRetriever(OidcConfiguration configuration, Credentials cred) {
@@ -154,7 +154,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
     }
   }
 
-  private class CachedResourceRetriever extends DefaultResourceRetriever {
+  private static class CachedResourceRetriever extends DefaultResourceRetriever {
     private final ImmutableMap<URL, Resource> resources;
 
     public CachedResourceRetriever(


### PR DESCRIPTION
### Description
This way we can make sure that we're fetching the key while this token is active, and caching it indefinitely.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
