### PR TITLE
Update `DateQuestionRenderer` to use the `ApplicantQuestionRenderer#renderInternal`

### DIFF
--- a/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
@@ -1,15 +1,11 @@
 package views.questiontypes;
 
-import static j2html.TagCreator.div;
-
 import j2html.tags.Tag;
 import java.time.LocalDate;
 import java.util.Optional;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.DateQuestion;
 import views.components.FieldWithLabel;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
 public class DateQuestionRenderer extends ApplicantQuestionRenderer {
 
@@ -23,26 +19,12 @@ public class DateQuestionRenderer extends ApplicantQuestionRenderer {
 
     FieldWithLabel dateField =
         FieldWithLabel.date().setFieldName(dateQuestion.getDatePath().toString());
-
     if (dateQuestion.getDateValue().isPresent()) {
       Optional<String> value = dateQuestion.getDateValue().map(LocalDate::toString);
       dateField.setValue(value);
     }
+    Tag dateQuestionFormContent = dateField.getContainer();
 
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.PX_16)
-        .with(
-            div()
-                .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT)
-                .withText(question.getQuestionText()),
-            div()
-                .withClasses(
-                    ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                    Styles.TEXT_BASE,
-                    Styles.FONT_THIN,
-                    Styles.MB_2)
-                .withText(question.getQuestionHelpText()),
-            dateField.getContainer());
+    return renderInternal(params.messages(), dateQuestionFormContent, false);
   }
 }


### PR DESCRIPTION
Previously, date questions were being rendered in an inconsistent way from the other questions.

### After
![Screen Shot 2021-05-24 at 2 08 27 PM](https://user-images.githubusercontent.com/5732310/119408619-ddf8fd00-bc9a-11eb-90f8-94259479458c.png)

### Before
![Screen Shot 2021-05-24 at 2 07 22 PM](https://user-images.githubusercontent.com/5732310/119408626-dfc2c080-bc9a-11eb-9d04-e6e4478d0660.png)

### Issue(s)
Works toward #1016 
