### PR TITLE
Admin predicate form: Display the right scalars for question type

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -41,6 +41,42 @@ public enum Scalar {
   UPDATED_AT,
   PROGRAM_UPDATED_IN;
 
+  @Override
+  public String toString() {
+    switch (this) {
+      case CITY:
+        return "city";
+      case DATE:
+        return "date";
+      case EMAIL:
+        return "email";
+      case FILE_KEY:
+        return "file key";
+      case FIRST_NAME:
+        return "first name";
+      case LAST_NAME:
+        return "last name";
+      case LINE2:
+        return "address line 2";
+      case MIDDLE_NAME:
+        return "middle name";
+      case NUMBER:
+        return "number";
+      case SELECTION:
+        return "selection";
+      case STATE:
+        return "state";
+      case STREET:
+        return "street";
+      case TEXT:
+        return "text";
+      case ZIP:
+        return "ZIP code";
+      default:
+        return this.toString();
+    }
+  }
+
   private static final ImmutableMap<Scalar, ScalarType> ADDRESS_SCALARS =
       ImmutableMap.of(
           STREET, ScalarType.STRING,

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -18,63 +18,38 @@ import services.question.types.ScalarType;
  * <p>EXISTING SCALARS SHOULD NOT BE MODIFIED. The Scalar enum should be treated as append-only.
  */
 public enum Scalar {
-  CITY,
-  DATE,
-  EMAIL,
-  FILE_KEY,
-  FIRST_NAME,
-  LAST_NAME,
-  LINE2,
-  MIDDLE_NAME,
-  NUMBER,
-  SELECTION,
-  STATE,
-  STREET,
-  TEXT,
-  ZIP,
+  CITY("city"),
+  DATE("date"),
+  EMAIL("email"),
+  FILE_KEY("file key"),
+  FIRST_NAME("first name"),
+  LAST_NAME("last name"),
+  LINE2("address line 2"),
+  MIDDLE_NAME("middle name"),
+  NUMBER("number"),
+  SELECTION("selection"),
+  STATE("state"),
+  STREET("street"),
+  TEXT("text"),
+  ZIP("ZIP code"),
 
   // Special scalars for Enumerator updates
-  DELETE_ENTITY, // This is used for deleting enumerator entries
-  ENTITY_NAME, // This is used for adding/updating enumerator entries
+  DELETE_ENTITY("delete entity"), // This is used for deleting enumerator entries
+  ENTITY_NAME("entity name"), // This is used for adding/updating enumerator entries
 
   // Metadata scalars
-  UPDATED_AT,
-  PROGRAM_UPDATED_IN;
+  UPDATED_AT("updated at"),
+  PROGRAM_UPDATED_IN("program updated in");
 
-  @Override
-  public String toString() {
-    switch (this) {
-      case CITY:
-        return "city";
-      case DATE:
-        return "date";
-      case EMAIL:
-        return "email";
-      case FILE_KEY:
-        return "file key";
-      case FIRST_NAME:
-        return "first name";
-      case LAST_NAME:
-        return "last name";
-      case LINE2:
-        return "address line 2";
-      case MIDDLE_NAME:
-        return "middle name";
-      case NUMBER:
-        return "number";
-      case SELECTION:
-        return "selection";
-      case STATE:
-        return "state";
-      case STREET:
-        return "street";
-      case TEXT:
-        return "text";
-      case ZIP:
-        return "ZIP code";
-      default:
-        return this.toString();
-    }
+  private final String displayString;
+
+  /** The displayString should only be used in the Admin UI, since it is not localized. */
+  Scalar(String displayString) {
+    this.displayString = displayString;
+  }
+
+  public String getDisplayString() {
+    return this.displayString;
   }
 
   private static final ImmutableMap<Scalar, ScalarType> ADDRESS_SCALARS =

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -48,7 +48,7 @@ public enum Scalar {
     this.displayString = displayString;
   }
 
-  public String getDisplayString() {
+  public String toDisplayString() {
     return this.displayString;
   }
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -273,12 +273,13 @@ public abstract class ProgramDefinition {
    * Returns a list of the question definitions that may be used to define predicates on the block
    * definition with the given ID.
    *
-   * <p>The available question definitions for predicates satisfy BOTH of the following:
+   * <p>The available question definitions for predicates satisfy ALL of the following:
    *
    * <ul>
    *   <li>In a block definition that comes sequentially before the given block definition.
    *   <li>In a block definition that either has the same enumerator ID as the given block
    *       definition, or has the same enumerator ID as some "parent" of the given block definition.
+   *   <li>Is not an enumerator.
    * </ul>
    */
   public ImmutableList<QuestionDefinition> getAvailablePredicateQuestionDefinitions(long blockId)
@@ -290,6 +291,7 @@ public abstract class ProgramDefinition {
       builder.addAll(
           blockDefinition.programQuestionDefinitions().stream()
               .map(ProgramQuestionDefinition::getQuestionDefinition)
+              .filter(qd -> !qd.isEnumerator())
               .collect(Collectors.toList()));
     }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -122,7 +122,6 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
 
     ImmutableList.Builder<SimpleEntry<String, String>> scalarOptionsBuilder =
         ImmutableList.builder();
-
     scalars.forEach(
         (scalar, type) -> {
           scalarOptionsBuilder.add(new SimpleEntry<>(scalar.toString(), scalar.toString()));
@@ -141,7 +140,6 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
 
       valueField =
           new SelectWithLabel().setLabelText("Value").setOptions(valueOptions).getContainer();
-
     } else {
       valueField = FieldWithLabel.input().setLabelText("Value").getContainer();
     }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -125,7 +125,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
         ImmutableList.builder();
     scalars.forEach(
         (scalar, type) -> {
-          scalarOptionsBuilder.add(new SimpleEntry<>(scalar.getDisplayString(), scalar.name()));
+          scalarOptionsBuilder.add(new SimpleEntry<>(scalar.toDisplayString(), scalar.name()));
         });
 
     ContainerTag valueField;

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -116,6 +116,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
     try {
       scalars = Scalar.getScalars(questionDefinition.getQuestionType());
     } catch (InvalidQuestionTypeException | UnsupportedQuestionTypeException e) {
+      // This should never happen since we filter out Enumerator questions before this point.
       return div()
           .withText("Sorry, you cannot create a show/hide predicate with this question type.");
     }
@@ -124,11 +125,15 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
         ImmutableList.builder();
     scalars.forEach(
         (scalar, type) -> {
-          scalarOptionsBuilder.add(new SimpleEntry<>(scalar.toString(), scalar.toString()));
+          scalarOptionsBuilder.add(new SimpleEntry<>(scalar.getDisplayString(), scalar.name()));
         });
 
     ContainerTag valueField;
     if (questionDefinition.getQuestionType().isMultiOptionType()) {
+      // If it's a multi-option question, we need to provide a discrete list of possible values to
+      // choose from instead of a freeform text field. Not only is it a better UX, but we store the
+      // ID of the options rather than the display strings since the option display strings are
+      // localized.
       ImmutableList<SimpleEntry<String, String>> valueOptions =
           ((MultiOptionQuestionDefinition) questionDefinition)
               .getOptions().stream()

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -104,7 +104,7 @@ public final class BaseStyles {
           Styles.ROUNDED_XL,
           Styles.SHADOW_XL,
           Styles.BG_WHITE,
-          Styles.W_1_3,
+          Styles.W_AUTO,
           Styles.MAX_H_SCREEN,
           Styles.OVERFLOW_Y_AUTO);
 


### PR DESCRIPTION
Also:
* Fix the "Value" field for multi-option questions. Now the admin will see a dropdown of options for the "Value" instead of a freeform input box.
* Don't include enumerator questions in the list of available predicate question definitions. This is because enumerators do not have any "scalar" values associated with them. If we want to support predicates based on enumerator questions, it will take a bit more design and special case implementation. This is not in scope for the current goal.

### Screenshots
![Screen Shot 2021-06-11 at 1 40 00 PM](https://user-images.githubusercontent.com/5732310/121746307-8809bf00-caba-11eb-8159-875e0caac59b.png)
![Screen Shot 2021-06-11 at 1 40 22 PM](https://user-images.githubusercontent.com/5732310/121746329-935cea80-caba-11eb-8e3e-ed9f77736e09.png)

### Checklist
- [ ] Created tests which fail without the change (if possible)
  - Will add browser tests for this flow once it's working e2e. 
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #322 
