### PR TITLE
Deflake browser tests take 2

### DIFF
--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -3,8 +3,8 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "jest --testTimeout=120000 --forceExit --maxConcurrency=1 --runInBand",
-    "probe": "jest --testTimeout=120000 --forceExit --maxConcurrency=1 --runInBand"
+    "test": "jest --testTimeout=180000 --forceExit --maxConcurrency=1 --runInBand",
+    "probe": "jest --testTimeout=180000 --forceExit --maxConcurrency=1 --runInBand"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -26,11 +26,11 @@ describe('create dropdown question with options', () => {
 
     // Add three options
     await page.click('#add-new-option');
-    await page.fill('input:above(#add-new-option)', 'chocolate');
+    await page.fill('#question-settings div.flex-row:last-of-type input', 'chocolate');
     await page.click('#add-new-option');
-    await page.fill('input:above(#add-new-option)', 'vanilla');
+    await page.fill('#question-settings div.flex-row:last-of-type input', 'vanilla');
     await page.click('#add-new-option');
-    await page.fill('input:above(#add-new-option)', 'strawberry');
+    await page.fill('#question-settings div.flex-row:last-of-type input', 'strawberry');
 
     // Assert there are three options present
     var questionSettingsDiv = await page.innerHTML('#question-settings');

--- a/browser-test/src/admin_program_admins.test.ts
+++ b/browser-test/src/admin_program_admins.test.ts
@@ -13,9 +13,10 @@ describe('manage program admins', () => {
     // Add two program admins and save
     await adminPrograms.gotoManageProgramAdminsPage(programName);
     await page.click('#add-program-admin-button');
-    await page.fill('input:above(#add-program-admin-button)', 'test@test.com');
+    var lastProgramAdminEmailInput = '#program-admin-emails div.flex-row:last-of-type input';
+    await page.fill(lastProgramAdminEmailInput, 'test@test.com');
     await page.click('#add-program-admin-button');
-    await page.fill('input:above(#add-program-admin-button)', 'other@test.com');
+    await page.fill(lastProgramAdminEmailInput, 'other@test.com');
     await page.click('text=Save');
 
     // Go to manage program admins again
@@ -24,28 +25,30 @@ describe('manage program admins', () => {
 
     // Assert that the two emails we added are present.
     // Use input:visible to get the first visible input, since the template is hidden.
-    expect(await page.getAttribute('#program-admin-emails input:visible', 'value')).toContain('test@test.com');
-    expect(await page.getAttribute('input:above(#add-program-admin-button)', 'value')).toContain('other@test.com');
+    var firstProgramAdminEmailInput = '#program-admin-emails div.flex-row:first-of-type input';
+    expect(await page.getAttribute(firstProgramAdminEmailInput, 'value')).toContain('test@test.com');
+    expect(await page.getAttribute(lastProgramAdminEmailInput, 'value')).toContain('other@test.com');
 
     // Add another program admin
     await page.click('#add-program-admin-button');
-    await page.fill('input:above(#add-program-admin-button)', 'newperson@test.com');
+    await page.fill(lastProgramAdminEmailInput, 'newperson@test.com');
 
     // Remove the one we just added
-    await page.click('button:above(#add-program-admin-button)');
+    var removeLastProgramAdminEmailButton = '#program-admin-emails div.flex-row:last-of-type button';
+    await page.click(removeLastProgramAdminEmailButton);
     const visibleInputs = await page.$$('input:visible');
     expect(visibleInputs.length).toBe(2);
 
     // Remove an old one and add a new one, then submit.
-    await page.click('button:above(#add-program-admin-button)'); // Remove
+    await page.click(removeLastProgramAdminEmailButton);
     await page.click('#add-program-admin-button');
-    await page.fill('input:above(#add-program-admin-button)', 'new@test.com');
+    await page.fill(lastProgramAdminEmailInput, 'new@test.com');
     await page.click('text=Save');
 
     // Go back and check that there are exactly two - test and new.
     await adminPrograms.gotoManageProgramAdminsPage(programName);
-    expect(await page.getAttribute('#program-admin-emails input:visible', 'value')).toContain('test@test.com');
-    expect(await page.getAttribute('input:above(#add-program-admin-button)', 'value')).toContain('new@test.com');
+    expect(await page.getAttribute(firstProgramAdminEmailInput, 'value')).toContain('test@test.com');
+    expect(await page.getAttribute(lastProgramAdminEmailInput, 'value')).toContain('new@test.com');
 
     await endSession(browser);
   });

--- a/browser-test/src/admin_program_admins.test.ts
+++ b/browser-test/src/admin_program_admins.test.ts
@@ -24,7 +24,6 @@ describe('manage program admins', () => {
     await adminPrograms.gotoManageProgramAdminsPage(programName);
 
     // Assert that the two emails we added are present.
-    // Use input:visible to get the first visible input, since the template is hidden.
     var firstProgramAdminEmailInput = '#program-admin-emails div.flex-row:first-of-type input';
     expect(await page.getAttribute(firstProgramAdminEmailInput, 'value')).toContain('test@test.com');
     expect(await page.getAttribute(lastProgramAdminEmailInput, 'value')).toContain('other@test.com');
@@ -36,8 +35,8 @@ describe('manage program admins', () => {
     // Remove the one we just added
     var removeLastProgramAdminEmailButton = '#program-admin-emails div.flex-row:last-of-type button';
     await page.click(removeLastProgramAdminEmailButton);
-    const visibleInputs = await page.$$('input:visible');
-    expect(visibleInputs.length).toBe(2);
+    const programAdminEmailInputs = await page.$$('#program-admin-emails input');
+    expect(programAdminEmailInputs.length).toBe(2);
 
     // Remove an old one and add a new one, then submit.
     await page.click(removeLastProgramAdminEmailButton);

--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -8,7 +8,7 @@ describe('normal application flow', () => {
     // want to verify that your selectors are working as expected first.
     // Because all tests are run concurrently, it could be that your selector
     // selects a different entity from another test.
-    page.setDefaultTimeout(2000);
+    page.setDefaultTimeout(4000);
 
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page);

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -71,9 +71,9 @@ describe('normal application flow', () => {
 
     // Fix the address and name questions and submit.
     await applicantQuestions.answerNameQuestion('Queen', 'Hearts', 'of');
-    await applicantQuestions.answerAddressQuestion('1234 St', 'Unit B', 'Sim', 'Ames', '54321');    
+    await applicantQuestions.answerAddressQuestion('1234 St', 'Unit B', 'Sim', 'Ames', '54321');
     await applicantQuestions.clickNext();
-    
+
     // Applicant fills out second application block.
     await applicantQuestions.answerDropdownQuestion('banana');
     await applicantQuestions.answerCheckboxQuestion(['cherry', 'pine']);

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -111,7 +111,7 @@ describe('End to end enumerator test', () => {
 
     // Remove one of the 'Banker' entries and add 'Painter'.
     // the value attribute of the inputs isn't set, so we're clicking the second one.
-    await page.click(':nth-match(:text("Remove Entity"), 2)');    
+    await page.click(':nth-match(:text("Remove Entity"), 2)');
     await applicantQuestions.addEnumeratorAnswer("Painter");
     await applicantQuestions.clickNext();
 

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -34,7 +34,7 @@ export class AdminPrograms {
     await this.page.fill('#program-display-name-input', programName);
     await this.page.fill('#program-display-description-textarea', description);
 
-    await this.page.click('text=Save');
+    await this.page.click('#program-update-button');
 
     await this.expectAdminProgramsPage();
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -24,10 +24,10 @@ export class AdminQuestions {
     helpText: string,
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     // This function should only be called on question create/edit page.
-    await this.page.fill('text="Name"', questionName);
-    await this.page.fill('text=Description', description);
-    await this.page.fill('text=Question Text', questionText);
-    await this.page.fill('text=Question help text', helpText);
+    await this.page.fill('label:has-text("Name")', questionName);
+    await this.page.fill('label:has-text("Description")', description);
+    await this.page.fill('label:has-text("Question Text")', questionText);
+    await this.page.fill('label:has-text("Question help text")', helpText);
     await this.page.selectOption('#question-enumerator-select', { label: enumeratorName });
   }
 
@@ -176,7 +176,7 @@ export class AdminQuestions {
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -195,7 +195,7 @@ export class AdminQuestions {
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -220,7 +220,7 @@ export class AdminQuestions {
       await this.page.fill('input:above(#add-new-option)', options[index]);
     }
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -245,7 +245,7 @@ export class AdminQuestions {
       await this.page.fill('input:above(#add-new-option)', options[index]);
     }
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -264,7 +264,7 @@ export class AdminQuestions {
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -283,7 +283,7 @@ export class AdminQuestions {
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -302,7 +302,7 @@ export class AdminQuestions {
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -327,7 +327,7 @@ export class AdminQuestions {
       await this.page.fill('input:above(#add-new-option)', options[index])
     }
 
-    await this.page.click('text=Create')
+    await this.page.click('button:has-text("Create")')
 
     await this.expectAdminQuestionsPage();
 
@@ -346,7 +346,7 @@ export class AdminQuestions {
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 
@@ -354,23 +354,23 @@ export class AdminQuestions {
   }
 
   async addEmailQuestion(questionName: string,
-      description = 'email description',
-      questionText = 'email question text',
-      helpText = 'email question help text',
-      enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
-      await this.gotoAdminQuestionsPage();
-      await this.page.click('#create-question-button');
+    description = 'email description',
+    questionText = 'email question text',
+    helpText = 'email question help text',
+    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
+    await this.gotoAdminQuestionsPage();
+    await this.page.click('#create-question-button');
 
-      await this.page.click('#create-email-question');
+    await this.page.click('#create-email-question');
 
-      await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
+    await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
-      await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
-      await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPage();
 
-      await this.expectDraftQuestionExist(questionName, questionText);
-    }
+    await this.expectDraftQuestionExist(questionName, questionText);
+  }
 
   /**
    * The `enumeratorName` argument is used to make _this_ enumerator question a repeated question.
@@ -389,7 +389,7 @@ export class AdminQuestions {
 
     await this.page.fill('text=Repeated Entity Type', 'Entity');
 
-    await this.page.click('text=Create');
+    await this.page.click('button:has-text("Create")');
 
     await this.expectAdminQuestionsPage();
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -217,7 +217,8 @@ export class AdminQuestions {
 
     for (var index in options) {
       await this.page.click('#add-new-option');
-      await this.page.fill('input:above(#add-new-option)', options[index]);
+      var matchIndex = Number(index) + 1;
+      await this.page.fill(`:nth-match(#question-settings div.flex-row, ${matchIndex}) input`, options[index]);
     }
 
     await this.page.click('button:has-text("Create")');
@@ -242,7 +243,8 @@ export class AdminQuestions {
 
     for (var index in options) {
       await this.page.click('#add-new-option');
-      await this.page.fill('input:above(#add-new-option)', options[index]);
+      var matchIndex = Number(index) + 1;
+      await this.page.fill(`:nth-match(#question-settings div.flex-row, ${matchIndex}) input`, options[index]);
     }
 
     await this.page.click('button:has-text("Create")');
@@ -324,7 +326,8 @@ export class AdminQuestions {
 
     for (var index in options) {
       await this.page.click('#add-new-option')
-      await this.page.fill('input:above(#add-new-option)', options[index])
+      var matchIndex = Number(index) + 1;
+      await this.page.fill(`:nth-match(#question-settings div.flex-row, ${matchIndex}) input`, options[index]);
     }
 
     await this.page.click('button:has-text("Create")')

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -170,6 +170,8 @@ export class AdminQuestions {
     helpText = 'address question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-address-question');
@@ -189,6 +191,8 @@ export class AdminQuestions {
     helpText = 'date question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-date-question');
@@ -209,6 +213,8 @@ export class AdminQuestions {
     helpText = 'checkbox question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-checkbox-question');
@@ -235,6 +241,8 @@ export class AdminQuestions {
     helpText = 'dropdown question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-dropdown-question');
@@ -260,6 +268,8 @@ export class AdminQuestions {
     helpText = 'fileupload question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-fileupload-question');
@@ -279,6 +289,8 @@ export class AdminQuestions {
     helpText = 'name question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-name-question');
@@ -298,6 +310,8 @@ export class AdminQuestions {
     helpText = 'number question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-number-question');
@@ -318,6 +332,8 @@ export class AdminQuestions {
     helpText = 'radio button question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-radio_button-question');
@@ -343,6 +359,8 @@ export class AdminQuestions {
     helpText = 'text question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-text-question');
@@ -362,6 +380,8 @@ export class AdminQuestions {
     helpText = 'email question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-email-question');
@@ -384,6 +404,8 @@ export class AdminQuestions {
     helpText = 'enumerator question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
     await this.page.click('#create-question-button');
 
     await this.page.click('#create-enumerator-question');

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -56,12 +56,12 @@ export class ApplicantQuestions {
   }
 
   async answerEmailQuestion(email: string) {
-      await this.page.fill('input[type="email"]', email);
-    }
+    await this.page.fill('input[type="email"]', email);
+  }
 
   async addEnumeratorAnswer(entityName: string) {
     await this.page.click('button:text("add entity")');
-    await this.page.fill('input:above(#enumerator-field-add-button)', entityName)
+    await this.page.fill('#enumerator-fields .cf-enumerator-field:last-of-type input', entityName)
   }
 
   async applyProgram(programName: string) {

--- a/browser-test/src/ti_group.test.ts
+++ b/browser-test/src/ti_group.test.ts
@@ -3,7 +3,7 @@ import { startSession, loginAsAdmin, endSession, AdminTIGroups } from './support
 describe('normal application flow', () => {
   it('all major steps', async () => {
     const { browser, page } = await startSession()
-    page.setDefaultTimeout(2000);
+    page.setDefaultTimeout(4000);
 
     await loginAsAdmin(page);
     const adminGroups = new AdminTIGroups(page);


### PR DESCRIPTION
### Description
It is really hard to tell why our browser tests are flakey. A few things I noticed are listed below.
- `:above` seems to be unstable and could select wrong elements so I went and changed all usage of it to more specific selectors. 
- I also increased the timeout since `question_lifecycle.test.ts` is so large that it frequently times out on my machine locally.
- `:visible` also seems to be unstable so I replace it in one place to increase stability.
- Make sure when we are on admin question page to create a new question, we wait until the page is fully loaded and the javascript dropdown event listener is attached. This breaks sometimes as you can see in one of the failed test in this PR.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
