### PR TITLE
[WIP] Add a method to determine whether to show a block based on its predicate

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -14,6 +14,7 @@ import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.PresentsErrors;
 import services.program.BlockDefinition;
 import services.program.ProgramQuestionDefinition;
+import services.program.predicate.PredicateDefinition;
 import services.question.types.ScalarType;
 
 /** Represents a block in the context of a specific user's application. */
@@ -64,6 +65,10 @@ public final class Block {
 
   public String getDescription() {
     return blockDefinition.description();
+  }
+
+  public Optional<PredicateDefinition> getVisibilityPredicate() {
+    return blockDefinition.visibilityPredicate();
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -1,6 +1,7 @@
 package services.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -11,12 +12,15 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import services.LocalizedStrings;
 import services.Path;
+import services.applicant.predicate.JsonPathPredicateGenerator;
+import services.applicant.predicate.PredicateEvaluator;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.FileUploadQuestion;
 import services.applicant.question.Scalar;
 import services.aws.SimpleStorage;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
+import services.program.predicate.PredicateDefinition;
 import services.question.LocalizedQuestionOption;
 import services.question.types.EnumeratorQuestionDefinition;
 
@@ -103,6 +107,42 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     return programDefinition.getSupportedLocales().contains(applicantData.preferredLocale());
   }
 
+  @Override
+  public ImmutableList<AnswerData> getSummaryData() {
+    // TODO: We need to be able to use this on the admin side with admin-specific l10n.
+    ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
+    ImmutableList<Block> blocks = getAllBlocks();
+    for (Block block : blocks) {
+      ImmutableList<ApplicantQuestion> questions = block.getQuestions();
+      for (int questionIndex = 0; questionIndex < questions.size(); questionIndex++) {
+        ApplicantQuestion question = questions.get(questionIndex);
+        String questionText = question.getQuestionText();
+        String answerText = question.errorsPresenter().getAnswerString();
+        Optional<Long> timestamp = question.getLastUpdatedTimeMetadata();
+        Optional<Long> updatedProgram = question.getUpdatedInProgramMetadata();
+        boolean isPreviousResponse =
+            updatedProgram.isPresent() && updatedProgram.get() != programDefinition.id();
+        AnswerData data =
+            AnswerData.builder()
+                .setProgramId(programDefinition.id())
+                .setBlockId(block.getId())
+                .setQuestionDefinition(question.getQuestionDefinition())
+                .setRepeatedEntity(block.getRepeatedEntity())
+                .setQuestionIndex(questionIndex)
+                .setQuestionText(questionText)
+                .setAnswerText(answerText)
+                .setAnswerLink(getAnswerLink(question))
+                .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))
+                .setIsPreviousResponse(isPreviousResponse)
+                .setScalarAnswersInDefaultLocale(
+                    getScalarAnswers(question, LocalizedStrings.DEFAULT_LOCALE))
+                .build();
+        builder.add(data);
+      }
+    }
+    return builder.build();
+  }
+
   /**
    * Gets {@link Block}s for this program and applicant. If {@code onlyIncludeInProgressBlocks} is
    * true, then only the current blocks will be included in the list. A block is "in progress" if it
@@ -173,40 +213,30 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
     return blockListBuilder.build();
   }
 
-  @Override
-  public ImmutableList<AnswerData> getSummaryData() {
-    // TODO: We need to be able to use this on the admin side with admin-specific l10n.
-    ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
-    ImmutableList<Block> blocks = getAllBlocks();
-    for (Block block : blocks) {
-      ImmutableList<ApplicantQuestion> questions = block.getQuestions();
-      for (int questionIndex = 0; questionIndex < questions.size(); questionIndex++) {
-        ApplicantQuestion question = questions.get(questionIndex);
-        String questionText = question.getQuestionText();
-        String answerText = question.errorsPresenter().getAnswerString();
-        Optional<Long> timestamp = question.getLastUpdatedTimeMetadata();
-        Optional<Long> updatedProgram = question.getUpdatedInProgramMetadata();
-        boolean isPreviousResponse =
-            updatedProgram.isPresent() && updatedProgram.get() != programDefinition.id();
-        AnswerData data =
-            AnswerData.builder()
-                .setProgramId(programDefinition.id())
-                .setBlockId(block.getId())
-                .setQuestionDefinition(question.getQuestionDefinition())
-                .setRepeatedEntity(block.getRepeatedEntity())
-                .setQuestionIndex(questionIndex)
-                .setQuestionText(questionText)
-                .setAnswerText(answerText)
-                .setAnswerLink(getAnswerLink(question))
-                .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))
-                .setIsPreviousResponse(isPreviousResponse)
-                .setScalarAnswersInDefaultLocale(
-                    getScalarAnswers(question, LocalizedStrings.DEFAULT_LOCALE))
-                .build();
-        builder.add(data);
-      }
+  // TODO(cdanzi): Change to private when this method is used.
+  protected boolean showBlock(Block block) {
+    if (block.getVisibilityPredicate().isEmpty()) {
+      // Default to show
+      return true;
     }
-    return builder.build();
+
+    JsonPathPredicateGenerator predicateGenerator =
+        new JsonPathPredicateGenerator(
+            this.applicantData,
+            this.programDefinition.streamQuestionDefinitions().collect(toImmutableList()),
+            block.getRepeatedEntity());
+    PredicateEvaluator predicateEvaluator =
+        new PredicateEvaluator(this.applicantData, predicateGenerator);
+    PredicateDefinition predicate = block.getVisibilityPredicate().get();
+
+    switch (predicate.action()) {
+      case HIDE_BLOCK:
+        return !predicateEvaluator.evaluate(predicate.rootNode());
+      case SHOW_BLOCK:
+        return predicateEvaluator.evaluate(predicate.rootNode());
+      default:
+        return true;
+    }
   }
 
   /** Returns a link to answer content if applicable, e.g. an uploaded file. */

--- a/universal-application-tool-0.0.1/app/services/applicant/exception/InvalidPredicateException.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/exception/InvalidPredicateException.java
@@ -1,0 +1,8 @@
+package services.applicant.exception;
+
+public class InvalidPredicateException extends Exception {
+
+  public InvalidPredicateException(String message) {
+    super(message);
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -1,20 +1,90 @@
 package services.applicant.predicate;
 
-import services.Path;
-import services.program.predicate.LeafOperationExpressionNode;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
+import services.Path;
+import services.applicant.ApplicantData;
+import services.applicant.RepeatedEntity;
+import services.applicant.exception.InvalidPredicateException;
+import services.applicant.question.ApplicantQuestion;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.question.types.QuestionDefinition;
+
+/** Generates {@link JsonPathPredicate}s based on the current applicant filling out the program. */
 public class JsonPathPredicateGenerator {
+
+  private final ApplicantData applicantData;
+  private final ImmutableMap<Long, QuestionDefinition> questionsById;
+  private final Optional<RepeatedEntity> currentRepeatedContext;
+
+  /**
+   * This cannot be built from a set of {@link ApplicantQuestion}s because the question IDs for
+   * repeated questions are used multiple times. For example, if there is a repeated name question,
+   * that name question is repeated for each entity. Instead, we use {@link QuestionDefinition}s and
+   * pass in the current block's repeated entity context, so we can determine which repeated entity
+   * we are currently on, as well as find the target question used in the predicate.
+   */
+  public JsonPathPredicateGenerator(
+      ApplicantData applicantData,
+      ImmutableList<QuestionDefinition> programQuestions,
+      Optional<RepeatedEntity> currentRepeatedContext) {
+    this.applicantData = applicantData;
+    this.questionsById =
+        programQuestions.stream().collect(toImmutableMap(QuestionDefinition::getId, q -> q));
+    this.currentRepeatedContext = currentRepeatedContext;
+  }
 
   /**
    * Formats a {@link LeafOperationExpressionNode} in JsonPath format: {@code path[?(expression)]}
    *
    * <p>Example: \$.applicant.address[?(@.zip in ["12345", "56789"])]
    */
-  public JsonPathPredicate fromLeafNode(LeafOperationExpressionNode node, Path questionPath) {
+  public JsonPathPredicate fromLeafNode(LeafOperationExpressionNode node)
+      throws InvalidPredicateException {
+    if (!questionsById.containsKey(node.questionId())) {
+      // This means a predicate was incorrectly configured - we are depending upon a question that
+      // does not appear anywhere in this program.
+      throw new InvalidPredicateException(
+          String.format(
+              "Tried to apply a predicate based on question %d, which is not found in this"
+                  + " program.",
+              node.questionId()));
+    }
+
+    QuestionDefinition targetQuestion = questionsById.get(node.questionId());
+    Optional<RepeatedEntity> predicateContext;
+
+    if (targetQuestion.getEnumeratorId().isEmpty()) {
+      // This is a top-level question (i.e. is not repeated) - use an empty repeated context.
+      predicateContext = Optional.empty();
+    } else {
+      // Walk up the RepeatedEntity ancestors to find the right context. We need the context of the
+      // question in the predicate definition - that is, the one where the predicate question's
+      // enumerator ID matches the context's enumerator ID.
+      long enumeratorId = targetQuestion.getEnumeratorId().get();
+      predicateContext = this.currentRepeatedContext;
+      while (predicateContext.isPresent()
+          && predicateContext.get().enumeratorQuestionDefinition().getId() != enumeratorId) {
+        predicateContext = predicateContext.get().parent();
+      }
+    }
+
+    Path path =
+        new ApplicantQuestion(targetQuestion, applicantData, predicateContext)
+            .getContextualizedPath();
+
+    if (path.isArrayElement() && targetQuestion.isEnumerator()) {
+      // In this case, we don't want the [] at the end of the path.
+      path = path.withoutArrayReference();
+    }
+
     return JsonPathPredicate.create(
         String.format(
             "%s[?(@.%s %s %s)]",
-            questionPath.predicateFormat(),
+            path.predicateFormat(),
             node.scalar().name().toLowerCase(),
             node.operator().toJsonPathOperator(),
             node.comparedValue().value()));

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateEvaluator.java
@@ -1,0 +1,49 @@
+package services.applicant.predicate;
+
+import services.applicant.ApplicantData;
+import services.applicant.exception.InvalidPredicateException;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.PredicateExpressionNode;
+
+/** Evaluates complex predicates based on the given {@link ApplicantData}. */
+public class PredicateEvaluator {
+
+  private final ApplicantData applicantData;
+  private final JsonPathPredicateGenerator predicateGenerator;
+
+  public PredicateEvaluator(
+      ApplicantData applicantData, JsonPathPredicateGenerator predicateGenerator) {
+    this.applicantData = applicantData;
+    this.predicateGenerator = predicateGenerator;
+  }
+
+  /**
+   * Evaluate an expression tree rooted at the given {@link PredicateExpressionNode}. Will return
+   * true if and only if the entire tree evaluates to true based on the {@link ApplicantData} used
+   * to create this evaluator.
+   */
+  public boolean evaluate(PredicateExpressionNode node) {
+    switch (node.getType()) {
+      case LEAF_OPERATION:
+        return evaluateLeafNode(node.getLeafNode());
+      case AND: // fallthrough intended
+      case OR: // fallthrough intended
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Returns true if and only if there exists a value in {@link ApplicantData} that satisfies the
+   * given leaf node operation. Returns false if the predicate is invalid or the predicate evaluates
+   * to false.
+   */
+  private boolean evaluateLeafNode(LeafOperationExpressionNode node) {
+    try {
+      JsonPathPredicate predicate = predicateGenerator.fromLeafNode(node);
+      return applicantData.evalPredicate(predicate);
+    } catch (InvalidPredicateException e) {
+      return false;
+    }
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -191,19 +191,19 @@ public abstract class ProgramDefinition {
         .collect(ImmutableList.toImmutableList());
   }
 
-  public Program toProgram() {
-    return new Program(this);
-  }
-
-  public abstract Builder toBuilder();
-
-  private Stream<QuestionDefinition> streamQuestionDefinitions() {
+  public Stream<QuestionDefinition> streamQuestionDefinitions() {
     return blockDefinitions().stream()
         .flatMap(
             b ->
                 b.programQuestionDefinitions().stream()
                     .map(ProgramQuestionDefinition::getQuestionDefinition));
   }
+
+  public Program toProgram() {
+    return new Program(this);
+  }
+
+  public abstract Builder toBuilder();
 
   @AutoValue.Builder
   public abstract static class Builder {

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateAction.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateAction.java
@@ -1,6 +1,8 @@
 package services.program.predicate;
 
 public enum PredicateAction {
+  /** If the predicate evaluates to true, hide the current block. */
   HIDE_BLOCK,
+  /** If the predicate evaluates to true, show the current block. */
   SHOW_BLOCK
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -1,39 +1,218 @@
 package services.applicant.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.junit.Before;
 import org.junit.Test;
 import services.Path;
 import services.applicant.ApplicantData;
+import services.applicant.RepeatedEntity;
+import services.applicant.exception.InvalidPredicateException;
+import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Scalar;
 import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.Operator;
 import services.program.predicate.PredicateValue;
+import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+import support.TestQuestionBank;
 
 public class JsonPathPredicateGeneratorTest {
 
-  private final JsonPathPredicateGenerator generator = new JsonPathPredicateGenerator();
+  private final TestQuestionBank questionBank = new TestQuestionBank(false);
+  private QuestionDefinition question;
+  private JsonPathPredicateGenerator generator;
 
-  @Test
-  public void fromLeafNode_generatesCorrectFormat() {
-    LeafOperationExpressionNode node =
-        LeafOperationExpressionNode.create(
-            1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Seattle"));
-
-    assertThat(generator.fromLeafNode(node, Path.create("applicant.address")))
-        .isEqualTo(JsonPathPredicate.create("$.applicant.address[?(@.city == \"Seattle\")]"));
+  @Before
+  public void setupGenerator() {
+    question = questionBank.applicantAddress().getQuestionDefinition();
+    generator =
+        new JsonPathPredicateGenerator(
+            new ApplicantData(), ImmutableList.of(question), Optional.empty());
   }
 
   @Test
-  public void fromLeafNode_canBeEvaluated() {
-    ApplicantData data = new ApplicantData();
-    data.putString(Path.create("applicant.address.city"), "Chicago");
+  public void fromLeafNode_nonRepeatedQuestion_generatesCorrectFormat() throws Exception {
     LeafOperationExpressionNode node =
         LeafOperationExpressionNode.create(
-            1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Chicago"));
+            question.getId(), Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Seattle"));
 
-    JsonPathPredicate predicate = generator.fromLeafNode(node, Path.create("applicant.address"));
+    assertThat(generator.fromLeafNode(node))
+        .isEqualTo(
+            JsonPathPredicate.create("$.applicant.applicant_address[?(@.city == \"Seattle\")]"));
+  }
+
+  @Test
+  public void fromLeafNode_canBeEvaluated() throws Exception {
+    ApplicantData data = new ApplicantData();
+    data.putString(Path.create("applicant.applicant_address.city"), "Chicago");
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            question.getId(), Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Chicago"));
+
+    JsonPathPredicate predicate = generator.fromLeafNode(node);
 
     assertThat(data.evalPredicate(predicate)).isTrue();
+  }
+
+  @Test
+  public void fromLeafNode_missingQuestion_throwsInvalidPredicateException() {
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(123L, Scalar.DATE, Operator.IN, PredicateValue.of(23));
+
+    assertThatThrownBy(() -> generator.fromLeafNode(node))
+        .isInstanceOf(InvalidPredicateException.class)
+        .hasMessageContaining(
+            "Tried to apply a predicate based on question 123, which is not found in this program");
+  }
+
+  @Test
+  public void fromLeafNode_predicateBasedOnParentEnumerator_generatesCorrectPath()
+      throws Exception {
+    ApplicantData applicantData = new ApplicantData();
+    EnumeratorQuestionDefinition enumerator =
+        (EnumeratorQuestionDefinition)
+            questionBank.applicantHouseholdMembers().getQuestionDefinition();
+    QuestionDefinition repeatedQuestion =
+        new QuestionDefinitionBuilder(
+                questionBank.applicantHouseholdMemberName().getQuestionDefinition())
+            .setEnumeratorId(Optional.of(enumerator.getId()))
+            .build();
+
+    // Put an entity at the enumerator path, so the entity is generated.
+    ApplicantQuestion applicantEnumerator =
+        new ApplicantQuestion(enumerator, applicantData, Optional.empty());
+    applicantData.putRepeatedEntities(
+        applicantEnumerator.getContextualizedPath(), ImmutableList.of("Xylia"));
+    System.out.println(applicantData.asJsonString());
+
+    ImmutableList<RepeatedEntity> repeatedEntities =
+        RepeatedEntity.createRepeatedEntities(enumerator, applicantData);
+    Optional<RepeatedEntity> repeatedEntity = repeatedEntities.stream().findFirst();
+
+    // The block repeated entity context is the one for the repeated name question.
+    generator =
+        new JsonPathPredicateGenerator(
+            applicantData, ImmutableList.of(enumerator, repeatedQuestion), repeatedEntity);
+
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            enumerator.getId(), // The predicate is based on the parent enumerator.
+            Scalar.FIRST_NAME,
+            Operator.EQUAL_TO,
+            PredicateValue.of("Xylia"));
+
+    // The top-level enumerator should not appear with [], since it is not repeated.
+    assertThat(generator.fromLeafNode(node))
+        .isEqualTo(
+            JsonPathPredicate.create(
+                "$.applicant.applicant_household_members[?(@.first_name == \"Xylia\")]"));
+  }
+
+  @Test
+  public void fromLeafNode_predicateBasedOnSiblingRepeatedQuestion_generatesCorrectPath()
+      throws Exception {
+    ApplicantData applicantData = new ApplicantData();
+    EnumeratorQuestionDefinition enumerator =
+        (EnumeratorQuestionDefinition)
+            questionBank.applicantHouseholdMembers().getQuestionDefinition();
+    QuestionDefinition siblingQuestion =
+        new QuestionDefinitionBuilder(
+                questionBank.applicantHouseholdMemberName().getQuestionDefinition())
+            .setEnumeratorId(Optional.of(enumerator.getId()))
+            .build();
+
+    // Put an entity at the enumerator path so we can generate repeated contexts.
+    ApplicantQuestion applicantEnumerator =
+        new ApplicantQuestion(enumerator, applicantData, Optional.empty());
+    applicantData.putRepeatedEntities(
+        applicantEnumerator.getContextualizedPath(), ImmutableList.of("Bernard", "Alice"));
+
+    // Just use a repeated entity for the first (index 0) entity.
+    ImmutableList<RepeatedEntity> repeatedEntities =
+        RepeatedEntity.createRepeatedEntities(enumerator, applicantData);
+    Optional<RepeatedEntity> repeatedEntity = repeatedEntities.stream().findFirst();
+
+    generator =
+        new JsonPathPredicateGenerator(
+            applicantData, ImmutableList.of(enumerator, siblingQuestion), repeatedEntity);
+
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            siblingQuestion.getId(), // The predicate is based on the sibling "name" question.
+            Scalar.FIRST_NAME,
+            Operator.EQUAL_TO,
+            PredicateValue.of("Bernard"));
+
+    assertThat(generator.fromLeafNode(node))
+        .isEqualTo(
+            JsonPathPredicate.create(
+                "$.applicant.applicant_household_members[0].household_members_name"
+                    + "[?(@.first_name == \"Bernard\")]"));
+  }
+
+  @Test
+  public void fromLeafNode_twoLevelsDeepRepeater_generatesCorrectPath() throws Exception {
+    ApplicantData applicantData = new ApplicantData();
+    // household members
+    //  \_ name (target), jobs
+    //                      \_ income (current block)
+    QuestionDefinition topLevelEnumerator =
+        questionBank.applicantHouseholdMembers().getQuestionDefinition();
+    QuestionDefinition targetQuestion =
+        questionBank.applicantHouseholdMemberName().getQuestionDefinition();
+    QuestionDefinition nestedEnumerator =
+        questionBank.applicantHouseholdMemberJobs().getQuestionDefinition();
+    QuestionDefinition currentQuestion =
+        questionBank.applicantHouseholdMemberJobIncome().getQuestionDefinition();
+
+    // Put an entity at the enumerator path so we can generate repeated contexts.
+    ApplicantQuestion applicantEnumerator =
+        new ApplicantQuestion(topLevelEnumerator, applicantData, Optional.empty());
+    applicantData.putRepeatedEntities(
+        applicantEnumerator.getContextualizedPath(), ImmutableList.of("Bernard", "Alice"));
+    // Context for index 1 ('Alice')
+    Optional<RepeatedEntity> topLevelRepeatedEntity =
+        RepeatedEntity.createRepeatedEntities(
+                (EnumeratorQuestionDefinition) topLevelEnumerator, applicantData)
+            .reverse()
+            .stream()
+            .findFirst();
+
+    // Create entities for the nested enumerator
+    ApplicantQuestion nestedApplicantEnumerator =
+        new ApplicantQuestion(nestedEnumerator, applicantData, topLevelRepeatedEntity);
+    applicantData.putRepeatedEntities(
+        nestedApplicantEnumerator.getContextualizedPath(), ImmutableList.of("Software Engineer"));
+    Optional<RepeatedEntity> currentContext =
+        topLevelRepeatedEntity
+            .get()
+            .createNestedRepeatedEntities(
+                (EnumeratorQuestionDefinition) nestedEnumerator, applicantData)
+            .stream()
+            .findFirst();
+
+    generator =
+        new JsonPathPredicateGenerator(
+            applicantData,
+            ImmutableList.of(topLevelEnumerator, nestedEnumerator, targetQuestion, currentQuestion),
+            currentContext);
+
+    LeafOperationExpressionNode node =
+        LeafOperationExpressionNode.create(
+            targetQuestion.getId(), // The predicate is based on the "name" question.
+            Scalar.FIRST_NAME,
+            Operator.EQUAL_TO,
+            PredicateValue.of("Alice"));
+
+    assertThat(generator.fromLeafNode(node))
+        .isEqualTo(
+            JsonPathPredicate.create(
+                "$.applicant.applicant_household_members[1].household_members_name"
+                    + "[?(@.first_name == \"Alice\")]"));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/predicate/PredicateEvaluatorTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/predicate/PredicateEvaluatorTest.java
@@ -1,0 +1,73 @@
+package services.applicant.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import services.applicant.ApplicantData;
+import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.Scalar;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.Operator;
+import services.program.predicate.PredicateExpressionNode;
+import services.program.predicate.PredicateValue;
+import services.question.types.QuestionDefinition;
+import support.TestQuestionBank;
+
+public class PredicateEvaluatorTest {
+
+  private final TestQuestionBank questionBank = new TestQuestionBank(false);
+  private final QuestionDefinition addressQuestion =
+      questionBank.applicantAddress().getQuestionDefinition();
+
+  private ApplicantData applicantData;
+  private ApplicantQuestion applicantQuestion;
+  private JsonPathPredicateGenerator generator;
+  private PredicateEvaluator evaluator;
+
+  @Before
+  public void setupEvaluator() {
+    applicantData = new ApplicantData();
+    applicantQuestion = new ApplicantQuestion(addressQuestion, applicantData, Optional.empty());
+    generator =
+        new JsonPathPredicateGenerator(
+            applicantData, ImmutableList.of(addressQuestion), Optional.empty());
+    evaluator = new PredicateEvaluator(applicantData, generator);
+  }
+
+  @Test
+  public void evalLeafNode_correctlyEvaluatesValidPredicate() {
+    LeafOperationExpressionNode leafNode =
+        LeafOperationExpressionNode.create(
+            addressQuestion.getId(),
+            Scalar.STREET,
+            Operator.EQUAL_TO,
+            PredicateValue.of("123 Rhode St."));
+    PredicateExpressionNode node = PredicateExpressionNode.create(leafNode);
+
+    applicantData.putString(
+        applicantQuestion.createAddressQuestion().getStreetPath(), "123 Rhode St.");
+    assertThat(evaluator.evaluate(node)).isTrue();
+
+    applicantData.putString(applicantQuestion.createAddressQuestion().getStreetPath(), "different");
+    assertThat(evaluator.evaluate(node)).isFalse();
+  }
+
+  @Test
+  public void evalLeafNode_returnsFalseForInvalidPredicate() {
+    LeafOperationExpressionNode leafNode =
+        LeafOperationExpressionNode.create(
+            addressQuestion.getId() + 1, // Invalid question ID
+            Scalar.STREET,
+            Operator.EQUAL_TO,
+            PredicateValue.of("123 Rhode St."));
+    PredicateExpressionNode node = PredicateExpressionNode.create(leafNode);
+
+    applicantData.putString(
+        applicantQuestion.createAddressQuestion().getStreetPath(), "123 Rhode St.");
+
+    assertThat(evaluator.evaluate(node)).isFalse();
+  }
+}


### PR DESCRIPTION
### Description
1. (Minor cleanup): Moves `summaryData` method to be next to the other overridden methods in the file
2. Adds a `showBlock` method that determines whether to show a block based on evaluating its predicate
2. This method is `protected` for now (for unit testing), but will change to `private` once it is used to determine lists of blocks for a given applicant

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1001
