### PR TITLE
Update repeated questions and programs when enumerator question has a new draft

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -155,4 +155,25 @@ describe('End to end enumerator test', () => {
 
     await endSession(browser);
   });
+
+  it('Create new version of enumerator and update repeated questions and programs', async () => {
+    const { browser, page } = await startSession();
+    page.setDefaultTimeout(4000);
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+    const adminPrograms = new AdminPrograms(page);
+
+    await adminQuestions.createNewVersion('enumerator-ete-householdmembers');
+
+    // Repeated questions are updated.
+    await adminQuestions.expectDraftQuestionExist('enumerator-ete-repeated-name');
+    await adminQuestions.expectDraftQuestionExist('enumerator-ete-repeated-jobs');
+    await adminQuestions.expectDraftQuestionExist('enumerator-ete-repeated-jobs-income');
+
+    // Assert publish does not cause problem, i.e. no program refers to old questions.
+    await adminPrograms.publishProgram(programName);
+
+    await endSession(browser);
+  });
 })

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -175,10 +175,10 @@ export class AdminQuestions {
   }
 
   async addDateQuestion(questionName: string,
-                           description = 'date description',
-                           questionText = 'date question text',
-                           helpText = 'date question help text',
-                           enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
+    description = 'date description',
+    questionText = 'date question text',
+    helpText = 'date question help text',
+    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
     await this.page.click('#create-question-button');
 

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -81,7 +81,7 @@ export class ApplicantQuestions {
     const pleaseLogInPageRegex = /considerSignIn\?redirectTo=/;
     const maybePleaseLogInPage = await this.page.url();
     if (maybePleaseLogInPage.match(pleaseLogInPageRegex)) {
-       await this.page.click('text="Not right now"');
+      await this.page.click('text="Not right now"');
     }
 
     // Ensure that we redirected to the programs list page.

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -88,32 +88,39 @@ public class QuestionRepository {
   }
 
   private void updateAllRepeatedQuestions(long newEnumeratorId, long oldEnumeratorId) {
-    versionRepositoryProvider.get().getDraftVersion().getQuestions().stream()
-        .filter(
-            question ->
-                question
-                    .getQuestionDefinition()
-                    .getEnumeratorId()
-                    .equals(Optional.of(oldEnumeratorId)))
-        .forEach(
-            question ->
-                updateOrCreateDraft(
-                    new QuestionDefinitionBuilder(question.getQuestionDefinition())
-                        .setEnumeratorId(Optional.of(newEnumeratorId))
-                        .build()));
-    versionRepositoryProvider.get().getActiveVersion().getQuestions().stream()
-        .filter(
-            question ->
-                question
-                    .getQuestionDefinition()
-                    .getEnumeratorId()
-                    .equals(Optional.of(oldEnumeratorId)))
-        .forEach(
-            question ->
-                updateOrCreateDraft(
-                    new QuestionDefinitionBuilder(question.getQuestionDefinition())
-                        .setEnumeratorId(Optional.of(newEnumeratorId))
-                        .build()));
+    try {
+      versionRepositoryProvider.get().getDraftVersion().getQuestions().stream()
+          .filter(
+              question ->
+                  question
+                      .getQuestionDefinition()
+                      .getEnumeratorId()
+                      .equals(Optional.of(oldEnumeratorId)))
+          .forEach(
+              question ->
+                  updateOrCreateDraft(
+                      new QuestionDefinitionBuilder(question.getQuestionDefinition())
+                          .setEnumeratorId(Optional.of(newEnumeratorId))
+                          .build()));
+      versionRepositoryProvider.get().getActiveVersion().getQuestions().stream()
+          .filter(
+              question ->
+                  question
+                      .getQuestionDefinition()
+                      .getEnumeratorId()
+                      .equals(Optional.of(oldEnumeratorId)))
+          .forEach(
+              question ->
+                  updateOrCreateDraft(
+                      new QuestionDefinitionBuilder(question.getQuestionDefinition())
+                          .setEnumeratorId(Optional.of(newEnumeratorId))
+                          .build()));
+    } catch (UnsupportedQuestionTypeException e) {
+      // This should not be able to happen since the provided question definition is inherently
+      // valid.
+      // Throw runtime exception so callers don't have to deal with it.
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/repository/VersionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/VersionRepository.java
@@ -186,6 +186,7 @@ public class VersionRepository {
     draftProgram = new Program(updatedDefinition.build());
     LOG.trace("Submitting update.");
     ebeanServer.update(draftProgram);
+    draftProgram.refresh();
   }
 
   public boolean isInactive(Question question) {


### PR DESCRIPTION
### Description
When we create a new version of an enumerator question, we want to update all references to it in its repeated questions and update programs that contain the repeated questions besides just updating the enumerator question itself. If we don't do this, old version of the enumerator becomes obsolete in the next version (when we hit publish all programs next time), and the server throws an error because it cannot find a valid enumerator question definition in the current active (and draft) version. 

### Checklist
- [x] Created tests which fail without the change (if possible)