### PR TITLE
Implement AND and OR nodes on the backend

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateEvaluator.java
@@ -51,10 +51,12 @@ public class PredicateEvaluator {
     }
   }
 
+  /** Returns true if and only if each of the node's children evaluates to true. */
   private boolean evaluateAndNode(AndNode node) {
     return node.children().stream().allMatch(this::evaluate);
   }
 
+  /** Returns true if and only if one or more of the node's children evaluates to true. */
   private boolean evaluateOrNode(OrNode node) {
     return node.children().stream().anyMatch(this::evaluate);
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/predicate/PredicateEvaluator.java
@@ -2,7 +2,9 @@ package services.applicant.predicate;
 
 import services.applicant.ApplicantData;
 import services.applicant.exception.InvalidPredicateException;
+import services.program.predicate.AndNode;
 import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.OrNode;
 import services.program.predicate.PredicateExpressionNode;
 
 /** Evaluates complex predicates based on the given {@link ApplicantData}. */
@@ -26,8 +28,10 @@ public class PredicateEvaluator {
     switch (node.getType()) {
       case LEAF_OPERATION:
         return evaluateLeafNode(node.getLeafNode());
-      case AND: // fallthrough intended
-      case OR: // fallthrough intended
+      case AND:
+        return evaluateAndNode(node.getAndNode());
+      case OR:
+        return evaluateOrNode(node.getOrNode());
       default:
         return false;
     }
@@ -45,5 +49,13 @@ public class PredicateEvaluator {
     } catch (InvalidPredicateException e) {
       return false;
     }
+  }
+
+  private boolean evaluateAndNode(AndNode node) {
+    return node.children().stream().allMatch(this::evaluate);
+  }
+
+  private boolean evaluateOrNode(OrNode node) {
+    return node.children().stream().anyMatch(this::evaluate);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
@@ -7,6 +7,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
+/**
+ * Represents the boolean operator AND. Each of the child predicates must evaluate to true for the
+ * entire AND node to be considered true.
+ */
 @JsonTypeName("and")
 @AutoValue
 public abstract class AndNode implements ConcretePredicateExpressionNode {

--- a/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
@@ -1,0 +1,28 @@
+package services.program.predicate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+@JsonTypeName("and")
+@AutoValue
+public abstract class AndNode implements ConcretePredicateExpressionNode {
+
+  @JsonCreator
+  public static AndNode create(
+      @JsonProperty("children") ImmutableSet<PredicateExpressionNode> children) {
+    return new AutoValue_AndNode(children);
+  }
+
+  @JsonProperty("children")
+  public abstract ImmutableSet<PredicateExpressionNode> children();
+
+  @Override
+  @JsonIgnore
+  public PredicateExpressionNodeType getType() {
+    return PredicateExpressionNodeType.AND;
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
@@ -1,0 +1,25 @@
+package services.program.predicate;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+@AutoValue
+public abstract class OrNode implements ConcretePredicateExpressionNode {
+
+  @JsonIgnore
+  public static OrNode create(
+      @JsonProperty("children") ImmutableSet<PredicateExpressionNode> children) {
+    return new AutoValue_OrNode(children);
+  }
+
+  @JsonProperty("children")
+  public abstract ImmutableSet<PredicateExpressionNode> children();
+
+  @Override
+  @JsonIgnore
+  public PredicateExpressionNodeType getType() {
+    return PredicateExpressionNodeType.OR;
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
@@ -2,9 +2,15 @@ package services.program.predicate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
+/**
+ * Represents the boolean operator OR. At least one of the child predicates must evaluate to true
+ * for the entire OR tree to be considered true.
+ */
+@JsonTypeName("or")
 @AutoValue
 public abstract class OrNode implements ConcretePredicateExpressionNode {
 

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
@@ -31,8 +31,30 @@ public abstract class PredicateExpressionNode {
   public LeafOperationExpressionNode getLeafNode() {
     if (!(node() instanceof LeafOperationExpressionNode)) {
       throw new RuntimeException(
-          String.format("Expected a leaf node but received %s node", getType()));
+          String.format("Expected a LEAF node but received %s node", getType()));
     }
     return (LeafOperationExpressionNode) node();
+  }
+
+  /** Get an and node if it exists, or throw if this is not an and node. */
+  @JsonIgnore
+  @Memoized
+  public AndNode getAndNode() {
+    if (!(node() instanceof AndNode)) {
+      throw new RuntimeException(
+          String.format("Expected an AND node but received %s node", getType()));
+    }
+    return (AndNode) node();
+  }
+
+  /** Get an or node if it exists, or throw if this is not an or node. */
+  @JsonIgnore
+  @Memoized
+  public OrNode getOrNode() {
+    if (!(node() instanceof OrNode)) {
+      throw new RuntimeException(
+          String.format("Expected an OR node but received %s node", getType()));
+    }
+    return (OrNode) node();
   }
 }


### PR DESCRIPTION
### Description
1. Adds `AndNode` and `OrNode` definitions
2. Implements evaluation logic in `PredicateEvaluator`

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1001 
