### PR TITLE
Added Dropdown null state

### DIFF
--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -31,6 +31,7 @@ public enum MessageKey {
   CONTENT_GET_BENEFITS("content.benefits"),
   CONTENT_PLEASE_CREATE_ACCOUNT("content.pleaseCreateAccount"),
   CONTENT_SELECT_LANGUAGE("label.selectLanguage"),
+  DROPDOWN_PLACEHOLDER("placeholder.noDropdownSelection"),
   ENUMERATOR_BUTTON_ADD_ENTITY("button.addEntity"),
   ENUMERATOR_BUTTON_REMOVE_ENTITY("button.removeEntity"),
   ENUMERATOR_PLACEHOLDER_ENTITY_NAME("placeholder.entityName"),

--- a/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
@@ -72,6 +72,11 @@ public class SelectWithLabel extends FieldWithLabel {
 
   @Override
   public ContainerTag getContainer() {
+    Tag placeholder = option(placeholderText).withValue("").attr(Attr.HIDDEN);
+    if (this.fieldValue.isEmpty()) {
+      placeholder.attr(Attr.SELECTED);
+    }
+    ((ContainerTag) fieldTag).with(placeholder);
     for (SimpleEntry<String, String> option : this.options) {
       Tag optionTag = option(option.getKey()).withValue(option.getValue());
       if (option.getValue().equals(this.fieldValue)) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -7,6 +7,8 @@ import static j2html.TagCreator.select;
 
 import j2html.tags.Tag;
 import java.util.AbstractMap;
+import play.i18n.Messages;
+import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.SingleSelectQuestion;
 import views.components.SelectWithLabel;
@@ -24,12 +26,14 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
 
   @Override
   public Tag render(ApplicantQuestionRendererParams params) {
+    Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 
     SelectWithLabel select =
         new SelectWithLabel()
             .addReferenceClass("cf-dropdown-question")
             .setFieldName(singleSelectQuestion.getSelectionPath().toString())
+            .setPlaceholderText(messages.at(MessageKey.DROPDOWN_PLACEHOLDER.getKeyName()))
             .setOptions(
                 singleSelectQuestion.getOptions().stream()
                     .map(

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -127,6 +127,13 @@ validation.zipcodeRequired=Please enter valid ZIP code.
 validation.invalidZipcode=Please enter valid 5-digit ZIP code.
 validation.noPoBox=Please enter a valid address. We do not accept PO Boxes.
 
+#----------------------------------------------------------------------------------------------------------#
+# DROPDOWN QUESTION - text shown when answering a question where a user must select an option from a list. #
+#----------------------------------------------------------------------------------------------------------#
+
+# Placeholder text shown in a dropdown selector before the user has made a selection.
+placeholder.noDropdownSelection=Choose an option:
+
 #--------------------------------------------------------------------------------------------------------#
 # ENUMERATION QUESTION - text when viewing a question where a user must name entities, such as children. #
 #--------------------------------------------------------------------------------------------------------#

--- a/universal-application-tool-0.0.1/test/views/components/SelectWithLabelTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/SelectWithLabelTest.java
@@ -12,26 +12,35 @@ public class SelectWithLabelTest {
   public void createSelect_rendersSelect() {
     SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
     assertThat(selectWithLabel.getContainer().render()).contains("<select");
-    assertThat(selectWithLabel.getContainer().render()).doesNotContain("<option");
   }
 
   @Test
   public void createSelect_rendersOptions() {
     SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
     ImmutableList<SimpleEntry<String, String>> options =
-        ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
+            ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
     selectWithLabel.setOptions(options);
     assertThat(selectWithLabel.getContainer().render()).contains("<option");
+  }
+
+  @Test
+  public void createSelect_rendersPlaceholder() {
+    String placeholderText = "Placeholder text";
+    SelectWithLabel selectWithLabel =
+            new SelectWithLabel().setId("id").setPlaceholderText(placeholderText);
+    assertThat(selectWithLabel.getContainer().render()).contains(placeholderText);
+    assertThat(selectWithLabel.getContainer().render()).contains("hidden selected");
   }
 
   @Test
   public void createSelect_rendersSelectedOption() {
     SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
     ImmutableList<SimpleEntry<String, String>> options =
-        ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
+            ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
     selectWithLabel.setOptions(options);
     selectWithLabel.setValue("b");
     assertThat(selectWithLabel.getContainer().render()).contains("<select");
-    assertThat(selectWithLabel.getContainer().render()).contains("selected");
+    assertThat(selectWithLabel.getContainer().render()).contains("value=\"b\" selected");
+    assertThat(selectWithLabel.getContainer().render()).doesNotContain("hidden selected");
   }
 }

--- a/universal-application-tool-0.0.1/test/views/components/SelectWithLabelTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/SelectWithLabelTest.java
@@ -18,7 +18,7 @@ public class SelectWithLabelTest {
   public void createSelect_rendersOptions() {
     SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
     ImmutableList<SimpleEntry<String, String>> options =
-            ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
+        ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
     selectWithLabel.setOptions(options);
     assertThat(selectWithLabel.getContainer().render()).contains("<option");
   }
@@ -27,7 +27,7 @@ public class SelectWithLabelTest {
   public void createSelect_rendersPlaceholder() {
     String placeholderText = "Placeholder text";
     SelectWithLabel selectWithLabel =
-            new SelectWithLabel().setId("id").setPlaceholderText(placeholderText);
+        new SelectWithLabel().setId("id").setPlaceholderText(placeholderText);
     assertThat(selectWithLabel.getContainer().render()).contains(placeholderText);
     assertThat(selectWithLabel.getContainer().render()).contains("hidden selected");
   }
@@ -36,7 +36,7 @@ public class SelectWithLabelTest {
   public void createSelect_rendersSelectedOption() {
     SelectWithLabel selectWithLabel = new SelectWithLabel().setId("id");
     ImmutableList<SimpleEntry<String, String>> options =
-            ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
+        ImmutableList.of(new SimpleEntry<String, String>("a", "b"));
     selectWithLabel.setOptions(options);
     selectWithLabel.setValue("b");
     assertThat(selectWithLabel.getContainer().render()).contains("<select");

--- a/universal-application-tool-0.0.1/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -1,0 +1,77 @@
+package views.questiontypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import j2html.tags.Tag;
+import java.util.Locale;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import play.i18n.Lang;
+import play.i18n.Messages;
+import play.i18n.MessagesApi;
+import repository.WithPostgresContainer;
+import services.LocalizedStrings;
+import services.applicant.ApplicantData;
+import services.applicant.question.ApplicantQuestion;
+import services.question.QuestionOption;
+import services.question.types.DropdownQuestionDefinition;
+import support.QuestionAnswerer;
+
+public class DropdownQuestionRendererTest extends WithPostgresContainer {
+
+  private static final DropdownQuestionDefinition QUESTION =
+      new DropdownQuestionDefinition(
+          "favorite ice cream",
+          Optional.empty(),
+          "description",
+          LocalizedStrings.of(Locale.US, "question?"),
+          LocalizedStrings.of(Locale.US, "help text"),
+          ImmutableList.of(
+              QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "chocolate")),
+              QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "peanut butter")),
+              QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "vanilla")),
+              QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "raspberry"))));
+
+  private final ApplicantData applicantData = new ApplicantData();
+
+  private ApplicantQuestion question;
+  private Messages messages;
+  private ApplicantQuestionRendererParams params;
+  private DropdownQuestionRenderer renderer;
+
+  @Before
+  public void setup() {
+    question = new ApplicantQuestion(QUESTION, applicantData, Optional.empty());
+    messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
+    params = ApplicantQuestionRendererParams.sample(messages);
+    renderer = new DropdownQuestionRenderer(question);
+  }
+
+  @Test
+  public void render_generatesCorrectInputNames() {
+    Tag result = renderer.render(params);
+
+    assertThat(result.render()).contains("name=\"applicant.favorite_ice_cream.selection\"");
+    assertThat(result.render()).contains("value=\"2\"");
+  }
+
+  @Test
+  public void render_withExistingAnswer_selectsThatOption() {
+    QuestionAnswerer.answerSingleSelectQuestion(
+        applicantData, question.getContextualizedPath(), 2L);
+    Tag result = renderer.render(params);
+
+    assertThat(result.render()).contains("<option value=\"2\" selected");
+  }
+
+  @Test
+  public void render_noExistingAnswer_selectsPlaceholder() {
+    Tag result = renderer.render(params);
+
+    assertThat(result.render()).contains("hidden selected");
+    assertThat(result.render()).contains("Choose an option");
+  }
+}


### PR DESCRIPTION
### Description
I added an option to the dropdown with text "Choose an option:" that will only show when nothing is selected.  Once a user has selected an option, the "choose" option will be not be visible or selectable any more.  The user is able to skip the dropdown question and submit the application if they leave the "choose" option selected.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1244 

<img width="489" alt="Capture" src="https://user-images.githubusercontent.com/1851626/121758986-8b13a800-cad8-11eb-8375-67d28334a098.PNG">