### PR TITLE
Require unique program names.

### DIFF
--- a/browser-test/src/admin_program_translation.test.ts
+++ b/browser-test/src/admin_program_translation.test.ts
@@ -86,7 +86,7 @@ describe('Admin can manage translations', () => {
 
     // Add the question to a program and publish
     const adminPrograms = new AdminPrograms(page);
-    const programName = 'spanish question';
+    const programName = 'spanish question multi-option';
     await adminPrograms.addProgram(programName);
     await adminPrograms.editProgramBlock(programName, 'block', [questionName]);
     await adminPrograms.publishProgram(programName);
@@ -122,7 +122,7 @@ describe('Admin can manage translations', () => {
 
     // Add the question to a program and publish
     const adminPrograms = new AdminPrograms(page);
-    const programName = 'spanish question';
+    const programName = 'spanish question enumerator';
     await adminPrograms.addProgram(programName);
     await adminPrograms.editProgramBlock(programName, 'block', [questionName]);
     await adminPrograms.publishProgram(programName);

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -91,6 +91,9 @@ public class ProgramServiceImpl implements ProgramService {
       String defaultDisplayDescription) {
 
     ImmutableSet.Builder<CiviFormError> errorsBuilder = ImmutableSet.builder();
+    if (hasProgramNameCollision(adminName)) {
+      errorsBuilder.add(CiviFormError.of("a program named " + adminName + " already exists"));
+    }
     validateProgramText(errorsBuilder, "admin name", adminName);
     validateProgramText(errorsBuilder, "admin description", adminDescription);
     validateProgramText(errorsBuilder, "display name", defaultDisplayName);
@@ -170,6 +173,10 @@ public class ProgramServiceImpl implements ProgramService {
                 programRepository.updateProgramSync(program).getProgramDefinition())
             .toCompletableFuture()
             .join());
+  }
+
+  private boolean hasProgramNameCollision(String programName) {
+    return getActiveAndDraftPrograms().getProgramNames().contains(programName);
   }
 
   private void validateProgramText(

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -50,7 +50,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void syncQuestions_constructsAllQuestionDefinitions() throws Exception {
+  public void syncQuestions_constructsAllQuestionDefinitions() {
     QuestionDefinition questionOne = nameQuestion;
     QuestionDefinition questionTwo = addressQuestion;
     QuestionDefinition questionThree = colorQuestion;
@@ -114,11 +114,24 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
     assertThat(result.getErrors())
-        .containsOnly(
+        .containsExactly(
             CiviFormError.of("program admin name cannot be blank"),
             CiviFormError.of("program admin description cannot be blank"),
             CiviFormError.of("program display name cannot be blank"),
             CiviFormError.of("program display description cannot be blank"));
+  }
+
+  @Test
+  public void createProgram_protectsAgainstProgramNameCollisions() {
+    ps.createProgramDefinition("name", "description", "display name", "display description");
+
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.createProgramDefinition("name", "description", "display name", "display description");
+
+    assertThat(result.hasResult()).isFalse();
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors())
+        .containsExactly(CiviFormError.of("a program named name already exists"));
   }
 
   @Test


### PR DESCRIPTION
### Description
Program names NEED to be unique for `ActiveAndDraftProgram`, but the `ProgramService` was not checking that they were unique. Now it does.

### Checklist
- [x] Created tests which fail without the change (if possible)
