### PR TITLE
Fake code used for tests was accidentally being called from prod.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java
+++ b/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java
@@ -50,7 +50,7 @@ public class FakeAdminClient extends IndirectClient {
           if (adminType.get().equals(GLOBAL_ADMIN)) {
             cred.setUserProfile(profileFactory.createNewAdmin());
           } else if (adminType.get().equals(PROGRAM_ADMIN)) {
-            cred.setUserProfile(profileFactory.createNewProgramAdmin());
+            cred.setUserProfile(profileFactory.createFakeProgramAdmin());
           } else {
             throw new IllegalArgumentException(
                 String.format("admin type %s not recognized", adminType.get()));

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -70,8 +70,8 @@ public class ProfileFactory {
   }
 
   /**
-   * This creates a program admin who is automatically the admin of all programs currently live, with
-   * a fake email address.
+   * This creates a program admin who is automatically the admin of all programs currently live,
+   * with a fake email address.
    */
   public UatProfileData createFakeProgramAdmin() {
     UatProfileData p = create(Roles.ROLE_PROGRAM_ADMIN);

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -66,6 +66,14 @@ public class ProfileFactory {
   }
 
   public UatProfileData createNewProgramAdmin() {
+    return create(Roles.ROLE_PROGRAM_ADMIN);
+  }
+
+  /**
+   * This creates a program admin who is automatically the admin of all programs currently live, with
+   * a fake email address.
+   */
+  public UatProfileData createFakeProgramAdmin() {
     UatProfileData p = create(Roles.ROLE_PROGRAM_ADMIN);
     wrapProfileData(p)
         .getAccount()


### PR DESCRIPTION
### Description
This makes a new admin properly rather than using the test path.

This was preventing any new (blank) non-global admins from signing in.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary