### PR TITLE
Hide PDF buttons.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
@@ -158,6 +158,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
   }
 
   private Tag renderDownloadLink(String text, long programId, long applicationId) {
+    // This link doesn't work since we don't have PDF filling yet.  Disable.
     String downloadLink =
         controllers.admin.routes.AdminApplicationController.download(programId, applicationId)
             .url();
@@ -167,7 +168,9 @@ public final class ProgramApplicationListView extends BaseHtmlView {
         .setHref(downloadLink)
         .setText(text)
         .setStyles(Styles.MR_2, ReferenceClasses.DOWNLOAD_BUTTON)
-        .asAnchorText();
+        .asAnchorText()
+        // TODO: when the download link works, un-hide.
+        .isHidden();
   }
 
   private Tag renderViewLink(String text, long programId, long applicationId) {

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationView.java
@@ -74,7 +74,9 @@ public final class ProgramApplicationView extends BaseHtmlView {
         .setId("download-button")
         .setHref(link)
         .setText("Download (PDF)")
-        .asButton();
+        .asButton()
+        // TODO: when the download link works, un-hide.
+        .isHidden();
   }
 
   private Tag renderApplicationBlock(Block block, Collection<AnswerData> answers) {


### PR DESCRIPTION
### Description
I looked through and the only controller methods raising UnsupportedOperationException is the PDF download one and the profile page one, and we never link to the profile page.  Just stick a hidden tag on these to make them easy to put back if the time comes.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1106.