### PR TITLE
Update predicate question references when publishing

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/VersionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/VersionRepository.java
@@ -251,7 +251,8 @@ public class VersionRepository {
     return updatedBlock.build();
   }
 
-  // Update the referenced question IDs in all leaf nodes.
+  // Update the referenced question IDs in all leaf nodes. Since nodes are immutable, we
+  // recursively recreate the tree with updated leaf nodes.
   @VisibleForTesting
   protected PredicateExpressionNode updatePredicateNode(PredicateExpressionNode current) {
     switch (current.getType()) {
@@ -269,7 +270,7 @@ public class VersionRepository {
         LeafOperationExpressionNode leaf = current.getLeafNode();
         Optional<Question> updated = getLatestVersionOfQuestion(leaf.questionId());
         return PredicateExpressionNode.create(
-            leaf.toBuilder().questionId(updated.orElseThrow().id).build());
+            leaf.toBuilder().setQuestionId(updated.orElseThrow().id).build());
       default:
         return current;
     }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -23,10 +23,10 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
       @JsonProperty("operator") Operator operator,
       @JsonProperty("value") PredicateValue comparedValue) {
     return builder()
-        .questionId(questionId)
-        .scalar(scalar)
-        .operator(operator)
-        .comparedValue(comparedValue)
+        .setQuestionId(questionId)
+        .setScalar(scalar)
+        .setOperator(operator)
+        .setComparedValue(comparedValue)
         .build();
   }
 
@@ -62,13 +62,13 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder questionId(long questionId);
+    public abstract Builder setQuestionId(long questionId);
 
-    public abstract Builder scalar(Scalar scalar);
+    public abstract Builder setScalar(Scalar scalar);
 
-    public abstract Builder operator(Operator operator);
+    public abstract Builder setOperator(Operator operator);
 
-    public abstract Builder comparedValue(PredicateValue comparedValue);
+    public abstract Builder setComparedValue(PredicateValue comparedValue);
 
     public abstract LeafOperationExpressionNode build();
   }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -22,7 +22,12 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
       @JsonProperty("scalar") Scalar scalar,
       @JsonProperty("operator") Operator operator,
       @JsonProperty("value") PredicateValue comparedValue) {
-    return new AutoValue_LeafOperationExpressionNode(questionId, scalar, operator, comparedValue);
+    return builder()
+        .questionId(questionId)
+        .scalar(scalar)
+        .operator(operator)
+        .comparedValue(comparedValue)
+        .build();
   }
 
   /**
@@ -47,5 +52,24 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   @JsonIgnore
   public PredicateExpressionNodeType getType() {
     return PredicateExpressionNodeType.LEAF_OPERATION;
+  }
+
+  public static Builder builder() {
+    return new AutoValue_LeafOperationExpressionNode.Builder();
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder questionId(long questionId);
+
+    public abstract Builder scalar(Scalar scalar);
+
+    public abstract Builder operator(Operator operator);
+
+    public abstract Builder comparedValue(PredicateValue comparedValue);
+
+    public abstract LeafOperationExpressionNode build();
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
@@ -2,12 +2,22 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
 import io.ebean.Transaction;
 import models.LifecycleStage;
+import models.Question;
 import models.Version;
 import org.junit.Before;
 import org.junit.Test;
+import services.applicant.question.Scalar;
+import services.program.predicate.AndNode;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.Operator;
+import services.program.predicate.OrNode;
+import services.program.predicate.PredicateExpressionNode;
+import services.program.predicate.PredicateExpressionNodeType;
+import services.program.predicate.PredicateValue;
 
 public class VersionRepositoryTest extends WithPostgresContainer {
   private VersionRepository versionRepository;
@@ -19,9 +29,9 @@ public class VersionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void testPublish() {
-    this.resourceCreator.insertActiveProgram("foo");
-    this.resourceCreator.insertActiveProgram("bar");
-    this.resourceCreator.insertDraftProgram("bar");
+    resourceCreator.insertActiveProgram("foo");
+    resourceCreator.insertActiveProgram("bar");
+    resourceCreator.insertDraftProgram("bar");
     assertThat(this.versionRepository.getActiveVersion().getPrograms()).hasSize(2);
     assertThat(this.versionRepository.getDraftVersion().getPrograms()).hasSize(1);
     Version oldDraft = this.versionRepository.getDraftVersion();
@@ -34,8 +44,8 @@ public class VersionRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void testSetLive() {
-    this.resourceCreator.insertActiveProgram("foo");
-    this.resourceCreator.insertDraftProgram("bar");
+    resourceCreator.insertActiveProgram("foo");
+    resourceCreator.insertDraftProgram("bar");
     Version oldDraft = this.versionRepository.getDraftVersion();
     Version oldActive = this.versionRepository.getActiveVersion();
     this.versionRepository.publishNewSynchronizedVersion();
@@ -72,5 +82,72 @@ public class VersionRepositoryTest extends WithPostgresContainer {
     outer.rollback();
     assertThat(outer.isActive()).isFalse();
     assertThat(draft).isEqualTo(draft2);
+  }
+
+  @Test
+  public void updatePredicateNode() {
+    Version draft = versionRepository.getDraftVersion();
+    Version active = versionRepository.getActiveVersion();
+
+    // Old versions of questions
+    Question oldOne = resourceCreator.insertQuestion("one");
+    oldOne.addVersion(active);
+    oldOne.save();
+    Question oldTwo = resourceCreator.insertQuestion("two");
+    oldTwo.addVersion(active);
+    oldTwo.save();
+
+    // New versions of questions
+    Question newOne = resourceCreator.insertQuestion("one");
+    newOne.addVersion(draft);
+    newOne.save();
+    Question newTwo = resourceCreator.insertQuestion("two");
+    newTwo.addVersion(draft);
+    newTwo.save();
+
+    // Build a predicate tree that covers all node types:
+    //        AND
+    //      /     \
+    //   LEAF1    OR
+    //          /    \
+    //       LEAF2   LEAF3
+    PredicateExpressionNode leafOne =
+        PredicateExpressionNode.create(
+            LeafOperationExpressionNode.create(
+                oldOne.id, Scalar.TEXT, Operator.EQUAL_TO, PredicateValue.of("")));
+    PredicateExpressionNode leafTwo =
+        PredicateExpressionNode.create(
+            LeafOperationExpressionNode.create(
+                oldTwo.id, Scalar.TEXT, Operator.EQUAL_TO, PredicateValue.of("")));
+    PredicateExpressionNode leafThree =
+        PredicateExpressionNode.create(
+            LeafOperationExpressionNode.create(
+                oldOne.id, Scalar.NUMBER, Operator.LESS_THAN, PredicateValue.of(12)));
+    PredicateExpressionNode or =
+        PredicateExpressionNode.create(OrNode.create(ImmutableSet.of(leafTwo, leafThree)));
+    PredicateExpressionNode and =
+        PredicateExpressionNode.create(AndNode.create(ImmutableSet.of(leafOne, or)));
+
+    PredicateExpressionNode updated = versionRepository.updatePredicateNode(and);
+
+    // The tree should have the same structure, just with question IDs for the draft version.
+    PredicateExpressionNode expectedLeafOne =
+        PredicateExpressionNode.create(
+            leafOne.getLeafNode().toBuilder().questionId(newOne.id).build());
+    PredicateExpressionNode expectedLeafTwo =
+        PredicateExpressionNode.create(
+            leafTwo.getLeafNode().toBuilder().questionId(newTwo.id).build());
+    PredicateExpressionNode expectedLeafThree =
+        PredicateExpressionNode.create(
+            leafThree.getLeafNode().toBuilder().questionId(newOne.id).build());
+    PredicateExpressionNode expectedOr =
+        PredicateExpressionNode.create(
+            OrNode.create(ImmutableSet.of(expectedLeafTwo, expectedLeafThree)));
+    PredicateExpressionNode expectedAnd =
+        PredicateExpressionNode.create(
+            AndNode.create(ImmutableSet.of(expectedLeafOne, expectedOr)));
+
+    assertThat(updated.getType()).isEqualTo(PredicateExpressionNodeType.AND);
+    assertThat(updated).isEqualTo(expectedAnd);
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/VersionRepositoryTest.java
@@ -133,13 +133,13 @@ public class VersionRepositoryTest extends WithPostgresContainer {
     // The tree should have the same structure, just with question IDs for the draft version.
     PredicateExpressionNode expectedLeafOne =
         PredicateExpressionNode.create(
-            leafOne.getLeafNode().toBuilder().questionId(newOne.id).build());
+            leafOne.getLeafNode().toBuilder().setQuestionId(newOne.id).build());
     PredicateExpressionNode expectedLeafTwo =
         PredicateExpressionNode.create(
-            leafTwo.getLeafNode().toBuilder().questionId(newTwo.id).build());
+            leafTwo.getLeafNode().toBuilder().setQuestionId(newTwo.id).build());
     PredicateExpressionNode expectedLeafThree =
         PredicateExpressionNode.create(
-            leafThree.getLeafNode().toBuilder().questionId(newOne.id).build());
+            leafThree.getLeafNode().toBuilder().setQuestionId(newOne.id).build());
     PredicateExpressionNode expectedOr =
         PredicateExpressionNode.create(
             OrNode.create(ImmutableSet.of(expectedLeafTwo, expectedLeafThree)));

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -30,6 +30,15 @@ public class ResourceCreator {
     Models.truncate(ebeanServer);
   }
 
+  public Question insertQuestion(String name) {
+    QuestionDefinition definition =
+        new TextQuestionDefinition(
+            name, Optional.empty(), "", LocalizedStrings.of(), LocalizedStrings.empty());
+    Question question = new Question(definition);
+    question.save();
+    return question;
+  }
+
   public Question insertQuestion() {
     String name = UUID.randomUUID().toString();
     QuestionDefinition definition =


### PR DESCRIPTION
### Description
1. Updates leaf nodes in the `PredicateDefinition` to use updated question IDs
2. Please scrutinize my recursive predicate tree update - it's been awhile since I've worked with tree structures!
3. Adds unit tests for `updateQuestionVersions`

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1001 
