### PR TITLE
Create initial data classes for predicates

### DIFF
--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -70,7 +70,7 @@ public abstract class Path {
   /**
    * Returns this path in JsonPath predicate format, which must start with {@code \$.}
    *
-   * <p>Example: {@code \$.applicant.address.zip}
+   * <p>Example: {@code $$.applicant.address.zip}
    */
   @Memoized
   public String predicateFormat() {

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -67,11 +67,7 @@ public abstract class Path {
     return isEmpty() ? JSON_PATH_START_TOKEN : JSON_JOINER.join(segments());
   }
 
-  /**
-   * Returns this path in JsonPath predicate format, which must start with
-   *
-   * <p>Example:
-   */
+  /** Returns this path in JsonPath predicate format, which must start with \$. */
   @Memoized
   public String predicateFormat() {
     return JSON_PATH_START + toString();

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -68,9 +68,9 @@ public abstract class Path {
   }
 
   /**
-   * Returns this path in JsonPath predicate format, which must start with {@code \$.}
+   * Returns this path in JsonPath predicate format, which must start with
    *
-   * <p>Example: {@code $$.applicant.address.zip}
+   * <p>Example:
    */
   @Memoized
   public String predicateFormat() {

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -68,9 +68,9 @@ public abstract class Path {
   }
 
   /**
-   * Returns this path in JsonPath predicate format, which must start with "$."
+   * Returns this path in JsonPath predicate format, which must start with
    *
-   * <p>Example: {@code "$.applicant.address"}>
+   * <p>Example:
    */
   @Memoized
   public String predicateFormat() {

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -67,6 +67,11 @@ public abstract class Path {
     return isEmpty() ? JSON_PATH_START_TOKEN : JSON_JOINER.join(segments());
   }
 
+  @Memoized
+  public String predicateFormat() {
+    return JSON_PATH_START + toString();
+  }
+
   /**
    * The {@link Path} of the parent. For example, a path {@code applicant.favorite_color.text} would
    * return {@code applicant.favorite_color}.

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -67,6 +67,11 @@ public abstract class Path {
     return isEmpty() ? JSON_PATH_START_TOKEN : JSON_JOINER.join(segments());
   }
 
+  /**
+   * Returns this path in JsonPath predicate format, which must start with "$."
+   *
+   * <p>Example: {@code "$.applicant.address"}>
+   */
   @Memoized
   public String predicateFormat() {
     return JSON_PATH_START + toString();

--- a/universal-application-tool-0.0.1/app/services/Path.java
+++ b/universal-application-tool-0.0.1/app/services/Path.java
@@ -68,9 +68,9 @@ public abstract class Path {
   }
 
   /**
-   * Returns this path in JsonPath predicate format, which must start with
+   * Returns this path in JsonPath predicate format, which must start with {@code \$.}
    *
-   * <p>Example:
+   * <p>Example: {@code \$.applicant.address.zip}
    */
   @Memoized
   public String predicateFormat() {

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/ConcretePredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/ConcretePredicateExpressionNode.java
@@ -1,0 +1,10 @@
+package services.applicant.predicate;
+
+public interface ConcretePredicateExpressionNode {
+
+  /**
+   * Returns the type of this node, as a {@link
+   * services.applicant.predicate.PredicateExpressionNodeType}.
+   */
+  PredicateExpressionNodeType getType();
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -6,10 +6,10 @@ import services.applicant.question.Scalar;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
- * the format ${json_key} ${operator} ${value}. The expression must be in the context of a single
+ * the format [json_key][operator][value]. The expression must be in the context of a single
  * question.
  *
- * <p>Example: {@code @.zip in ['12345', '12344']}
+ * <p>Example: {@code {@literal @}.zip in ['12345', '12344']}
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode {
@@ -39,7 +39,7 @@ public abstract class LeafOperationExpressionNode {
   /**
    * Formats this expression in JsonPath format: path[?(expression)]
    *
-   * <p>Example: {@code $.applicant.address[?(@.zip in ['12345', '56789'])]}
+   * <p>Example: {@code $.applicant.address[?({@literal @}.zip in ['12345', '56789'])]}
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -6,10 +6,10 @@ import services.applicant.question.Scalar;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
- * the format: {@code \[json_key\]\[operator\]\[value\]} The expression must be in the context of a single
+ * the format:  The expression must be in the context of a single
  * question.
  *
- * <p>Example: {@code \$.applicant.address\[?(@.zip in \["12345", "56789"\])\]}
+ * <p>Example: {@code $$.applicant.address}
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -39,9 +39,9 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   }
 
   /**
-   * Formats this expression in JsonPath format: {@code path\[?(expression)\]}
+   * Formats this expression in JsonPath format:
    *
-   * <p>Example: {@code \$.applicant.address\[?(@.zip in \["12345", "56789"\])\]}
+   * <p>Example: {@code $$.applicant.address}
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -9,7 +9,7 @@ import services.applicant.question.Scalar;
  * the format:  The expression must be in the context of a single
  * question.
  *
- * <p>Example: {@code $$.applicant.address}
+ * <p>Example:
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -41,7 +41,7 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   /**
    * Formats this expression in JsonPath format:
    *
-   * <p>Example: {@code $$.applicant.address}
+   * <p>Example:
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -6,9 +6,10 @@ import services.applicant.question.Scalar;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
- * the format: The expression must be in the context of a single question.
+ * the format: {@code [json_key][operator][value]} The expression must be in the context of a single
+ * question.
  *
- * <p>Example:
+ * <p>Example: {@code \$.applicant.address[?(@.zip in ["12345", "56789"])]}
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -26,10 +27,7 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   /** The specific {@link Scalar} to operate on. */
   public abstract Scalar scalar();
 
-  /**
-   * The JsonPath operator (https://github.com/json-path/JsonPath) for this
-   * expression
-   */
+  /** The operator for this expression. */
   public abstract Operator operator();
 
   /** The value to compare the question key to using the operator, represented as a string. */
@@ -41,9 +39,9 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   }
 
   /**
-   * Formats this expression in JsonPath format:
+   * Formats this expression in JsonPath format: {@code path[?(expression)]}
    *
-   * <p>Example:
+   * <p>Example: {@code \$.applicant.address[?(@.zip in ["12345", "56789"])]}
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -12,7 +12,7 @@ import services.applicant.question.Scalar;
  * <p>Example: {@code {@literal @}.zip in ['12345', '12344']}
  */
 @AutoValue
-public abstract class LeafOperationExpressionNode {
+public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
 
   public static LeafOperationExpressionNode create(
       long questionId, Scalar scalar, Operator operator, PredicateValue comparedValue) {
@@ -36,6 +36,11 @@ public abstract class LeafOperationExpressionNode {
   /** The value to compare the question key to using the operator, represented as a string. */
   public abstract PredicateValue comparedValue();
 
+  @Override
+  public PredicateExpressionNodeType getType() {
+    return PredicateExpressionNodeType.LEAF_OPERATION;
+  }
+
   /**
    * Formats this expression in JsonPath format: path[?(expression)]
    *
@@ -43,13 +48,11 @@ public abstract class LeafOperationExpressionNode {
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(
-        questionPath.predicateFormat()
-            + "[?(@."
-            + scalar().name().toLowerCase()
-            + " "
-            + operator().toJsonPathOperator()
-            + " "
-            + comparedValue().value()
-            + ")]");
+        String.format(
+            "%s[?(@.%s %s %s)]",
+            questionPath.predicateFormat(),
+            scalar().name().toLowerCase(),
+            operator().toJsonPathOperator(),
+            comparedValue().value()));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -9,7 +9,7 @@ import services.applicant.question.Scalar;
  * the format ${json_key} ${operator} ${value}. The expression must be in the context of a single
  * question.
  *
- * <p>Example: @.zip in ['12345', '12344']
+ * <p>Example: {@code @.zip in ['12345', '12344']}
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode {
@@ -39,7 +39,7 @@ public abstract class LeafOperationExpressionNode {
   /**
    * Formats this expression in JsonPath format: path[?(expression)]
    *
-   * <p>Example: $.applicant.address[?(@.zip in ['12345', '56789'])]
+   * <p>Example: {@code $.applicant.address[?(@.zip in ['12345', '56789'])]}
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -6,10 +6,9 @@ import services.applicant.question.Scalar;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
- * the format [json_key][operator][value]. The expression must be in the context of a single
- * question.
+ * the format: The expression must be in the context of a single question.
  *
- * <p>Example: {@literal @.zip in ['12345', '12344']}
+ * <p>Example:
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -28,7 +27,7 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   public abstract Scalar scalar();
 
   /**
-   * The JsonPath operator (https://github.com/json-path/JsonPath#filter-operators) for this
+   * The JsonPath operator (https://github.com/json-path/JsonPath) for this
    * expression
    */
   public abstract Operator operator();
@@ -42,9 +41,9 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   }
 
   /**
-   * Formats this expression in JsonPath format: path[?(expression)]
+   * Formats this expression in JsonPath format:
    *
-   * <p>Example: {@literal $.applicant.address[?(@.zip in ['12345', '56789'])]}
+   * <p>Example:
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -6,10 +6,8 @@ import services.applicant.question.Scalar;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
- * the format:  The expression must be in the context of a single
+ * the format: {@code [json_key][operator][value]} The expression must be in the context of a single
  * question.
- *
- * <p>Example:
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -39,9 +37,9 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   }
 
   /**
-   * Formats this expression in JsonPath format:
+   * Formats this expression in JsonPath format: {@code path[?(expression)]}
    *
-   * <p>Example:
+   * <p>Example: \$.applicant.address[?(@.zip in ["12345", "56789"])]
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -1,0 +1,55 @@
+package services.applicant.predicate;
+
+import com.google.auto.value.AutoValue;
+import services.Path;
+import services.applicant.question.Scalar;
+
+/**
+ * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
+ * the format ${json_key} ${operator} ${value}. The expression must be in the context of a single
+ * question.
+ *
+ * <p>Example: @.zip in ['12345', '12344']
+ */
+@AutoValue
+public abstract class LeafOperationExpressionNode {
+
+  public static LeafOperationExpressionNode create(
+      long questionId, Scalar scalar, Operator operator, PredicateValue comparedValue) {
+    return new AutoValue_LeafOperationExpressionNode(questionId, scalar, operator, comparedValue);
+  }
+
+  /**
+   * The ID of the {@link services.question.types.QuestionDefinition} this expression operates on.
+   */
+  public abstract long questionId();
+
+  /** The specific {@link Scalar} to operate on. */
+  public abstract Scalar scalar();
+
+  /**
+   * The JsonPath operator (https://github.com/json-path/JsonPath#filter-operators) for this
+   * expression
+   */
+  public abstract Operator operator();
+
+  /** The value to compare the question key to using the operator, represented as a string. */
+  public abstract PredicateValue comparedValue();
+
+  /**
+   * Formats this expression in JsonPath format: path[?(expression)]
+   *
+   * <p>Example: $.applicant.address[?(@.zip in ['12345', '56789'])]
+   */
+  public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
+    return JsonPathPredicate.create(
+        questionPath.predicateFormat()
+            + "[?(@."
+            + scalar().name().toLowerCase()
+            + " "
+            + operator().toJsonPathOperator()
+            + " "
+            + comparedValue().value()
+            + ")]");
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -6,10 +6,10 @@ import services.applicant.question.Scalar;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
- * the format: {@code [json_key][operator][value]} The expression must be in the context of a single
+ * the format: {@code \[json_key\]\[operator\]\[value\]} The expression must be in the context of a single
  * question.
  *
- * <p>Example: {@code \$.applicant.address[?(@.zip in ["12345", "56789"])]}
+ * <p>Example: {@code \$.applicant.address\[?(@.zip in \["12345", "56789"\])\]}
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -39,9 +39,9 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   }
 
   /**
-   * Formats this expression in JsonPath format: {@code path[?(expression)]}
+   * Formats this expression in JsonPath format: {@code path\[?(expression)\]}
    *
-   * <p>Example: {@code \$.applicant.address[?(@.zip in ["12345", "56789"])]}
+   * <p>Example: {@code \$.applicant.address\[?(@.zip in \["12345", "56789"\])\]}
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/LeafOperationExpressionNode.java
@@ -9,7 +9,7 @@ import services.applicant.question.Scalar;
  * the format [json_key][operator][value]. The expression must be in the context of a single
  * question.
  *
- * <p>Example: {@code {@literal @}.zip in ['12345', '12344']}
+ * <p>Example: {@literal @.zip in ['12345', '12344']}
  */
 @AutoValue
 public abstract class LeafOperationExpressionNode implements ConcretePredicateExpressionNode {
@@ -44,7 +44,7 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   /**
    * Formats this expression in JsonPath format: path[?(expression)]
    *
-   * <p>Example: {@code $.applicant.address[?({@literal @}.zip in ['12345', '56789'])]}
+   * <p>Example: {@literal $.applicant.address[?(@.zip in ['12345', '56789'])]}
    */
   public JsonPathPredicate toJsonPathPredicate(Path questionPath) {
     return JsonPathPredicate.create(

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
@@ -1,0 +1,25 @@
+package services.applicant.predicate;
+
+public enum Operator {
+  ANY_OF("anyof"),
+  EQUAL_TO("=="),
+  GREATER_THAN(">"),
+  GREATER_THAN_OR_EQUAL_TO(">="),
+  IN("in"),
+  LESS_THAN("<"),
+  LESS_THAN_OR_EQUAL_TO("<="),
+  NONE_OF("noneof"),
+  NOT_EQUAL_TO("!="),
+  NOT_IN("nin"),
+  SUBSET_OF("subsetof");
+
+  private final String jsonPathOperator;
+
+  Operator(String jsonPathOperator) {
+    this.jsonPathOperator = jsonPathOperator;
+  }
+
+  public String toJsonPathOperator() {
+    return this.jsonPathOperator;
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
@@ -1,6 +1,6 @@
 package services.applicant.predicate;
 
-/** Represents a JsonPath operator (https://github.com/json-path/JsonPath#filter-operators). */
+/** Represents a JsonPath operator (https://github.com/json-path/JsonPath). */
 public enum Operator {
   ANY_OF("anyof"),
   EQUAL_TO("=="),

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
@@ -1,5 +1,6 @@
 package services.applicant.predicate;
 
+/** Represents a JsonPath operator (https://github.com/json-path/JsonPath#filter-operators). */
 public enum Operator {
   ANY_OF("anyof"),
   EQUAL_TO("=="),

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/Operator.java
@@ -1,6 +1,6 @@
 package services.applicant.predicate;
 
-/** Represents a JsonPath operator (https://github.com/json-path/JsonPath). */
+/** Represents a JsonPath operator (https://github.com/json-path/JsonPath#filter-operators). */
 public enum Operator {
   ANY_OF("anyof"),
   EQUAL_TO("=="),

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
@@ -2,6 +2,7 @@ package services.applicant.predicate;
 
 import javax.annotation.Nullable;
 
+/** Represents a predicate that can be evaluated over {@link services.applicant.ApplicantData}. */
 public class PredicateExpressionNode {
 
   private final PredicateExpressionNodeType type;
@@ -17,9 +18,10 @@ public class PredicateExpressionNode {
     return this.type;
   }
 
+  /** Get a leaf node if it exists, or throw if this is not a leaf node. */
   public LeafOperationExpressionNode getLeafNode() {
     if (leafNode == null) {
-      throw new RuntimeException("Tried to get a leaf node but no node exists");
+      throw new RuntimeException("Tried to get a predicate leaf node but no node exists");
     }
     return this.leafNode;
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
@@ -1,0 +1,13 @@
+package services.program.predicate;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class PredicateExpressionNode {
+
+  public static PredicateExpressionNode create() {
+    return new AutoValue_PredicateExpressionNode();
+  }
+
+  public abstract PredicateExpressionNodeType getType();
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
@@ -1,12 +1,14 @@
 package services.applicant.predicate;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /** Represents a predicate that can be evaluated over {@link services.applicant.ApplicantData}. */
 public class PredicateExpressionNode {
 
   private final ConcretePredicateExpressionNode node;
 
   public PredicateExpressionNode(ConcretePredicateExpressionNode node) {
-    this.node = node;
+    this.node = checkNotNull(node);
   }
 
   public PredicateExpressionNodeType getType() {

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
@@ -1,28 +1,25 @@
 package services.applicant.predicate;
 
-import javax.annotation.Nullable;
 
 /** Represents a predicate that can be evaluated over {@link services.applicant.ApplicantData}. */
 public class PredicateExpressionNode {
 
-  private final PredicateExpressionNodeType type;
-  private final LeafOperationExpressionNode leafNode;
+  private final ConcretePredicateExpressionNode node;
 
-  public PredicateExpressionNode(
-      PredicateExpressionNodeType type, @Nullable LeafOperationExpressionNode leafNode) {
-    this.type = type;
-    this.leafNode = leafNode;
+  public PredicateExpressionNode(ConcretePredicateExpressionNode node) {
+    this.node = node;
   }
 
   public PredicateExpressionNodeType getType() {
-    return this.type;
+    return node.getType();
   }
 
   /** Get a leaf node if it exists, or throw if this is not a leaf node. */
   public LeafOperationExpressionNode getLeafNode() {
-    if (leafNode == null) {
-      throw new RuntimeException("Tried to get a predicate leaf node but no node exists");
+    if (!(node instanceof LeafOperationExpressionNode)) {
+      throw new RuntimeException(
+          String.format("Expected a leaf node but received %s node", getType()));
     }
-    return this.leafNode;
+    return (LeafOperationExpressionNode) node;
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
@@ -1,13 +1,26 @@
-package services.program.predicate;
+package services.applicant.predicate;
 
-import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
-@AutoValue
-public abstract class PredicateExpressionNode {
+public class PredicateExpressionNode {
 
-  public static PredicateExpressionNode create() {
-    return new AutoValue_PredicateExpressionNode();
+  private final PredicateExpressionNodeType type;
+  private final LeafOperationExpressionNode leafNode;
+
+  public PredicateExpressionNode(
+      PredicateExpressionNodeType type, @Nullable LeafOperationExpressionNode leafNode) {
+    this.type = type;
+    this.leafNode = leafNode;
   }
 
-  public abstract PredicateExpressionNodeType getType();
+  public PredicateExpressionNodeType getType() {
+    return this.type;
+  }
+
+  public LeafOperationExpressionNode getLeafNode() {
+    if (leafNode == null) {
+      throw new RuntimeException("Tried to get a leaf node but no node exists");
+    }
+    return this.leafNode;
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNode.java
@@ -1,6 +1,5 @@
 package services.applicant.predicate;
 
-
 /** Represents a predicate that can be evaluated over {@link services.applicant.ApplicantData}. */
 public class PredicateExpressionNode {
 

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNodeType.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateExpressionNodeType.java
@@ -1,0 +1,7 @@
+package services.applicant.predicate;
+
+public enum PredicateExpressionNodeType {
+  AND,
+  OR,
+  LEAF_OPERATION
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateValue.java
@@ -16,7 +16,7 @@ public abstract class PredicateValue {
 
   public static PredicateValue of(String value) {
     // Escape the string value
-    return create("'" + value + "'");
+    return create("\"" + value + "\"");
   }
 
   private static PredicateValue create(String value) {

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateValue.java
@@ -2,6 +2,11 @@ package services.applicant.predicate;
 
 import com.google.auto.value.AutoValue;
 
+/**
+ * Represents the value on the right side of a JsonPath (https://github.com/json-path/JsonPath)
+ * predicate expression. This value is usually a defined constant, such as a number, string, or
+ * array.
+ */
 @AutoValue
 public abstract class PredicateValue {
 

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateValue.java
@@ -1,0 +1,22 @@
+package services.applicant.predicate;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class PredicateValue {
+
+  public static PredicateValue of(long value) {
+    return create(String.valueOf(value));
+  }
+
+  public static PredicateValue of(String value) {
+    // Escape the string value
+    return create("'" + value + "'");
+  }
+
+  private static PredicateValue create(String value) {
+    return new AutoValue_PredicateValue(value);
+  }
+
+  public abstract String value();
+}

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
@@ -38,21 +38,21 @@ public class QuestionTranslationView extends TranslationFormView {
   }
 
   public Content renderErrors(
-      Http.Request request, Locale locale, QuestionDefinition invalidQuestion, String errors) {
+          Http.Request request, Locale locale, QuestionDefinition invalidQuestion, String errors) {
     return render(request, locale, invalidQuestion, Optional.of(errors));
   }
 
   private Content render(
-      Http.Request request, Locale locale, QuestionDefinition question, Optional<String> errors) {
+          Http.Request request, Locale locale, QuestionDefinition question, Optional<String> errors) {
     String formAction =
-        controllers.admin.routes.AdminQuestionTranslationsController.update(
-                question.getId(), locale.toLanguageTag())
-            .url();
+            controllers.admin.routes.AdminQuestionTranslationsController.update(
+                    question.getId(), locale.toLanguageTag())
+                    .url();
 
     // Add form fields for questions.
     ImmutableList.Builder<FieldWithLabel> inputFields = ImmutableList.builder();
     inputFields.addAll(
-        questionTextFields(locale, question.getQuestionText(), question.getQuestionHelpText()));
+            questionTextFields(locale, question.getQuestionText(), question.getQuestionHelpText()));
     inputFields.addAll(getQuestionTypeSpecificFields(question, locale));
 
     ContainerTag form = renderTranslationForm(request, locale, formAction, inputFields.build());
@@ -60,11 +60,11 @@ public class QuestionTranslationView extends TranslationFormView {
     String title = "Manage Question Translations";
 
     HtmlBundle htmlBundle =
-        layout
-            .getBundle()
-            .setTitle(title)
-            .addMainContent(
-                renderHeader(title), renderLanguageLinks(question.getId(), locale), form);
+            layout
+                    .getBundle()
+                    .setTitle(title)
+                    .addMainContent(
+                            renderHeader(title), renderLanguageLinks(question.getId(), locale), form);
     errors.ifPresent(s -> htmlBundle.addToastMessages(ToastMessage.error(s).setDismissible(false)));
 
     return layout.renderCentered(htmlBundle);
@@ -74,11 +74,11 @@ public class QuestionTranslationView extends TranslationFormView {
   protected String languageLinkDestination(long questionId, Locale locale) {
     return controllers.admin.routes.AdminQuestionTranslationsController.edit(
             questionId, locale.toLanguageTag())
-        .url();
+            .url();
   }
 
   private ImmutableList<FieldWithLabel> getQuestionTypeSpecificFields(
-      QuestionDefinition question, Locale toUpdate) {
+          QuestionDefinition question, Locale toUpdate) {
     switch (question.getQuestionType()) {
       case CHECKBOX: // fallthrough intended
       case DROPDOWN: // fallthrough intended
@@ -99,50 +99,50 @@ public class QuestionTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<FieldWithLabel> questionTextFields(
-      Locale locale, LocalizedStrings questionText, LocalizedStrings helpText) {
+          Locale locale, LocalizedStrings questionText, LocalizedStrings helpText) {
     ImmutableList.Builder<FieldWithLabel> fields = ImmutableList.builder();
     fields.add(
-        FieldWithLabel.input()
-            .setId("localize-question-text")
-            .setFieldName("questionText")
-            .setLabelText(questionText.getDefault())
-            .setPlaceholderText("Question text")
-            .setValue(questionText.maybeGet(locale)));
+            FieldWithLabel.input()
+                    .setId("localize-question-text")
+                    .setFieldName("questionText")
+                    .setLabelText(questionText.getDefault())
+                    .setPlaceholderText("Question text")
+                    .setValue(questionText.maybeGet(locale)));
 
     // Help text is optional - only show if present.
     if (!helpText.isEmpty()) {
       fields.add(
-          FieldWithLabel.input()
-              .setId("localize-question-help-text")
-              .setFieldName("questionHelpText")
-              .setLabelText(helpText.getDefault())
-              .setPlaceholderText("Question help text")
-              .setValue(helpText.maybeGet(locale)));
+              FieldWithLabel.input()
+                      .setId("localize-question-help-text")
+                      .setFieldName("questionHelpText")
+                      .setLabelText(helpText.getDefault())
+                      .setPlaceholderText("Question help text")
+                      .setValue(helpText.maybeGet(locale)));
     }
 
     return fields.build();
   }
 
   private ImmutableList<FieldWithLabel> multiOptionQuestionFields(
-      ImmutableList<QuestionOption> options, Locale toUpdate) {
+          ImmutableList<QuestionOption> options, Locale toUpdate) {
     return options.stream()
-        .map(
-            option ->
-                FieldWithLabel.input()
-                    .setFieldName("options[]")
-                    .setLabelText(option.optionText().getDefault())
-                    .setPlaceholderText("Answer option")
-                    .setValue(option.optionText().translations().getOrDefault(toUpdate, "")))
-        .collect(toImmutableList());
+            .map(
+                    option ->
+                            FieldWithLabel.input()
+                                    .setFieldName("options[]")
+                                    .setLabelText(option.optionText().getDefault())
+                                    .setPlaceholderText("Answer option")
+                                    .setValue(option.optionText().translations().getOrDefault(toUpdate, "")))
+            .collect(toImmutableList());
   }
 
   private ImmutableList<FieldWithLabel> enumeratorQuestionFields(
-      LocalizedStrings entityType, Locale toUpdate) {
+          LocalizedStrings entityType, Locale toUpdate) {
     return ImmutableList.of(
-        FieldWithLabel.input()
-            .setFieldName("entityType")
-            .setLabelText(entityType.getDefault())
-            .setPlaceholderText("What are we enumerating?")
-            .setValue(entityType.maybeGet(toUpdate).orElse("")));
+            FieldWithLabel.input()
+                    .setFieldName("entityType")
+                    .setLabelText(entityType.getDefault())
+                    .setPlaceholderText("What are we enumerating?")
+                    .setValue(entityType.maybeGet(toUpdate).orElse("")));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionTranslationView.java
@@ -38,21 +38,21 @@ public class QuestionTranslationView extends TranslationFormView {
   }
 
   public Content renderErrors(
-          Http.Request request, Locale locale, QuestionDefinition invalidQuestion, String errors) {
+      Http.Request request, Locale locale, QuestionDefinition invalidQuestion, String errors) {
     return render(request, locale, invalidQuestion, Optional.of(errors));
   }
 
   private Content render(
-          Http.Request request, Locale locale, QuestionDefinition question, Optional<String> errors) {
+      Http.Request request, Locale locale, QuestionDefinition question, Optional<String> errors) {
     String formAction =
-            controllers.admin.routes.AdminQuestionTranslationsController.update(
-                    question.getId(), locale.toLanguageTag())
-                    .url();
+        controllers.admin.routes.AdminQuestionTranslationsController.update(
+                question.getId(), locale.toLanguageTag())
+            .url();
 
     // Add form fields for questions.
     ImmutableList.Builder<FieldWithLabel> inputFields = ImmutableList.builder();
     inputFields.addAll(
-            questionTextFields(locale, question.getQuestionText(), question.getQuestionHelpText()));
+        questionTextFields(locale, question.getQuestionText(), question.getQuestionHelpText()));
     inputFields.addAll(getQuestionTypeSpecificFields(question, locale));
 
     ContainerTag form = renderTranslationForm(request, locale, formAction, inputFields.build());
@@ -60,11 +60,11 @@ public class QuestionTranslationView extends TranslationFormView {
     String title = "Manage Question Translations";
 
     HtmlBundle htmlBundle =
-            layout
-                    .getBundle()
-                    .setTitle(title)
-                    .addMainContent(
-                            renderHeader(title), renderLanguageLinks(question.getId(), locale), form);
+        layout
+            .getBundle()
+            .setTitle(title)
+            .addMainContent(
+                renderHeader(title), renderLanguageLinks(question.getId(), locale), form);
     errors.ifPresent(s -> htmlBundle.addToastMessages(ToastMessage.error(s).setDismissible(false)));
 
     return layout.renderCentered(htmlBundle);
@@ -74,11 +74,11 @@ public class QuestionTranslationView extends TranslationFormView {
   protected String languageLinkDestination(long questionId, Locale locale) {
     return controllers.admin.routes.AdminQuestionTranslationsController.edit(
             questionId, locale.toLanguageTag())
-            .url();
+        .url();
   }
 
   private ImmutableList<FieldWithLabel> getQuestionTypeSpecificFields(
-          QuestionDefinition question, Locale toUpdate) {
+      QuestionDefinition question, Locale toUpdate) {
     switch (question.getQuestionType()) {
       case CHECKBOX: // fallthrough intended
       case DROPDOWN: // fallthrough intended
@@ -99,50 +99,50 @@ public class QuestionTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<FieldWithLabel> questionTextFields(
-          Locale locale, LocalizedStrings questionText, LocalizedStrings helpText) {
+      Locale locale, LocalizedStrings questionText, LocalizedStrings helpText) {
     ImmutableList.Builder<FieldWithLabel> fields = ImmutableList.builder();
     fields.add(
-            FieldWithLabel.input()
-                    .setId("localize-question-text")
-                    .setFieldName("questionText")
-                    .setLabelText(questionText.getDefault())
-                    .setPlaceholderText("Question text")
-                    .setValue(questionText.maybeGet(locale)));
+        FieldWithLabel.input()
+            .setId("localize-question-text")
+            .setFieldName("questionText")
+            .setLabelText(questionText.getDefault())
+            .setPlaceholderText("Question text")
+            .setValue(questionText.maybeGet(locale)));
 
     // Help text is optional - only show if present.
     if (!helpText.isEmpty()) {
       fields.add(
-              FieldWithLabel.input()
-                      .setId("localize-question-help-text")
-                      .setFieldName("questionHelpText")
-                      .setLabelText(helpText.getDefault())
-                      .setPlaceholderText("Question help text")
-                      .setValue(helpText.maybeGet(locale)));
+          FieldWithLabel.input()
+              .setId("localize-question-help-text")
+              .setFieldName("questionHelpText")
+              .setLabelText(helpText.getDefault())
+              .setPlaceholderText("Question help text")
+              .setValue(helpText.maybeGet(locale)));
     }
 
     return fields.build();
   }
 
   private ImmutableList<FieldWithLabel> multiOptionQuestionFields(
-          ImmutableList<QuestionOption> options, Locale toUpdate) {
+      ImmutableList<QuestionOption> options, Locale toUpdate) {
     return options.stream()
-            .map(
-                    option ->
-                            FieldWithLabel.input()
-                                    .setFieldName("options[]")
-                                    .setLabelText(option.optionText().getDefault())
-                                    .setPlaceholderText("Answer option")
-                                    .setValue(option.optionText().translations().getOrDefault(toUpdate, "")))
-            .collect(toImmutableList());
+        .map(
+            option ->
+                FieldWithLabel.input()
+                    .setFieldName("options[]")
+                    .setLabelText(option.optionText().getDefault())
+                    .setPlaceholderText("Answer option")
+                    .setValue(option.optionText().translations().getOrDefault(toUpdate, "")))
+        .collect(toImmutableList());
   }
 
   private ImmutableList<FieldWithLabel> enumeratorQuestionFields(
-          LocalizedStrings entityType, Locale toUpdate) {
+      LocalizedStrings entityType, Locale toUpdate) {
     return ImmutableList.of(
-            FieldWithLabel.input()
-                    .setFieldName("entityType")
-                    .setLabelText(entityType.getDefault())
-                    .setPlaceholderText("What are we enumerating?")
-                    .setValue(entityType.maybeGet(toUpdate).orElse("")));
+        FieldWithLabel.input()
+            .setFieldName("entityType")
+            .setLabelText(entityType.getDefault())
+            .setPlaceholderText("What are we enumerating?")
+            .setValue(entityType.maybeGet(toUpdate).orElse("")));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/predicate/LeafOperationExpressionNodeTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/predicate/LeafOperationExpressionNodeTest.java
@@ -15,12 +15,13 @@ public class LeafOperationExpressionNodeTest {
         LeafOperationExpressionNode.create(
             1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Seattle"));
 
+    assertThat(node.getType()).isEqualTo(PredicateExpressionNodeType.LEAF_OPERATION);
     assertThat(node.questionId()).isEqualTo(1L);
     assertThat(node.scalar()).isEqualTo(Scalar.CITY);
     assertThat(node.operator()).isEqualTo(Operator.EQUAL_TO);
     assertThat(node.comparedValue()).isEqualTo(PredicateValue.of("Seattle"));
     assertThat(node.toJsonPathPredicate(Path.create("applicant.address")))
-        .isEqualTo(JsonPathPredicate.create("$.applicant.address[?(@.city == 'Seattle')]"));
+        .isEqualTo(JsonPathPredicate.create("$.applicant.address[?(@.city == \"Seattle\")]"));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/predicate/LeafOperationExpressionNodeTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/predicate/LeafOperationExpressionNodeTest.java
@@ -1,0 +1,38 @@
+package services.applicant.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import services.Path;
+import services.applicant.ApplicantData;
+import services.applicant.question.Scalar;
+
+public class LeafOperationExpressionNodeTest {
+
+  @Test
+  public void create() {
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Seattle"));
+
+    assertThat(node.questionId()).isEqualTo(1L);
+    assertThat(node.scalar()).isEqualTo(Scalar.CITY);
+    assertThat(node.operator()).isEqualTo(Operator.EQUAL_TO);
+    assertThat(node.comparedValue()).isEqualTo(PredicateValue.of("Seattle"));
+    assertThat(node.toJsonPathPredicate(Path.create("applicant.address")))
+        .isEqualTo(JsonPathPredicate.create("$.applicant.address[?(@.city == 'Seattle')]"));
+  }
+
+  @Test
+  public void toJsonPathPredicate_canBeEvaluated() {
+    ApplicantData data = new ApplicantData();
+    data.putString(Path.create("applicant.address.city"), "Chicago");
+
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Chicago"));
+    JsonPathPredicate predicate = node.toJsonPathPredicate(Path.create("applicant.address"));
+
+    assertThat(data.evalPredicate(predicate)).isTrue();
+  }
+}


### PR DESCRIPTION
### Description
Adds initial data classes for block show/hide logic, including:

1. `PredicateExpressionNodeType` - the type of expression node (either AND, OR, or LEAF)
1. `PredicateExpressionNode` - acts as a oneof for AND, OR, and LEAF nodes
2. `LeafOperatorExpressionNode` - a single JsonPath expression on a single question
4. `PredicateValue` - a class for formatting values as JsonPath expression value strings
5. `Operator` - an enum for JsonPath operators

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1001 
