### PR TITLE
Deflake program admin browser test

### DIFF
--- a/browser-test/src/admin_program_admins.test.ts
+++ b/browser-test/src/admin_program_admins.test.ts
@@ -24,7 +24,7 @@ describe('manage program admins', () => {
 
     // Assert that the two emails we added are present.
     // Use input:visible to get the first visible input, since the template is hidden.
-    expect(await page.getAttribute('input:visible', 'value')).toContain('test@test.com');
+    expect(await page.getAttribute('#program-admin-emails input:visible', 'value')).toContain('test@test.com');
     expect(await page.getAttribute('input:above(#add-program-admin-button)', 'value')).toContain('other@test.com');
 
     // Add another program admin
@@ -44,7 +44,7 @@ describe('manage program admins', () => {
 
     // Go back and check that there are exactly two - test and new.
     await adminPrograms.gotoManageProgramAdminsPage(programName);
-    expect(await page.getAttribute('input:visible', 'value')).toContain('test@test.com');
+    expect(await page.getAttribute('#program-admin-emails input:visible', 'value')).toContain('test@test.com');
     expect(await page.getAttribute('input:above(#add-program-admin-button)', 'value')).toContain('new@test.com');
 
     await endSession(browser);


### PR DESCRIPTION
### Description
My current theory is that the selector is too generic that when the page loads, before styles are applied (we've seen this happened elsewhere), the selector selects the hidden template (wrong element) and thus fails the assertion. Using a more specific selector appears to work. Tested in staging with 10 successful runs.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
