### PR TITLE
Feature/1228 move blocks

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -8,6 +8,7 @@ import forms.BlockForm;
 import java.util.Optional;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
+import play.data.DynamicForm;
 import play.data.Form;
 import play.data.FormFactory;
 import play.mvc.Http.Request;
@@ -17,6 +18,7 @@ import services.ErrorAnd;
 import services.program.BlockDefinition;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
+import services.program.ProgramDefinition.Direction;
 import services.program.ProgramNeedsABlockException;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
@@ -110,6 +112,18 @@ public class AdminProgramBlocksController extends CiviFormController {
       return notFound(e.toString());
     }
 
+    return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
+  }
+
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  public Result move(Request request, long programId, long blockId) {
+    DynamicForm requestData = formFactory.form().bindFromRequest(request);
+    Direction direction = Direction.valueOf(requestData.get("direction"));
+    try {
+      programService.moveBlock(programId, blockId, direction);
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    }
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
   }
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -133,8 +133,8 @@ public abstract class ProgramDefinition {
    * repeated or nested repeated block with the same enumerator. If there is no enumerator, it is
    * added at the end.
    */
-  public ProgramDefinition insertBlockDefinitionInTheRightPlace(
-      BlockDefinition newBlockDefinition) {
+  public ProgramDefinition insertBlockDefinitionInTheRightPlace(BlockDefinition newBlockDefinition)
+      throws ProgramBlockDefinitionNotFoundException {
     // Precondition: blocks have to be ordered
     if (!hasOrderedBlockDefinitions()) {
       return orderBlockDefinitions().insertBlockDefinitionInTheRightPlace(newBlockDefinition);

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -9,11 +9,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import models.Program;
 import services.LocalizedStrings;
@@ -122,6 +126,173 @@ public abstract class ProgramDefinition {
       hasOrderedBlockDefinitionsMemo = true;
     }
     return hasOrderedBlockDefinitionsMemo;
+  }
+
+  /**
+   * Inserts the new block into the list of blocks such that it appears immediately after the last
+   * repeated or nested repeated block with the same enumerator. If there is no enumerator, it is
+   * added at the end.
+   */
+  public ProgramDefinition insertBlockDefinitionInTheRightPlace(
+      BlockDefinition newBlockDefinition) {
+    // Precondition: blocks have to be ordered
+    if (!hasOrderedBlockDefinitions()) {
+      return orderBlockDefinitions().insertBlockDefinitionInTheRightPlace(newBlockDefinition);
+    }
+
+    // Simple return for non-repeated block - just add to the end of the list
+    if (!newBlockDefinition.isRepeated()) {
+      return toBuilder().addBlockDefinition(newBlockDefinition).build();
+    }
+    BlockSlice enumeratorIndices = getBlockSlice(newBlockDefinition.enumeratorId().get());
+    int insertIndex = enumeratorIndices.endIndex();
+
+    // At this point, insertIndex is AFTER the last repeated or nested repeated block of the
+    // enumerator. This might be off the end of the list.
+    ImmutableList.Builder<BlockDefinition> newBlockDefinitionsBuilder = ImmutableList.builder();
+    blockDefinitions().stream()
+        .limit(insertIndex)
+        .forEach(blockDefinition -> newBlockDefinitionsBuilder.add(blockDefinition));
+    newBlockDefinitionsBuilder.add(newBlockDefinition);
+    blockDefinitions().stream()
+        .skip(insertIndex)
+        .forEach(blockDefinition -> newBlockDefinitionsBuilder.add(blockDefinition));
+
+    return toBuilder().setBlockDefinitions(newBlockDefinitionsBuilder.build()).build();
+  }
+
+  public ProgramDefinition moveBlock(long blockId, Direction direction) {
+    // Precondition: blocks have to be ordered
+    if (!hasOrderedBlockDefinitions()) {
+      return orderBlockDefinitions().moveBlock(blockId, direction);
+    }
+
+    BlockSlice blockSlice = getBlockSlice(blockId);
+    Optional<BlockDefinition> otherBlock = findNextBlockWithSameEnumerator(blockSlice, direction);
+
+    // Early return if there's no other block to swap with.
+    if (otherBlock.isEmpty()) {
+      return this;
+    }
+
+    BlockSlice otherBlockSlice = getBlockSlice(otherBlock.get().id());
+
+    BlockSlice earlierSlice =
+        blockSlice.startsBefore(otherBlockSlice) ? blockSlice : otherBlockSlice;
+    BlockSlice latterSlice =
+        blockSlice.startsBefore(otherBlockSlice) ? otherBlockSlice : blockSlice;
+    ImmutableList.Builder<BlockDefinition> blocksBuilder = ImmutableList.builder();
+
+    // Swap the two slices, assuming these slices are consecutive slices
+    blockDefinitions().stream()
+        .limit(earlierSlice.startIndex())
+        .forEach(blockDefinition -> blocksBuilder.add(blockDefinition));
+    blockDefinitions().stream()
+        .skip(latterSlice.startIndex())
+        .limit(latterSlice.endIndex() - latterSlice.startIndex())
+        .forEach(blockDefinition -> blocksBuilder.add(blockDefinition));
+    blockDefinitions().stream()
+        .skip(earlierSlice.startIndex())
+        .limit(earlierSlice.endIndex() - earlierSlice.startIndex())
+        .forEach(blockDefinition -> blocksBuilder.add(blockDefinition));
+    blockDefinitions().stream()
+        .skip(latterSlice.endIndex())
+        .forEach(blockDefinition -> blocksBuilder.add(blockDefinition));
+
+    return toBuilder().setBlockDefinitions(blocksBuilder.build()).build();
+  }
+
+  /**
+   * Find the start and end indices of the slice of blocks associated with the block definition id.
+   * For non-enumerator blocks, the slice of blocks associated with the block is just the block
+   * itself. For enumerator blocks, the slice of blocks also contain all of its repeated and nested
+   * repeated blocks.
+   */
+  private BlockSlice getBlockSlice(long blockId) {
+    // Precondition: blocks have to be ordered
+    if (!hasOrderedBlockDefinitions()) {
+      return orderBlockDefinitions().getBlockSlice(blockId);
+    }
+
+    // Find the enumerator block
+    int startIndex;
+    try {
+      startIndex =
+          IntStream.range(0, blockDefinitions().size())
+              .filter(i -> blockDefinitions().get(i).id() == blockId)
+              .findFirst()
+              .getAsInt();
+    } catch (NoSuchElementException e) {
+      // The enumerator id must correspond to a block within blocks.
+      throw new RuntimeException(e);
+    }
+    BlockDefinition blockDefinition = blockDefinitions().get(startIndex);
+    int endIndex = startIndex + 1;
+
+    // Early return for non-enumerator blocks
+    if (!blockDefinition.isEnumerator()) {
+      return BlockSlice.create(startIndex, endIndex);
+    }
+
+    // Increment the index until the ordered block definitions are not repeated or nested repeated
+    // blocks of the enumerator
+    Set<Long> enumeratorIds = new HashSet<>(Arrays.asList(blockId));
+    while (endIndex < getBlockCount()) {
+      BlockDefinition current = blockDefinitions().get(endIndex);
+      if (current.enumeratorId().isEmpty()
+          || !enumeratorIds.contains(current.enumeratorId().get())) {
+        // This is not a repeated or nested repeated block of the enumerator
+        break;
+      }
+      // Add nested enumerators into the set of enumerators
+      if (current.isEnumerator()) {
+        enumeratorIds.add(current.id());
+      }
+      endIndex++;
+    }
+
+    return BlockSlice.create(startIndex, endIndex);
+  }
+
+  /**
+   * Find the next block with the same enumerator as the block at the start of the slice in the
+   * specified direction. This block may not exist.
+   */
+  private Optional<BlockDefinition> findNextBlockWithSameEnumerator(
+      BlockSlice blockSlice, Direction direction) {
+    // Precondition: blocks have to be ordered
+    if (!hasOrderedBlockDefinitions()) {
+      return orderBlockDefinitions().findNextBlockWithSameEnumerator(blockSlice, direction);
+    }
+
+    BlockDefinition blockDefinition = blockDefinitions().get(blockSlice.startIndex());
+
+    int index;
+    switch (direction) {
+      case UP:
+        // Walk up from the start of the slice checking for the first block with
+        // matching enumerator.
+        index = blockSlice.startIndex() - 1;
+        while (index >= 0) {
+          if (blockDefinition.enumeratorId().equals(blockDefinitions().get(index).enumeratorId())) {
+            break;
+          }
+          index--;
+        }
+        break;
+      case DOWN:
+      default:
+        // Use the block after the end of the slice if it has the same enumerator,
+        // or the other block does not exist
+        BlockDefinition otherBlockDefinition = blockDefinitions().get(blockSlice.endIndex());
+        index =
+            blockDefinition.enumeratorId().equals(otherBlockDefinition.enumeratorId())
+                ? blockSlice.endIndex()
+                : -1;
+    }
+    return (0 <= index && index < getBlockCount())
+        ? Optional.of(blockDefinitions().get(index))
+        : Optional.empty();
   }
 
   /**
@@ -381,6 +552,26 @@ public abstract class ProgramDefinition {
     public Builder addLocalizedDescription(Locale locale, String description) {
       localizedDescriptionBuilder().put(locale, description);
       return this;
+    }
+  }
+
+  public enum Direction {
+    UP,
+    DOWN;
+  }
+
+  @AutoValue
+  abstract static class BlockSlice {
+    abstract int startIndex();
+
+    abstract int endIndex();
+
+    static BlockSlice create(int startIndex, int endIndex) {
+      return new AutoValue_ProgramDefinition_BlockSlice(startIndex, endIndex);
+    }
+
+    boolean startsBefore(BlockSlice other) {
+      return startIndex() < other.startIndex();
     }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -161,7 +161,12 @@ public abstract class ProgramDefinition {
     return toBuilder().setBlockDefinitions(newBlockDefinitionsBuilder.build()).build();
   }
 
-  public ProgramDefinition moveBlock(long blockId, Direction direction) {
+  /**
+   * Move the block in the direction specified if it is allowed. Blocks are not allowed to move
+   * beyond the contiguous slice of repeated and nested repeated blocks of their enumerator.
+   */
+  public ProgramDefinition moveBlock(long blockId, Direction direction)
+      throws ProgramBlockDefinitionNotFoundException {
     // Precondition: blocks have to be ordered
     if (!hasOrderedBlockDefinitions()) {
       return orderBlockDefinitions().moveBlock(blockId, direction);
@@ -208,7 +213,7 @@ public abstract class ProgramDefinition {
    * itself. For enumerator blocks, the slice of blocks also contain all of its repeated and nested
    * repeated blocks.
    */
-  private BlockSlice getBlockSlice(long blockId) {
+  private BlockSlice getBlockSlice(long blockId) throws ProgramBlockDefinitionNotFoundException {
     // Precondition: blocks have to be ordered
     if (!hasOrderedBlockDefinitions()) {
       return orderBlockDefinitions().getBlockSlice(blockId);
@@ -224,7 +229,7 @@ public abstract class ProgramDefinition {
               .getAsInt();
     } catch (NoSuchElementException e) {
       // The enumerator id must correspond to a block within blocks.
-      throw new RuntimeException(e);
+      throw new ProgramBlockDefinitionNotFoundException(id(), blockId);
     }
     BlockDefinition blockDefinition = blockDefinitions().get(startIndex);
     int endIndex = startIndex + 1;

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -127,6 +127,42 @@ public interface ProgramService {
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException;
 
   /**
+   * Move the block definition one position earlier in the program. If the movement is not allowed,
+   * then it is not moved.
+   *
+   * <p>Movement is not allowed if:
+   *
+   * <ul>
+   *   <li>it would move the block past the ends of the list
+   *   <li>it would move a repeated block such that it is not contiguous with its enumerator block's
+   *       repeated and nested repeated blocks.
+   * </ul>
+   *
+   * @param programId the ID of the program to update
+   * @param blockId the ID of the block to move
+   * @return the program definition, with the block moved if it is allowed.
+   */
+  ProgramDefinition moveBlockUp(long programId, long blockId) throws ProgramNotFoundException;
+
+  /**
+   * Move the block definition one position later in the program. If the movement is not allowed,
+   * then it is not moved.
+   *
+   * <p>Movement is not allowed if:
+   *
+   * <ul>
+   *   <li>it would move the block past the ends of the list
+   *   <li>it would move a repeated block such that it is not contiguous with its enumerator block's
+   *       repeated and nested repeated blocks.
+   * </ul>
+   *
+   * @param programId the ID of the program to update
+   * @param blockId the ID of the block to move
+   * @return the program definition, with the block moved if it is allowed.
+   */
+  ProgramDefinition moveBlockDown(long programId, long blockId) throws ProgramNotFoundException;
+
+  /**
    * Update a {@link BlockDefinition}'s attributes.
    *
    * @param programId the ID of the program to update

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -127,8 +127,8 @@ public interface ProgramService {
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException;
 
   /**
-   * Move the block definition one position earlier in the program. If the movement is not allowed,
-   * then it is not moved.
+   * Move the block definition one position in the direction specified. If the movement is not
+   * allowed, then it is not moved.
    *
    * <p>Movement is not allowed if:
    *
@@ -142,25 +142,8 @@ public interface ProgramService {
    * @param blockId the ID of the block to move
    * @return the program definition, with the block moved if it is allowed.
    */
-  ProgramDefinition moveBlockUp(long programId, long blockId) throws ProgramNotFoundException;
-
-  /**
-   * Move the block definition one position later in the program. If the movement is not allowed,
-   * then it is not moved.
-   *
-   * <p>Movement is not allowed if:
-   *
-   * <ul>
-   *   <li>it would move the block past the ends of the list
-   *   <li>it would move a repeated block such that it is not contiguous with its enumerator block's
-   *       repeated and nested repeated blocks.
-   * </ul>
-   *
-   * @param programId the ID of the program to update
-   * @param blockId the ID of the block to move
-   * @return the program definition, with the block moved if it is allowed.
-   */
-  ProgramDefinition moveBlockDown(long programId, long blockId) throws ProgramNotFoundException;
+  ProgramDefinition moveBlock(long programId, long blockId, ProgramDefinition.Direction direction)
+      throws ProgramNotFoundException;
 
   /**
    * Update a {@link BlockDefinition}'s attributes.

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -7,15 +7,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import forms.BlockForm;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.IntStream;
 import models.Account;
 import models.Application;
 import models.Program;
@@ -245,7 +241,7 @@ public class ProgramServiceImpl implements ProgramService {
             .setEnumeratorId(enumeratorBlockId)
             .build();
     Program program =
-        insertBlockDefinitionInTheRightPlace(programDefinition, blockDefinition).toProgram();
+        programDefinition.insertBlockDefinitionInTheRightPlace(blockDefinition).toProgram();
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(
                 programRepository.updateProgramSync(program).getProgramDefinition())
@@ -253,100 +249,16 @@ public class ProgramServiceImpl implements ProgramService {
             .join());
   }
 
-  /**
-   * Inserts the new block into the list of blocks such that it appears immediately after the last
-   * repeated or nested repeated block with the same enumerator. If there is no enumerator, it is
-   * added at the end.
-   */
-  private static ProgramDefinition insertBlockDefinitionInTheRightPlace(
-      ProgramDefinition programDefinition, BlockDefinition newBlockDefinition) {
-    // Simple return for non-repeated block - just add to the end of the list
-    if (!newBlockDefinition.isRepeated()) {
-      return programDefinition.toBuilder().addBlockDefinition(newBlockDefinition).build();
-    }
-
-    // Precondition: blocks have to be ordered
-    ProgramDefinition orderedProgramDefinition = programDefinition.orderBlockDefinitions();
-
-    // Find the index of the enumerator block
-    long enumeratorId = newBlockDefinition.enumeratorId().get();
-    int enumeratorIndex;
-    try {
-      enumeratorIndex =
-          orderedProgramDefinition
-              .blockDefinitions()
-              .indexOf(orderedProgramDefinition.getBlockDefinition(enumeratorId));
-    } catch (ProgramBlockDefinitionNotFoundException e) {
-      // This should never happen. A repeated block can only be added if its enumerator is present.
-      throw new RuntimeException(e);
-    }
-
-    // Increment the index until the ordered block definitions are not repeated or nested repeated
-    // blocks of the enumerator
-    int insertIndex = enumeratorIndex + 1;
-    Set<Long> enumeratorIds = new HashSet<>(Arrays.asList(enumeratorId));
-    while (insertIndex < orderedProgramDefinition.blockDefinitions().size()) {
-      BlockDefinition current = orderedProgramDefinition.blockDefinitions().get(insertIndex);
-      if (current.enumeratorId().isEmpty()
-          || !enumeratorIds.contains(current.enumeratorId().get())) {
-        // This is not a repeated or nested repeated block of the enumerator
-        break;
-      }
-      // Add nested enumerators into the set of enumerators
-      if (current.isEnumerator()) {
-        enumeratorIds.add(current.id());
-      }
-      insertIndex++;
-    }
-
-    // At this point, insertIndex is AFTER the last repeated or nested repeated block of the
-    // enumerator. This might be off the end of the list.
-    ImmutableList.Builder<BlockDefinition> newBlockDefinitionsBuilder = ImmutableList.builder();
-    orderedProgramDefinition.blockDefinitions().stream()
-        .limit(insertIndex)
-        .forEach(blockDefinition -> newBlockDefinitionsBuilder.add(blockDefinition));
-    newBlockDefinitionsBuilder.add(newBlockDefinition);
-    orderedProgramDefinition.blockDefinitions().stream()
-        .skip(insertIndex)
-        .forEach(blockDefinition -> newBlockDefinitionsBuilder.add(blockDefinition));
-
-    return programDefinition.toBuilder()
-        .setBlockDefinitions(newBlockDefinitionsBuilder.build())
-        .build();
-  }
-
   @Override
   @Transactional
-  public ProgramDefinition moveBlockUp(long programId, long blockId)
+  public ProgramDefinition moveBlock(
+      long programId, long blockId, ProgramDefinition.Direction direction)
       throws ProgramNotFoundException {
-    return moveBlock(programId, blockId, Direction.UP);
-  }
-
-  @Override
-  @Transactional
-  public ProgramDefinition moveBlockDown(long programId, long blockId)
-      throws ProgramNotFoundException {
-    return moveBlock(programId, blockId, Direction.DOWN);
-  }
-
-  private ProgramDefinition moveBlock(long programId, long blockId, Direction direction)
-      throws ProgramNotFoundException {
-    ProgramDefinition programDefinition = getProgramDefinition(programId);
-
-    // Find the block
-    int index =
-        IntStream.range(0, programDefinition.blockDefinitions().size())
-            .filter(i -> programDefinition.blockDefinitions().get(i).id() == blockId)
-            .findFirst()
-            .getAsInt();
-    BlockDefinition blockDefinition = programDefinition.blockDefinitions().get(index);
-
-    // Find the block to swap with
-    Optional<Integer> maybeSwapIndex =
-        direction.equals(Direction.UP) ? Optional.of(index - 1) : Optional.of(index + 1);
-
-    // Swap
-    return ProgramDefinition.builder().build();
+    Program program = getProgramDefinition(programId).moveBlock(blockId, direction).toProgram();
+    return syncProgramDefinitionQuestions(
+            programRepository.updateProgramSync(program).getProgramDefinition())
+        .toCompletableFuture()
+        .join();
   }
 
   @Override
@@ -636,10 +548,5 @@ public class ProgramServiceImpl implements ProgramService {
       throw new RuntimeException(e);
     }
     return ProgramQuestionDefinition.create(questionDefinition);
-  }
-
-  private enum Direction {
-    UP,
-    DOWN;
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -259,7 +259,7 @@ public class ProgramServiceImpl implements ProgramService {
       program = getProgramDefinition(programId).moveBlock(blockId, direction).toProgram();
     } catch (ProgramBlockDefinitionNotFoundException e) {
       throw new RuntimeException(
-          "Something happened to the programs block while trying to move it", e);
+          "Something happened to the program's block while trying to move it", e);
     }
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -254,7 +254,13 @@ public class ProgramServiceImpl implements ProgramService {
   public ProgramDefinition moveBlock(
       long programId, long blockId, ProgramDefinition.Direction direction)
       throws ProgramNotFoundException {
-    Program program = getProgramDefinition(programId).moveBlock(blockId, direction).toProgram();
+    Program program;
+    try {
+      program = getProgramDefinition(programId).moveBlock(blockId, direction).toProgram();
+    } catch (ProgramBlockDefinitionNotFoundException e) {
+      throw new RuntimeException(
+          "Something happened to the programs block while trying to move it", e);
+    }
     return syncProgramDefinitionQuestions(
             programRepository.updateProgramSync(program).getProgramDefinition())
         .toCompletableFuture()

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.IntStream;
 import models.Account;
 import models.Application;
 import models.Program;
@@ -316,6 +317,40 @@ public class ProgramServiceImpl implements ProgramService {
 
   @Override
   @Transactional
+  public ProgramDefinition moveBlockUp(long programId, long blockId)
+      throws ProgramNotFoundException {
+    return moveBlock(programId, blockId, Direction.UP);
+  }
+
+  @Override
+  @Transactional
+  public ProgramDefinition moveBlockDown(long programId, long blockId)
+      throws ProgramNotFoundException {
+    return moveBlock(programId, blockId, Direction.DOWN);
+  }
+
+  private ProgramDefinition moveBlock(long programId, long blockId, Direction direction)
+      throws ProgramNotFoundException {
+    ProgramDefinition programDefinition = getProgramDefinition(programId);
+
+    // Find the block
+    int index =
+        IntStream.range(0, programDefinition.blockDefinitions().size())
+            .filter(i -> programDefinition.blockDefinitions().get(i).id() == blockId)
+            .findFirst()
+            .getAsInt();
+    BlockDefinition blockDefinition = programDefinition.blockDefinitions().get(index);
+
+    // Find the block to swap with
+    Optional<Integer> maybeSwapIndex =
+        direction.equals(Direction.UP) ? Optional.of(index - 1) : Optional.of(index + 1);
+
+    // Swap
+    return ProgramDefinition.builder().build();
+  }
+
+  @Override
+  @Transactional
   public ErrorAnd<ProgramDefinition, CiviFormError> updateBlock(
       long programId, long blockDefinitionId, BlockForm blockForm)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
@@ -601,5 +636,10 @@ public class ProgramServiceImpl implements ProgramService {
       throw new RuntimeException(e);
     }
     return ProgramQuestionDefinition.create(questionDefinition);
+  }
+
+  private enum Direction {
+    UP,
+    DOWN;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/ViewUtils.java
+++ b/universal-application-tool-0.0.1/app/views/ViewUtils.java
@@ -12,8 +12,6 @@ import javax.inject.Inject;
 public final class ViewUtils {
   private final AssetsFinder assetsFinder;
 
-  public static final String POST = "post";
-
   @Inject
   ViewUtils(AssetsFinder assetsFinder) {
     this.assetsFinder = checkNotNull(assetsFinder);

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -190,52 +190,9 @@ public class ProgramBlockEditView extends BaseHtmlView {
       String questionCountText = String.format("Question count: %d", numQuestions);
       String blockName = blockDefinition.name();
 
-      String selectedClasses = blockDefinition.id() == focusedBlockId ? Styles.BG_GRAY_100 : "";
-
-      String moveUpFormAction =
-          routes.AdminProgramBlocksController.move(programDefinition.id(), blockDefinition.id())
-              .url();
-      // Move up button is invisible for the first block
-      String moveUpStyles =
-          StyleUtils.joinStyles(
-              AdminStyles.MOVE_BLOCK_BUTTON,
-              (blockDefinition.id() == blockDefinitions.get(0).id()) ? Styles.INVISIBLE : "");
-      Tag moveUp =
-          div()
-              .with(
-                  form()
-                      .withAction(moveUpFormAction)
-                      .withMethod(HttpVerbs.POST)
-                      .with(makeCsrfTokenInputTag(request))
-                      .with(input().isHidden().withName("direction").withValue(Direction.UP.name()))
-                      .with(submitButton("^").withClasses(moveUpStyles)));
-
-      String moveDownFormAction =
-          routes.AdminProgramBlocksController.move(programDefinition.id(), blockDefinition.id())
-              .url();
-      // Move down button is invisible for the last block
-      String moveDownStyles =
-          StyleUtils.joinStyles(
-              AdminStyles.MOVE_BLOCK_BUTTON,
-              (blockDefinition.id() == blockDefinitions.get(blockDefinitions.size() - 1).id())
-                  ? Styles.INVISIBLE
-                  : "");
-      Tag moveDown =
-          div()
-              .withClasses(Styles.TRANSFORM, Styles.ROTATE_180)
-              .with(
-                  form()
-                      .withAction(moveDownFormAction)
-                      .withMethod(HttpVerbs.POST)
-                      .with(makeCsrfTokenInputTag(request))
-                      .with(
-                          input().isHidden().withName("direction").withValue(Direction.DOWN.name()))
-                      .with(submitButton("^").withClasses(moveDownStyles)));
       ContainerTag moveButtons =
-          div()
-              .withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.SELF_CENTER)
-              .with(moveUp, moveDown);
-
+          blockMoveButtons(request, programDefinition.id(), blockDefinitions, blockDefinition);
+      String selectedClasses = blockDefinition.id() == focusedBlockId ? Styles.BG_GRAY_100 : "";
       ContainerTag blockTag =
           div()
               .withClasses(
@@ -268,6 +225,52 @@ public class ProgramBlockEditView extends BaseHtmlView {
       }
     }
     return container;
+  }
+
+  private ContainerTag blockMoveButtons(
+      Request request,
+      long programId,
+      ImmutableList<BlockDefinition> blockDefinitions,
+      BlockDefinition blockDefinition) {
+    String moveUpFormAction =
+        routes.AdminProgramBlocksController.move(programId, blockDefinition.id()).url();
+    // Move up button is invisible for the first block
+    String moveUpStyles =
+        StyleUtils.joinStyles(
+            AdminStyles.MOVE_BLOCK_BUTTON,
+            (blockDefinition.id() == blockDefinitions.get(0).id()) ? Styles.INVISIBLE : "");
+    Tag moveUp =
+        div()
+            .with(
+                form()
+                    .withAction(moveUpFormAction)
+                    .withMethod(HttpVerbs.POST)
+                    .with(makeCsrfTokenInputTag(request))
+                    .with(input().isHidden().withName("direction").withValue(Direction.UP.name()))
+                    .with(submitButton("^").withClasses(moveUpStyles)));
+
+    String moveDownFormAction =
+        routes.AdminProgramBlocksController.move(programId, blockDefinition.id()).url();
+    // Move down button is invisible for the last block
+    String moveDownStyles =
+        StyleUtils.joinStyles(
+            AdminStyles.MOVE_BLOCK_BUTTON,
+            (blockDefinition.id() == blockDefinitions.get(blockDefinitions.size() - 1).id())
+                ? Styles.INVISIBLE
+                : "");
+    Tag moveDown =
+        div()
+            .withClasses(Styles.TRANSFORM, Styles.ROTATE_180)
+            .with(
+                form()
+                    .withAction(moveDownFormAction)
+                    .withMethod(HttpVerbs.POST)
+                    .with(makeCsrfTokenInputTag(request))
+                    .with(input().isHidden().withName("direction").withValue(Direction.DOWN.name()))
+                    .with(submitButton("^").withClasses(moveDownStyles)));
+    ContainerTag moveButtons =
+        div().withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.SELF_CENTER).with(moveUp, moveDown);
+    return moveButtons;
   }
 
   private ContainerTag blockEditPanel(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -235,39 +235,36 @@ public class ProgramBlockEditView extends BaseHtmlView {
     String moveUpFormAction =
         routes.AdminProgramBlocksController.move(programId, blockDefinition.id()).url();
     // Move up button is invisible for the first block
-    String moveUpStyles =
-        StyleUtils.joinStyles(
-            AdminStyles.MOVE_BLOCK_BUTTON,
-            (blockDefinition.id() == blockDefinitions.get(0).id()) ? Styles.INVISIBLE : "");
+    String moveUpInvisible =
+        blockDefinition.id() == blockDefinitions.get(0).id() ? Styles.INVISIBLE : "";
     Tag moveUp =
         div()
+            .withClass(moveUpInvisible)
             .with(
                 form()
                     .withAction(moveUpFormAction)
                     .withMethod(HttpVerbs.POST)
                     .with(makeCsrfTokenInputTag(request))
                     .with(input().isHidden().withName("direction").withValue(Direction.UP.name()))
-                    .with(submitButton("^").withClasses(moveUpStyles)));
+                    .with(submitButton("^").withClasses(AdminStyles.MOVE_BLOCK_BUTTON)));
 
     String moveDownFormAction =
         routes.AdminProgramBlocksController.move(programId, blockDefinition.id()).url();
     // Move down button is invisible for the last block
-    String moveDownStyles =
-        StyleUtils.joinStyles(
-            AdminStyles.MOVE_BLOCK_BUTTON,
-            (blockDefinition.id() == blockDefinitions.get(blockDefinitions.size() - 1).id())
-                ? Styles.INVISIBLE
-                : "");
+    String moveDownInvisible =
+        blockDefinition.id() == blockDefinitions.get(blockDefinitions.size() - 1).id()
+            ? Styles.INVISIBLE
+            : "";
     Tag moveDown =
         div()
-            .withClasses(Styles.TRANSFORM, Styles.ROTATE_180)
+            .withClasses(Styles.TRANSFORM, Styles.ROTATE_180, moveDownInvisible)
             .with(
                 form()
                     .withAction(moveDownFormAction)
                     .withMethod(HttpVerbs.POST)
                     .with(makeCsrfTokenInputTag(request))
                     .with(input().isHidden().withName("direction").withValue(Direction.DOWN.name()))
-                    .with(submitButton("^").withClasses(moveDownStyles)));
+                    .with(submitButton("^").withClasses(AdminStyles.MOVE_BLOCK_BUTTON)));
     ContainerTag moveButtons =
         div().withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.SELF_CENTER).with(moveUp, moveDown);
     return moveButtons;

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -4,22 +4,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
+import static j2html.TagCreator.input;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.text;
-import static views.ViewUtils.POST;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import controllers.admin.routes;
 import forms.BlockForm;
 import j2html.TagCreator;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.OptionalLong;
+import play.mvc.Http.HttpVerbs;
 import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
+import services.program.ProgramDefinition.Direction;
 import services.program.ProgramQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import views.BaseHtmlView;
@@ -95,7 +98,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
                 div()
                     .withId("program-block-info")
                     .withClasses(Styles.FLEX, Styles.FLEX_GROW, Styles._MX_2)
-                    .with(blockOrderPanel(programDefinition, blockId))
+                    .with(blockOrderPanel(request, programDefinition, blockId))
                     .with(
                         blockEditPanel(
                             programDefinition,
@@ -120,12 +123,15 @@ public class ProgramBlockEditView extends BaseHtmlView {
     String blockCreateAction =
         controllers.admin.routes.AdminProgramBlocksController.create(programId).url();
     ContainerTag createBlockForm =
-        form(csrfTag).withId(CREATE_BLOCK_FORM_ID).withMethod(POST).withAction(blockCreateAction);
+        form(csrfTag)
+            .withId(CREATE_BLOCK_FORM_ID)
+            .withMethod(HttpVerbs.POST)
+            .withAction(blockCreateAction);
 
     ContainerTag createRepeatedBlockForm =
         form(csrfTag)
             .withId(CREATE_REPEATED_BLOCK_FORM_ID)
-            .withMethod(POST)
+            .withMethod(HttpVerbs.POST)
             .withAction(blockCreateAction)
             .with(
                 FieldWithLabel.number()
@@ -136,13 +142,17 @@ public class ProgramBlockEditView extends BaseHtmlView {
     String blockDeleteAction =
         controllers.admin.routes.AdminProgramBlocksController.destroy(programId, blockId).url();
     ContainerTag deleteBlockForm =
-        form(csrfTag).withId(DELETE_BLOCK_FORM_ID).withMethod(POST).withAction(blockDeleteAction);
+        form(csrfTag)
+            .withId(DELETE_BLOCK_FORM_ID)
+            .withMethod(HttpVerbs.POST)
+            .withAction(blockDeleteAction);
 
     return div(createBlockForm, createRepeatedBlockForm, deleteBlockForm)
         .withClasses(Styles.HIDDEN);
   }
 
-  public ContainerTag blockOrderPanel(ProgramDefinition program, long focusedBlockId) {
+  private ContainerTag blockOrderPanel(
+      Request request, ProgramDefinition program, long focusedBlockId) {
     ContainerTag ret =
         div()
             .withClasses(
@@ -151,7 +161,9 @@ public class ProgramBlockEditView extends BaseHtmlView {
                 Styles.W_1_5,
                 Styles.BORDER_R,
                 Styles.BORDER_GRAY_200);
-    ret.with(renderBlockList(program, program.getNonRepeatedBlockDefinitions(), focusedBlockId, 0));
+    ret.with(
+        renderBlockList(
+            request, program, program.getNonRepeatedBlockDefinitions(), focusedBlockId, 0));
     ret.with(
         submitButton("Add Block")
             .withId("add-block-button")
@@ -161,6 +173,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
   }
 
   private ContainerTag renderBlockList(
+      Request request,
       ProgramDefinition programDefinition,
       ImmutableList<BlockDefinition> blockDefinitions,
       long focusedBlockId,
@@ -177,11 +190,69 @@ public class ProgramBlockEditView extends BaseHtmlView {
       String questionCountText = String.format("Question count: %d", numQuestions);
       String blockName = blockDefinition.name();
 
-      ContainerTag blockTag =
-          a().withHref(editBlockLink)
-              .with(p(blockName), p(questionCountText).withClasses(Styles.TEXT_SM));
       String selectedClasses = blockDefinition.id() == focusedBlockId ? Styles.BG_GRAY_100 : "";
-      blockTag.withClasses(Styles.BLOCK, Styles.PY_2, Styles.PX_4, selectedClasses);
+
+      String moveUpFormAction =
+          routes.AdminProgramBlocksController.move(programDefinition.id(), blockDefinition.id())
+              .url();
+      // Move up button is invisible for the first block
+      String moveUpStyles =
+          StyleUtils.joinStyles(
+              AdminStyles.MOVE_BLOCK_BUTTON,
+              (blockDefinition.id() == blockDefinitions.get(0).id()) ? Styles.INVISIBLE : "");
+      Tag moveUp =
+          div()
+              .with(
+                  form()
+                      .withAction(moveUpFormAction)
+                      .withMethod(HttpVerbs.POST)
+                      .with(makeCsrfTokenInputTag(request))
+                      .with(input().isHidden().withName("direction").withValue(Direction.UP.name()))
+                      .with(submitButton("^").withClasses(moveUpStyles)));
+
+      String moveDownFormAction =
+          routes.AdminProgramBlocksController.move(programDefinition.id(), blockDefinition.id())
+              .url();
+      // Move down button is invisible for the last block
+      String moveDownStyles =
+          StyleUtils.joinStyles(
+              AdminStyles.MOVE_BLOCK_BUTTON,
+              (blockDefinition.id() == blockDefinitions.get(blockDefinitions.size() - 1).id())
+                  ? Styles.INVISIBLE
+                  : "");
+      Tag moveDown =
+          div()
+              .withClasses(Styles.TRANSFORM, Styles.ROTATE_180)
+              .with(
+                  form()
+                      .withAction(moveDownFormAction)
+                      .withMethod(HttpVerbs.POST)
+                      .with(makeCsrfTokenInputTag(request))
+                      .with(
+                          input().isHidden().withName("direction").withValue(Direction.DOWN.name()))
+                      .with(submitButton("^").withClasses(moveDownStyles)));
+      ContainerTag moveButtons =
+          div()
+              .withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.SELF_CENTER)
+              .with(moveUp, moveDown);
+
+      ContainerTag blockTag =
+          div()
+              .withClasses(
+                  Styles.FLEX,
+                  Styles.FLEX_ROW,
+                  Styles.GAP_2,
+                  Styles.PY_2,
+                  Styles.PX_4,
+                  Styles.BORDER,
+                  Styles.BORDER_WHITE,
+                  StyleUtils.hover(Styles.BORDER_GRAY_300),
+                  selectedClasses)
+              .with(
+                  a().withClasses(Styles.FLEX_GROW, Styles.OVERFLOW_HIDDEN)
+                      .withHref(editBlockLink)
+                      .with(p(blockName), p(questionCountText).withClasses(Styles.TEXT_SM)))
+              .with(moveButtons);
 
       container.with(blockTag);
 
@@ -189,6 +260,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
       if (blockDefinition.isEnumerator()) {
         container.with(
             renderBlockList(
+                request,
                 programDefinition,
                 programDefinition.getBlockDefinitionsForEnumerator(blockDefinition.id()),
                 focusedBlockId,
@@ -255,7 +327,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
     ContainerTag questionDeleteForm =
         form(csrfTag)
             .withId("block-questions-form")
-            .withMethod(POST)
+            .withMethod(HttpVerbs.POST)
             .withAction(deleteQuestionAction);
     blockQuestions.forEach(
         pqd -> questionDeleteForm.with(renderQuestion(pqd.getQuestionDefinition(), canDelete)));
@@ -332,7 +404,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
     String modalTitle = "Block Name and Description";
     String modalButtonText = "Edit Name and Description";
     ContainerTag blockDescriptionForm =
-        form(csrfTag).withMethod(POST).withAction(blockUpdateAction);
+        form(csrfTag).withMethod(HttpVerbs.POST).withAction(blockUpdateAction);
     blockDescriptionForm
         .withId("block-edit-form")
         .with(

--- a/universal-application-tool-0.0.1/app/views/components/QuestionBank.java
+++ b/universal-application-tool-0.0.1/app/views/components/QuestionBank.java
@@ -6,7 +6,6 @@ import static j2html.TagCreator.h1;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.text;
-import static views.ViewUtils.POST;
 
 import com.google.common.collect.ImmutableList;
 import j2html.TagCreator;
@@ -16,6 +15,7 @@ import j2html.tags.Tag;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Predicate;
+import play.mvc.Http.HttpVerbs;
 import services.program.BlockDefinition;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
@@ -64,7 +64,8 @@ public class QuestionBank {
   }
 
   private ContainerTag questionBankPanel() {
-    ContainerTag questionForm = form(this.csrfTag).withMethod(POST).withAction(questionAction);
+    ContainerTag questionForm =
+        form(this.csrfTag).withMethod(HttpVerbs.POST).withAction(questionAction);
 
     div().withClasses(Styles.INLINE_BLOCK, Styles.W_1_4);
     ContainerTag innerDiv =

--- a/universal-application-tool-0.0.1/app/views/style/AdminStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/AdminStyles.java
@@ -52,6 +52,15 @@ public class AdminStyles {
           Styles.TOP_0,
           Styles.W_FULL);
 
+  public static final String MOVE_BLOCK_BUTTON =
+      StyleUtils.joinStyles(
+          Styles.BG_TRANSPARENT,
+          Styles.P_0,
+          Styles.W_6,
+          Styles.TEXT_CENTER,
+          Styles.TEXT_GRAY_500,
+          StyleUtils.hover(Styles.BG_GRAY_200, Styles.TEXT_GRAY_900));
+
   public static final String BODY =
       StyleUtils.joinStyles(
           BODY_GRADIENT_STYLE,

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -36,6 +36,7 @@ GET     /admin/programs/:programId/blocks                              controlle
 GET     /admin/programs/:programId/blocks/:blockDefinitionId/edit      controllers.admin.AdminProgramBlocksController.edit(request: Request, programId: Long, blockDefinitionId: Long)
 POST    /admin/programs/:programId/blocks/:blockDefinitionId           controllers.admin.AdminProgramBlocksController.update(request: Request, programId: Long, blockDefinitionId: Long)
 POST    /admin/programs/:programId/blocks                              controllers.admin.AdminProgramBlocksController.create(request: Request, programId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/move      controllers.admin.AdminProgramBlocksController.move(request: Request, programId: Long, blockDefinitionId: Long)
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/delete    controllers.admin.AdminProgramBlocksController.destroy(programId: Long, blockDefinitionId: Long)
 
 # A controller for pages for an admin to configure show/hide logic on blocks for a program

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -6,14 +6,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Locale;
 import java.util.Optional;
 import org.junit.Test;
+import repository.WithPostgresContainer;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
 import services.question.types.QuestionDefinition;
+import support.ProgramBuilder;
 import support.TestQuestionBank;
 
-public class ProgramDefinitionTest {
+public class ProgramDefinitionTest extends WithPostgresContainer {
 
-  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(true);
 
   @Test
   public void createProgramDefinition() {
@@ -353,5 +355,100 @@ public class ProgramDefinitionTest {
     // blockE (applicantHouseholdMembers.householdMemberJobs.householdMemberJobIncome)
     assertThat(programDefinition.getAvailablePredicateQuestionDefinitions(5L))
         .containsExactly(questionA, questionC);
+  }
+
+  @Test
+  public void insertBlockDefinitionInTheRightPlace_repeatedBlock() throws Exception {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRepeatedBlock()
+            .withQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantFavoriteColor())
+            .build()
+            .getProgramDefinition();
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setName("new block")
+            .setDescription("new block")
+            .setId(100L)
+            .setEnumeratorId(Optional.of(1L))
+            .build();
+
+    ProgramDefinition result =
+        programDefinition.insertBlockDefinitionInTheRightPlace(blockDefinition);
+
+    assertThat(result.blockDefinitions()).hasSize(4);
+    assertThat(result.getBlockDefinitionByIndex(0).get().isEnumerator()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(0).get().isRepeated()).isFalse();
+    assertThat(result.getBlockDefinitionByIndex(0).get().getQuestionDefinition(0))
+        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+    assertThat(result.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(1).get().isRepeated()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(1).get().enumeratorId()).contains(1L);
+    assertThat(result.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
+        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+    assertThat(result.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(1L);
+    assertThat(result.getBlockDefinitionByIndex(2).get().getQuestionCount()).isEqualTo(0);
+    assertThat(result.getBlockDefinitionByIndex(3).get().isRepeated()).isFalse();
+  }
+
+  @Test
+  public void moveBlock_up() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRepeatedBlock()
+            .withQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantFavoriteColor())
+            .build()
+            .getProgramDefinition();
+
+    ProgramDefinition result = programDefinition.moveBlock(3L, ProgramDefinition.Direction.UP);
+
+    assertThat(result.blockDefinitions()).hasSize(3);
+    assertThat(result.getBlockDefinitionByIndex(0).get().isRepeated()).isFalse();
+    assertThat(result.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(1).get().isRepeated()).isFalse();
+    assertThat(result.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
+        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+    assertThat(result.getBlockDefinitionByIndex(2).get().isEnumerator()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(1L);
+    assertThat(result.getBlockDefinitionByIndex(2).get().getQuestionDefinition(0))
+        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
+  }
+
+  @Test
+  public void moveBlock_down() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantHouseholdMembers())
+            .withRepeatedBlock()
+            .withQuestion(testQuestionBank.applicantHouseholdMemberJobs())
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantFavoriteColor())
+            .build()
+            .getProgramDefinition();
+
+    ProgramDefinition result = programDefinition.moveBlock(1L, ProgramDefinition.Direction.DOWN);
+
+    assertThat(result.blockDefinitions()).hasSize(3);
+    assertThat(result.getBlockDefinitionByIndex(0).get().isRepeated()).isFalse();
+    assertThat(result.getBlockDefinitionByIndex(1).get().isEnumerator()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(1).get().isRepeated()).isFalse();
+    assertThat(result.getBlockDefinitionByIndex(1).get().getQuestionDefinition(0))
+        .isEqualTo(testQuestionBank.applicantHouseholdMembers().getQuestionDefinition());
+    assertThat(result.getBlockDefinitionByIndex(2).get().isEnumerator()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(2).get().isRepeated()).isTrue();
+    assertThat(result.getBlockDefinitionByIndex(2).get().enumeratorId()).contains(1L);
+    assertThat(result.getBlockDefinitionByIndex(2).get().getQuestionDefinition(0))
+        .isEqualTo(testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition());
   }
 }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -397,7 +397,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
   }
 
   @Test
-  public void moveBlock_up() {
+  public void moveBlock_up() throws Exception {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()
@@ -425,7 +425,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
   }
 
   @Test
-  public void moveBlock_down() {
+  public void moveBlock_down() throws Exception {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram()
             .withBlock()


### PR DESCRIPTION
### Description
Adds:
1. `ProgramDefinition#moveBlock` to move blocks up and down
2. Adds a program block controller `move` method
3. Adds arrows to move blocks up and down in block edit view

Moves helper methods for moving blocks from `ProgramServiceImpl` into `ProgramDefinition`. This allows us to put have more thorough tests in `ProgramDefinitionTest`, and keep the logic in the controller and view very simple.

Random change: gets rid of `ViewUtils.POST` in favor of `HttpsVerbs.POST`.

### Screenshot

Before clicking the highlighted arrow on the second block named "enumerator"
![image](https://user-images.githubusercontent.com/12072571/121627021-7200ed80-ca2b-11eb-9a18-3a7b38e50709.png)

After clicking the arrow. It moves the whole enumerator section down.
![image](https://user-images.githubusercontent.com/12072571/121627077-8cd36200-ca2b-11eb-8c43-e45963c9969f.png)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Enables #1228 for story acceptance