### PR TITLE
Update the look of the "upsell" account creation page

### DIFF
--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -81,7 +81,7 @@ export class ApplicantQuestions {
     const pleaseLogInPageRegex = /considerSignIn\?redirectTo=/;
     const maybePleaseLogInPage = await this.page.url();
     if (maybePleaseLogInPage.match(pleaseLogInPageRegex)) {
-       await this.page.click('text="Not Right Now"');
+       await this.page.click('text="Not right now"');
     }
 
     // Ensure that we redirected to the programs list page.

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -30,7 +30,7 @@ public enum MessageKey {
   CONTENT_CONFIRMED("content.confirmed"),
   CONTENT_GET_BENEFITS("content.benefits"),
   CONTENT_NO_CATEGORY("content.noCategory"),
-  CONTENT_PLEASE_SIGN_IN("content.pleaseCreateAccount"),
+  CONTENT_PLEASE_CREATE_ACCOUNT("content.pleaseCreateAccount"),
   CONTENT_SELECT_LANGUAGE("label.selectLanguage"),
   ENUMERATOR_BUTTON_ADD_ENTITY("button.addEntity"),
   ENUMERATOR_BUTTON_REMOVE_ENTITY("button.removeEntity"),

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
@@ -53,7 +53,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
   public Content renderWithNav(
       Http.Request request, String userName, Messages messages, HtmlBundle bundle) {
     // TODO: This will set the html lang attribute to the requested language when we actually want
-    // the rendered language.
+    //  the rendered language.
     Optional<Http.Cookie> language = request.cookies().get("PLAY_LANG");
     if (language.isPresent()) {
       bundle.setLanguage(language.get().value());

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantUpsellCreateAccountView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantUpsellCreateAccountView.java
@@ -3,7 +3,6 @@ package views.applicant;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.h1;
-import static j2html.TagCreator.h2;
 
 import com.google.inject.Inject;
 import controllers.routes;
@@ -16,6 +15,7 @@ import services.MessageKey;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.components.LinkElement;
+import views.style.ApplicantStyles;
 import views.style.Styles;
 
 public final class ApplicantUpsellCreateAccountView extends BaseHtmlView {
@@ -30,26 +30,40 @@ public final class ApplicantUpsellCreateAccountView extends BaseHtmlView {
   /** Renders a sign-up page with a baked-in redirect. */
   public Content render(
       Http.Request request, String redirectTo, Messages messages, String userName) {
-    String title = "Account Creation Interstitial";
+    // TODO(natsid): Either i18n this title, or move the content of this page to the application
+    // confirmation page.
+    String title = "Create an account or sign in";
     HtmlBundle bundle = layout.getBundle().setTitle(title);
 
-    ContainerTag content = div().withClasses(Styles.MX_16);
-    content.with(h2(messages.at(MessageKey.CONTENT_PLEASE_SIGN_IN.getKeyName())));
-    content.with(
-        new LinkElement()
-            .setHref(routes.LoginController.idcsLoginWithRedirect(Optional.of(redirectTo)).url())
-            .setText(messages.at(MessageKey.LINK_DO_SIGN_IN.getKeyName()))
-            .asButton());
-    content.with(
-        new LinkElement()
-            .setHref(redirectTo)
-            .setText(messages.at(MessageKey.LINK_DONT_SIGN_IN.getKeyName()))
-            .asButton());
+    ContainerTag content =
+        div()
+            .with(
+                div(messages.at(MessageKey.CONTENT_PLEASE_CREATE_ACCOUNT.getKeyName()))
+                    .withClasses(Styles.MB_4))
+            .with(
+                div()
+                    .withClasses(Styles.FLEX, Styles.FLEX_ROW, Styles.GAP_4)
+                    // Empty div to push buttons to the right.
+                    .with(div().withClasses(Styles.FLEX_GROW))
+                    .with(
+                        new LinkElement()
+                            .setHref(redirectTo)
+                            .setText(messages.at(MessageKey.LINK_DONT_SIGN_IN.getKeyName()))
+                            .asButton()
+                            .withClasses(ApplicantStyles.BUTTON_NOT_RIGHT_NOW))
+                    .with(
+                        new LinkElement()
+                            .setHref(
+                                routes.LoginController.idcsLoginWithRedirect(
+                                        Optional.of(redirectTo))
+                                    .url())
+                            .setText(messages.at(MessageKey.LINK_DO_SIGN_IN.getKeyName()))
+                            .asButton()
+                            .withClasses(ApplicantStyles.BUTTON_CREATE_ACCOUNT)));
 
-    bundle.addMainContent(
-        layout.renderProgramApplicationTitleAndProgressIndicator(title),
-        h1(title).withClasses(Styles.PX_16, Styles.PY_4),
-        content);
+    bundle
+        .addMainStyles(ApplicantStyles.MAIN_PROGRAM_APPLICATION)
+        .addMainContent(h1(title).withClasses(Styles.MB_4), content);
 
     return layout.renderWithNav(request, userName, messages, bundle);
   }

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -81,8 +81,7 @@ public final class ApplicantStyles {
 
   /** Base styles for semibold, upper case buttons with a solid background. */
   private static final String BUTTON_BASE_SOLID_UPPERCASE =
-      StyleUtils.joinStyles(
-          BUTTON_BASE_SOLID, Styles.UPPERCASE, Styles.FONT_SEMIBOLD, Styles.W_MIN, Styles.PX_8);
+      StyleUtils.joinStyles(BUTTON_BASE_SOLID, Styles.UPPERCASE, Styles.FONT_SEMIBOLD, Styles.PX_8);
 
   /** Base styles for buttons with a transparent background and an outline. */
   private static final String BUTTON_BASE_OUTLINE =
@@ -96,7 +95,7 @@ public final class ApplicantStyles {
 
   private static final String BUTTON_BASE_OUTLINE_UPPERCASE =
       StyleUtils.joinStyles(
-          BUTTON_BASE_OUTLINE, Styles.UPPERCASE, Styles.FONT_SEMIBOLD, Styles.W_MIN, Styles.PX_8);
+          BUTTON_BASE_OUTLINE, Styles.UPPERCASE, Styles.FONT_SEMIBOLD, Styles.PX_8);
 
   public static final String BUTTON_SELECT_LANGUAGE =
       StyleUtils.joinStyles(BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE, Styles.MX_AUTO);
@@ -119,4 +118,8 @@ public final class ApplicantStyles {
           Styles.FONT_NORMAL,
           Styles.JUSTIFY_SELF_END,
           Styles.SELF_CENTER);
+  public static final String BUTTON_CREATE_ACCOUNT =
+      StyleUtils.joinStyles(BUTTON_BASE_SOLID_UPPERCASE, Styles.TEXT_BASE);
+  public static final String BUTTON_NOT_RIGHT_NOW =
+      StyleUtils.joinStyles(BUTTON_BASE_OUTLINE_UPPERCASE, Styles.TEXT_BASE);
 }

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -42,13 +42,13 @@ content.confirmed=Thank you for applying to {0}.  Your application has been rece
 content.pleaseCreateAccount=If you sign into a city account now, your information will be saved and you''ll be able to return at any time to complete future applications.  If you do not already have an account, the login page will allow you to register.  You won''t lose any data you''ve already entered.
 
 # A link that offers applicants the option to create an account.
-link.doCreateAccount=Create Account (Sign In or Register)
+link.doCreateAccount=Create account or sign in
 
 # A link that appears next to the create account button that offers applicants the option to not create an account right now.
-link.dontCreateAccount=Not Right Now
+link.dontCreateAccount=Not right now
 
 # A link that offers an applicant the ability to return to their home page that lists all programs.
-link.returnToDash=Return to All Programs
+link.returnToDash=Return to all programs
 
 #----------------------------------------------------------------------------#
 # APPLICANT HOME PAGE - contains text specific to the applicant's home page. #

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -18,9 +18,9 @@ toast.programCompleted=Application was already completed.
 toast.applicationSaved=Successfully saved application: application ID {0}
 content.confirmed=Thank you for applying to {0}.  Your application has been received, and your application ID is {1}.
 content.pleaseCreateAccount=If you sign into a city account now, your information will be saved and you''ll be able to return at any time to complete future applications.  If you do not already have an account, the login page will allow you to register.  You won''t lose any data you''ve already entered.
-link.returnToDash=Return to All Programs
-link.doCreateAccount=Create Account (Sign In or Register)
-link.dontCreateAccount=Not Right Now
+link.returnToDash=Return to all programs
+link.doCreateAccount=Create account or sign in
+link.dontCreateAccount=Not right now
 
 title.programs=Programs & services
 link.programDetails=Program details

--- a/universal-application-tool-0.0.1/conf/messages.es-US
+++ b/universal-application-tool-0.0.1/conf/messages.es-US
@@ -23,6 +23,9 @@ link.programDetails=Detalles del programa
 content.benefits=Obtener beneficios
 content.description1=CiviForm le permite solicitar muchos beneficios a la vez reutilizando información.
 content.description2=Comience eligiendo una aplicación a continuación.
+link.returnToDash=Regresar a todos los programas
+link.doCreateAccount=Crea una cuenta o inicia sesión
+link.dontCreateAccount=No ahora
 
 label.street=Dirección Línea 1
 placeholder.street=Dirección


### PR DESCRIPTION
### Description
Edited the text and styles of this page.

Still needs work: It's kind of a confusing user experience that this page is shown _before_ the "application confirmation" page. I think we should try to show this info and these buttons _on_ the confirmation page (combine both into one). That will be done as a follow-up.

### Screenshot
![Screen Shot 2021-05-21 at 10 54 24 AM](https://user-images.githubusercontent.com/5732310/119185142-45107a80-ba2b-11eb-81f5-b680f35354ee.png)

