### PR TITLE
Bugfix/1261 empty helptext

### DIFF
--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -164,6 +164,37 @@ describe('Admin can manage translations', () => {
     await endSession(browser);
   });
 
+  it('deleting help text in question edit view deletes all help text translations', async () => {
+    const { browser, page } = await startSession();
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+
+    // Add a new question with help text
+    const questionName = 'translate-help-text-deletion';
+    await adminQuestions.addNumberQuestion(questionName);
+
+    // Add a translation for a non-English language.
+    await adminQuestions.goToQuestionTranslationPage(questionName);
+    const adminTranslations = new AdminTranslations(page);
+    await adminTranslations.selectLanguage('Spanish');
+    await adminTranslations.editQuestionTranslations('something different', 'help text different');
+
+    // Edit the question and delete the help text.
+    await adminQuestions.changeQuestionHelpText(questionName, "");
+
+    // Edit the question and add help text back
+    await adminQuestions.changeQuestionHelpText(questionName, "a new help text");
+
+    // View the question translations and check that the Spanish translations for question help text are gone.
+    await adminQuestions.goToQuestionTranslationPage(questionName);
+    await adminTranslations.selectLanguage('Spanish');
+    expect(await page.getAttribute('#localize-question-text', 'value')).toContain('something different');
+    expect(await page.getAttribute('#localize-question-help-text', 'value')).toEqual('');
+
+    await endSession(browser);
+  });
+
   it('Applicant sees toast message warning translation is not complete', async () => {
     const { browser, page } = await startSession();
 

--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -181,10 +181,11 @@ describe('Admin can manage translations', () => {
     await adminTranslations.editQuestionTranslations('something different', 'help text different');
 
     // Edit the question and delete the help text.
-    await adminQuestions.changeQuestionHelpText(questionName, "");
+    await adminQuestions.changeQuestionHelpText(questionName, '');
 
     // Edit the question and add help text back
-    await adminQuestions.changeQuestionHelpText(questionName, "a new help text");
+    await adminQuestions.changeQuestionHelpText(questionName, 'a new help text');
+
 
     // View the question translations and check that the Spanish translations for question help text are gone.
     await adminQuestions.goToQuestionTranslationPage(questionName);

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -14,8 +14,9 @@ describe('normal question lifecycle', () => {
     const repeatedQuestion = 'qlc-repeated-number';
     await adminQuestions.addNumberQuestion(
       repeatedQuestion, 'description', '$this\'s favorite number', '', 'qlc-enumerator');
-    const allQuestions = questions.concat(singleBlockQuestions);
 
+    // Combine all the questions that were made so we can update them all together.
+    const allQuestions = questions.concat(singleBlockQuestions);
     // Add to the front of the list because creating a new version of the enumerator question will
     // automatically create a new version of the repeated question.
     allQuestions.unshift(repeatedQuestion);

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -11,22 +11,30 @@ describe('normal question lifecycle', () => {
 
     const questions = await adminQuestions.addAllNonSingleBlockQuestionTypes('qlc-');
     const singleBlockQuestions = await adminQuestions.addAllSingleBlockQuestionTypes('qlc-');
+    const repeatedQuestion = 'qlc-repeated-number';
+    await adminQuestions.addNumberQuestion(
+      repeatedQuestion, 'description', '$this\'s favorite number', '', 'qlc-enumerator');
+    const allQuestions = questions.concat(singleBlockQuestions);
+    allQuestions.push(repeatedQuestion);
 
-    await adminQuestions.updateAllQuestions(questions);
+    await adminQuestions.updateAllQuestions(allQuestions);
 
     const programName = 'program for question lifecycle';
     await adminPrograms.addProgram(programName);
     await adminPrograms.editProgramBlock(programName, 'qlc program description', questions);
     for (const singleBlockQuestion of singleBlockQuestions) {
-      await adminPrograms.addProgramBlock(programName, 'single-block question', [singleBlockQuestion]);
+      const blockName = await adminPrograms.addProgramBlock(programName, 'single-block question', [singleBlockQuestion]);
+      if (singleBlockQuestion == 'qlc-enumerator') {
+        await adminPrograms.addProgramRepeatedBlock(programName, blockName, 'repeated block desc', [repeatedQuestion]);
+      }
     }
     await adminPrograms.publishProgram(programName);
 
-    await adminQuestions.expectActiveQuestions(questions);
+    await adminQuestions.expectActiveQuestions(allQuestions);
 
-    await adminQuestions.createNewVersionForQuestions(questions)
+    await adminQuestions.createNewVersionForQuestions(allQuestions)
 
-    await adminQuestions.updateAllQuestions(questions);
+    await adminQuestions.updateAllQuestions(allQuestions);
 
     await adminPrograms.publishProgram(programName);
 
@@ -34,7 +42,7 @@ describe('normal question lifecycle', () => {
 
     await adminPrograms.publishProgram(programName);
 
-    await adminQuestions.expectActiveQuestions(questions);
+    await adminQuestions.expectActiveQuestions(allQuestions);
 
     await endSession(browser);
   })

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -15,7 +15,10 @@ describe('normal question lifecycle', () => {
     await adminQuestions.addNumberQuestion(
       repeatedQuestion, 'description', '$this\'s favorite number', '', 'qlc-enumerator');
     const allQuestions = questions.concat(singleBlockQuestions);
-    allQuestions.push(repeatedQuestion);
+
+    // Add to the front of the list because creating a new version of the enumerator question will
+    // automatically create a new version of the repeated question.
+    allQuestions.unshift(repeatedQuestion);
 
     await adminQuestions.updateAllQuestions(allQuestions);
 

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -125,7 +125,27 @@ export class AdminPrograms {
 
     await this.page.click('#add-block-button');
 
-    await this.page.type('textarea', blockDescription);
+    await this.page.fill('textarea', blockDescription);
+    await this.page.click('#update-block-button');
+
+    for (const questionName of questionNames) {
+      await this.page.click(`button:text("${questionName}")`);
+    }
+    return await this.page.$eval('#block-name-input', el => (el as HTMLInputElement).value);
+  }
+
+  async addProgramRepeatedBlock(programName: string,
+    enumeratorBlockName: string,
+    blockDescription = 'block description',
+    questionNames: string[] = []) {
+    await this.gotoDraftProgramEditPage(programName);
+    await this.page.click('text=Manage Questions');
+    await this.expectProgramBlockEditPage(programName);
+
+    await this.page.click(`text=${enumeratorBlockName}`);
+    await this.page.click('#create-repeated-block-button');
+
+    await this.page.fill('#block-description-textarea', blockDescription);
     await this.page.click('#update-block-button');
 
     for (const questionName of questionNames) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -175,10 +175,10 @@ export class AdminQuestions {
   }
 
   async addDateQuestion(questionName: string,
-    description = 'date description',
-    questionText = 'date question text',
-    helpText = 'date question help text',
-    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
+                           description = 'date description',
+                           questionText = 'date question text',
+                           helpText = 'date question help text',
+                           enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
     await this.page.click('#create-question-button');
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -175,10 +175,10 @@ export class AdminQuestions {
   }
 
   async addDateQuestion(questionName: string,
-                           description = 'date description',
-                           questionText = 'date question text',
-                           helpText = 'date question help text',
-                           enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
+    description = 'date description',
+    questionText = 'date question text',
+    helpText = 'date question help text',
+    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
     await this.page.click('#create-question-button');
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -94,6 +94,13 @@ export class AdminQuestions {
     await this.expectDraftQuestionExist(questionName, newQuestionText);
   }
 
+  async changeQuestionHelpText(questionName: string, questionHelpText: string) {
+    await this.gotoQuestionEditPage(questionName);
+    await this.page.fill('text=Question Help Text', questionHelpText);
+    await this.page.click('button:text("Update")');
+    await this.expectDraftQuestionExist(questionName);
+  }
+
   async createNewVersion(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("New Version")'));

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -81,7 +81,7 @@ export class ApplicantQuestions {
     const pleaseLogInPageRegex = /considerSignIn\?redirectTo=/;
     const maybePleaseLogInPage = await this.page.url();
     if (maybePleaseLogInPage.match(pleaseLogInPageRegex)) {
-       await this.page.click('text="Not right now"');
+      await this.page.click('text="Not right now"');
     }
 
     // Ensure that we redirected to the programs list page.

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -81,7 +81,7 @@ export class ApplicantQuestions {
     const pleaseLogInPageRegex = /considerSignIn\?redirectTo=/;
     const maybePleaseLogInPage = await this.page.url();
     if (maybePleaseLogInPage.match(pleaseLogInPageRegex)) {
-      await this.page.click('text="Not right now"');
+       await this.page.click('text="Not right now"');
     }
 
     // Ensure that we redirected to the programs list page.

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -265,8 +265,11 @@ public class AdminQuestionController extends CiviFormController {
             .getQuestionText()
             .updateTranslation(LocalizedStrings.DEFAULT_LOCALE, questionForm.getQuestionText()));
 
-    // Question help text is optional, so only update it if there is a real value here.
-    if (!questionForm.getQuestionHelpText().isEmpty()) {
+    // Question help text is optional. If the admin submits an empty string, delete
+    // all translations of it.
+    if (questionForm.getQuestionHelpText().isEmpty()) {
+      updated.setQuestionHelpText(LocalizedStrings.empty());
+    } else {
       updated.setQuestionHelpText(
           existing
               .getQuestionHelpText()

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -267,7 +267,7 @@ public class AdminQuestionController extends CiviFormController {
 
     // Question help text is optional. If the admin submits an empty string, delete
     // all translations of it.
-    if (questionForm.getQuestionHelpText().isEmpty()) {
+    if (questionForm.getQuestionHelpText().isBlank()) {
       updated.setQuestionHelpText(LocalizedStrings.empty());
     } else {
       updated.setQuestionHelpText(

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -264,11 +264,15 @@ public class AdminQuestionController extends CiviFormController {
         existing
             .getQuestionText()
             .updateTranslation(LocalizedStrings.DEFAULT_LOCALE, questionForm.getQuestionText()));
-    updated.setQuestionHelpText(
-        existing
-            .getQuestionHelpText()
-            .updateTranslation(
-                LocalizedStrings.DEFAULT_LOCALE, questionForm.getQuestionHelpText()));
+
+    // Question help text is optional, so only update it if there is a real value here.
+    if (!questionForm.getQuestionHelpText().isEmpty()) {
+      updated.setQuestionHelpText(
+          existing
+              .getQuestionHelpText()
+              .updateTranslation(
+                  LocalizedStrings.DEFAULT_LOCALE, questionForm.getQuestionHelpText()));
+    }
 
     if (existing.getQuestionType().equals(QuestionType.ENUMERATOR)) {
       updateDefaultLocalizationForEntityType(


### PR DESCRIPTION
### Description
Question help text deleted in the question edit form now deletes all translations of it. This is the same behavior that happens when admins delete an option from a multi option question.

Two browser tests were added:
1. `admin_program_translation.test.ts` tests that translations are deleted when an admin updates the question help text to be blank.
2. `question_lifecycle.test.ts` tests that updating a repeated question does not require "$this" in the help text because it knows it is an empty set of localized strings. Before these changes, it behaved as if there was a help text, and then required "$this", even though the help string was empty.
    * Upon editing the `question_lifecycle.test.ts` it was clear that this test didn't create new versions of all the questions, so the test was fixed. 


This is what used to happen. Help text was set to empty string for default locale, but was kept for other locales. 
![after deleting help text](https://user-images.githubusercontent.com/12072571/119544974-1f46e680-bd47-11eb-9161-831c0b6a9cb9.PNG)

Now the translations are empty, instead of containing the empty string and old translations for other locales.
![image](https://user-images.githubusercontent.com/12072571/119545165-5b7a4700-bd47-11eb-9e99-bb30b9f92ca8.png)


### Checklist
- [x] Created tests which fail without the change (if possible)

### Issue(s)
Fixes #1261 
