### PR TITLE
Restrict file access to the explicit applicant or program

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/FileController.java
+++ b/universal-application-tool-0.0.1/app/controllers/FileController.java
@@ -39,6 +39,10 @@ public class FileController extends CiviFormController {
     return checkApplicantAuthorization(profileUtils, request, applicantId)
         .thenApplyAsync(
             v -> {
+              // Ensure the file being accessed indeed belongs to the applicant.
+              if (!fileKey.contains(String.format("applicant-%d", applicantId))) {
+                return notFound();
+              }
               return redirect(amazonS3Client.getPresignedUrl(fileKey).toString());
             },
             httpExecutionContext.current())
@@ -59,6 +63,10 @@ public class FileController extends CiviFormController {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
       checkProgramAdminAuthorization(profileUtils, request, program.adminName()).join();
+      // Ensure the file being accessed indeed belongs to the program.
+      if (!fileKey.contains(String.format("program-%d", programId))) {
+        return notFound();
+      }
       return redirect(amazonS3Client.getPresignedUrl(fileKey).toString());
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());

--- a/universal-application-tool-0.0.1/app/controllers/FileController.java
+++ b/universal-application-tool-0.0.1/app/controllers/FileController.java
@@ -40,6 +40,8 @@ public class FileController extends CiviFormController {
         .thenApplyAsync(
             v -> {
               // Ensure the file being accessed indeed belongs to the applicant.
+              // The key is generated when the applicant first uploaded the file, see below link.
+              // https://github.com/seattle-uat/civiform/blob/4d1e90fddd3d6da2c4a249f4f78442d08f9088d3/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java#L128
               if (!fileKey.contains(String.format("applicant-%d", applicantId))) {
                 return notFound();
               }

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -125,6 +125,10 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
   }
 
   private Tag renderFileUploadBlockSubmitForm(Params params) {
+    // Note: This key uniquely identifies the file to be uploaded by the applicant and will be
+    // persisted in DB. Other parts of the system rely on the format of the key, e.g. in
+    // FileController.java we check if a file can be accessed based on the key content, so be extra
+    // cautious if you want to change the format.
     String key =
         String.format(
             "applicant-%d/program-%d/block-%s",

--- a/universal-application-tool-0.0.1/test/controllers/FileControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/FileControllerTest.java
@@ -27,28 +27,39 @@ public class FileControllerTest extends WithMockedProfiles {
   @Test
   public void show_differentApplicant_returnsUnauthorizedResult() {
     Applicant applicant = createApplicantWithMockedProfile();
+    String fileKey = fakeFileKey(applicant.id, 1L);
     Request request = fakeRequest().build();
     Result result =
-        controller.show(request, applicant.id + 1, "fake-file-key").toCompletableFuture().join();
+        controller.show(request, applicant.id + 1, fileKey).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void show_differentFileKey_returnsNotFound() {
+    Applicant applicant = createApplicantWithMockedProfile();
+    String fileKey = fakeFileKey(applicant.id + 1, 1L);
+    Request request = fakeRequest().build();
+    Result result = controller.show(request, applicant.id, fileKey).toCompletableFuture().join();
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   @Test
   public void show_TIManagedApplicant_redirects() {
     Applicant managedApplicant = createApplicant();
     createTIWithMockedProfile(managedApplicant);
+    String fileKey = fakeFileKey(managedApplicant.id, 1L);
     Request request = fakeRequest().build();
     Result result =
-        controller.show(request, managedApplicant.id, "fake-file-key").toCompletableFuture().join();
+        controller.show(request, managedApplicant.id, fileKey).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   @Test
   public void show_redirects() {
     Applicant applicant = createApplicantWithMockedProfile();
+    String fileKey = fakeFileKey(applicant.id, 1L);
     Request request = fakeRequest().build();
-    Result result =
-        controller.show(request, applicant.id, "fake-file-key").toCompletableFuture().join();
+    Result result = controller.show(request, applicant.id, fileKey).toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
@@ -56,8 +67,9 @@ public class FileControllerTest extends WithMockedProfiles {
   public void adminShow_invalidProgram_returnsNotFound() {
     Program program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
+    String fileKey = fakeFileKey(1L, program.id);
     Request request = fakeRequest().build();
-    Result result = controller.adminShow(request, program.id + 1, "fake-file-key");
+    Result result = controller.adminShow(request, program.id + 1, fileKey);
     assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
@@ -66,9 +78,20 @@ public class FileControllerTest extends WithMockedProfiles {
     Program programOne = ProgramBuilder.newDraftProgram("one").build();
     Program programTwo = ProgramBuilder.newDraftProgram("two").build();
     createProgramAdminWithMockedProfile(programOne);
+    String fileKey = fakeFileKey(1L, programTwo.id);
     Request request = fakeRequest().build();
-    Result result = controller.adminShow(request, programTwo.id, "fake-file-key");
+    Result result = controller.adminShow(request, programTwo.id, fileKey);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
+  public void adminShow_differentFileKey_returnsNotFound() {
+    Program program = ProgramBuilder.newDraftProgram().build();
+    createProgramAdminWithMockedProfile(program);
+    String fileKey = fakeFileKey(1L, program.id + 1);
+    Request request = fakeRequest().build();
+    Result result = controller.adminShow(request, program.id, fileKey);
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 
   @Test
@@ -76,8 +99,9 @@ public class FileControllerTest extends WithMockedProfiles {
     Program program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
     createGlobalAdminWithMockedProfile();
+    String fileKey = fakeFileKey(1L, program.id);
     Request request = fakeRequest().build();
-    Result result = controller.adminShow(request, program.id, "fake-file-key");
+    Result result = controller.adminShow(request, program.id, fileKey);
     assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
@@ -85,8 +109,9 @@ public class FileControllerTest extends WithMockedProfiles {
   public void adminShow_globalAdminWhenNoProgramAdmin_redirects() {
     Program program = ProgramBuilder.newDraftProgram().build();
     createGlobalAdminWithMockedProfile();
+    String fileKey = fakeFileKey(1L, program.id);
     Request request = fakeRequest().build();
-    Result result = controller.adminShow(request, program.id, "fake-file-key");
+    Result result = controller.adminShow(request, program.id, fileKey);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
@@ -94,8 +119,13 @@ public class FileControllerTest extends WithMockedProfiles {
   public void adminShow_redirects() {
     Program program = ProgramBuilder.newDraftProgram().build();
     createProgramAdminWithMockedProfile(program);
+    String fileKey = fakeFileKey(1L, program.id);
     Request request = fakeRequest().build();
-    Result result = controller.adminShow(request, program.id, "fake-file-key");
+    Result result = controller.adminShow(request, program.id, fileKey);
     assertThat(result.status()).isEqualTo(SEE_OTHER);
+  }
+
+  private String fakeFileKey(long applicantId, long programId) {
+    return String.format("applicant-%d/program-%d/block-0", applicantId, programId);
   }
 }


### PR DESCRIPTION
### Description
- Only file keys that contain the explicit applicant id or program id can be accessed through file controller.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1355 
