### PR TITLE
Fix enumerator block delete issue

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -40,8 +40,14 @@ describe('End to end enumerator test', () => {
     expect(await page.innerText('id=question-bank-questions')).toContain('enumerator-ete-repeated-name');
     expect(await page.innerText('id=question-bank-questions')).toContain('enumerator-ete-repeated-jobs');
 
+    // Go back to the enumerator block, and with a repeated block, it cannot be deleted now. The enumerator question cannot be removed, either.
+    await page.click('p:text("Block 2")');
+    expect(await page.getAttribute('#delete-block-button', 'disabled')).not.toBeNull();
+    expect(await page.getAttribute('button:text("enumerator-ete-householdmembers")', 'disabled')).not.toBeNull();
+
     // Create the rest of the program.
     // Add repeated name question
+    await page.click('p:text("Block 3")');
     await page.click('button:text("enumerator-ete-repeated-name")');
 
     // Create another repeated block and add the nested enumerator question

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -183,7 +183,7 @@ export class AdminPrograms {
 
   async expectApplicationAnswerLinks(blockName: string, questionName: string) {
     expect(await this.page.innerText(this.selectApplicationBlock(blockName))).toContain(questionName);
-    expect(await this.page.getAttribute(this.selectWithinApplicationBlock(blockName, 'a'), 'href')).toBeDefined();
+    expect(await this.page.getAttribute(this.selectWithinApplicationBlock(blockName, 'a'), 'href')).not.toBeNull();
   }
 
   async getCsv() {


### PR DESCRIPTION
### Description
An enumerator block cannot be deleted from a program if it has repeated blocks. Similarly, the enumerator question cannot be removed from the block if there are still repeated blocks.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1259 

Block able to be removed
![Screen Shot 2021-05-24 at 6 27 23 PM](https://user-images.githubusercontent.com/2597580/119426587-59b87100-bcbe-11eb-864d-54d75025fe32.png)
Block not able to be removed (delete button grayed out, enumerator question button also grayed out)
![Screen Shot 2021-05-24 at 6 28 23 PM](https://user-images.githubusercontent.com/2597580/119426597-5de48e80-bcbe-11eb-83fb-ed2d0d50c1e1.png)
