### PR TITLE
Make Bug Report issues use the `bug` label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---


### PR DESCRIPTION
This makes bugs reported by community members easier to find and identify.

### Description
Community members will be encouraged to report bugs even past June 2021. They'll be directed to use the "Bug Report" Issue template. This PR simply has gives issues made with that template the `bug` label so they're easier to find and search for later.

