### PR TITLE
Only show relevant `Operator`s in predicate builder

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -159,10 +159,19 @@ function attachLineClampListeners() {
   applicationCardDescriptions.forEach(el => el.addEventListener("click", removeLineClamp));
 }
 
+function filterOperators(event: Event) {
+  // Filter the operators available for a given selected scalar.
+}
+
 window.addEventListener('load', (event) => {
   attachDropdown("create-question-button");
 
   attachLineClampListeners();
+
+  const scalarDropdown = document.getElementById("select-scalar");
+  if (scalarDropdown) {
+    scalarDropdown.addEventListener("change", filterOperators);
+  }
 
   // Submit button is disabled by default until program block edit form is changed
   const blockEditForm = document.getElementById("block-edit-form");

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -160,7 +160,19 @@ function attachLineClampListeners() {
 }
 
 function filterOperators(event: Event) {
-  // Filter the operators available for a given selected scalar.
+  const scalarDropdown = event.target as HTMLSelectElement;
+  const selectedScalarType = scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type;
+
+  // Filter the operators available for the given selected scalar type.
+  const operatorDropdown = document.getElementById("select-operator") as HTMLSelectElement;
+  Array.from(operatorDropdown.options).forEach(option => {
+    // Show by default.
+    option.classList.remove("hidden");
+    // If this operator is not for the currently selected type, hide it.
+    if (!option.classList.contains(selectedScalarType)) {
+      option.classList.add("hidden");
+    }
+  });
 }
 
 window.addEventListener('load', (event) => {

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -159,14 +159,23 @@ function attachLineClampListeners() {
   applicationCardDescriptions.forEach(el => el.addEventListener("click", removeLineClamp));
 }
 
+/**
+ * Filter the operators available for each scalar type based on the current scalar selected.
+ */
 function filterOperators(event: Event) {
+  // Get the type of scalar currently selected.
   const scalarDropdown = event.target as HTMLSelectElement;
   const selectedScalarType = scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type;
 
   // Filter the operators available for the given selected scalar type.
-  const operatorDropdown = document.getElementById("select-operator") as HTMLSelectElement;
+  const operatorDropdown =
+    scalarDropdown
+      .closest(".cf-predicate-options") // div containing all predicate builder dropdowns
+      .querySelector(".cf-operator-select") // div containing the operator dropdown
+      .querySelector("select") as HTMLSelectElement;
+
   Array.from(operatorDropdown.options).forEach(option => {
-    // Show by default.
+    // Remove any existing hidden class from previous filtering.
     option.classList.remove("hidden");
     // If this operator is not for the currently selected type, hide it.
     if (!option.classList.contains(selectedScalarType)) {
@@ -180,10 +189,10 @@ window.addEventListener('load', (event) => {
 
   attachLineClampListeners();
 
-  const scalarDropdown = document.getElementById("select-scalar");
-  if (scalarDropdown) {
-    scalarDropdown.addEventListener("change", filterOperators);
-  }
+  // Configure the admin predicate builder to filter available operators based on
+  // the type of scalar selected.
+  Array.from(document.querySelectorAll('.cf-scalar-select')).forEach(
+    el => el.addEventListener("input", filterOperators));
 
   // Submit button is disabled by default until program block edit form is changed
   const blockEditForm = document.getElementById("block-edit-form");

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -178,7 +178,7 @@ function filterOperators(event: Event) {
     // Remove any existing hidden class from previous filtering.
     option.classList.remove("hidden");
     // If this operator is not for the currently selected type, hide it.
-    if (!option.classList.contains(selectedScalarType)) {
+    if (!(selectedScalarType in option.dataset)) {
       option.classList.add("hidden");
     }
   });

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -476,6 +476,7 @@ public class ApplicantServiceImpl implements ApplicantService {
         case DATE:
           applicantData.putDate(currentPath, update.value());
           break;
+        case LIST_OF_STRINGS:
         case STRING:
           applicantData.putString(currentPath, update.value());
           break;

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -70,7 +70,7 @@ public enum Scalar {
       ImmutableMap.of(FILE_KEY, ScalarType.STRING);
 
   private static final ImmutableMap<Scalar, ScalarType> MULTI_SELECT_SCALARS =
-      ImmutableMap.of(SELECTION, ScalarType.STRING);
+      ImmutableMap.of(SELECTION, ScalarType.LIST_OF_STRINGS);
 
   private static final ImmutableMap<Scalar, ScalarType> NAME_SCALARS =
       ImmutableMap.of(

--- a/universal-application-tool-0.0.1/app/services/program/predicate/Operator.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/Operator.java
@@ -37,6 +37,10 @@ public enum Operator {
     return this.displayString;
   }
 
+  /**
+   * What type must the value on the left of the operator be? For example, "anyof" can only operate
+   * on a list, since it compares "does X list contain any of the values in Y list?"
+   */
   public ImmutableSet<ScalarType> getOperableTypes() {
     return this.operableTypes;
   }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/Operator.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/Operator.java
@@ -1,25 +1,32 @@
 package services.program.predicate;
 
+import com.google.common.collect.ImmutableSet;
+import services.question.types.ScalarType;
+
 /** Represents a JsonPath operator (https://github.com/json-path/JsonPath#filter-operators). */
 public enum Operator {
-  ANY_OF("anyof", "contains any of"),
-  EQUAL_TO("==", "is equal to"),
-  GREATER_THAN(">", "is greater than"),
-  GREATER_THAN_OR_EQUAL_TO(">=", "is greater than or equal to"),
-  IN("in", "is one of"),
-  LESS_THAN("<", "is less than"),
-  LESS_THAN_OR_EQUAL_TO("<=", "is less than or equal to"),
-  NONE_OF("noneof", "is none of"),
-  NOT_EQUAL_TO("!=", "is not equal to"),
-  NOT_IN("nin", "is not one of"),
-  SUBSET_OF("subsetof", "is a subset of");
+  ANY_OF("anyof", "contains any of", ImmutableSet.of(ScalarType.LIST_OF_STRINGS)),
+  EQUAL_TO("==", "is equal to", ImmutableSet.of(ScalarType.LONG, ScalarType.STRING)),
+  GREATER_THAN(">", "is greater than", ImmutableSet.of(ScalarType.LONG)),
+  GREATER_THAN_OR_EQUAL_TO(">=", "is greater than or equal to", ImmutableSet.of(ScalarType.LONG)),
+  IN("in", "is one of", ImmutableSet.of(ScalarType.STRING)),
+  IS_AFTER(">=", "is later than", ImmutableSet.of(ScalarType.DATE)),
+  IS_BEFORE("<=", "is earlier than", ImmutableSet.of(ScalarType.DATE)),
+  LESS_THAN("<", "is less than", ImmutableSet.of(ScalarType.LONG)),
+  LESS_THAN_OR_EQUAL_TO("<=", "is less than or equal to", ImmutableSet.of(ScalarType.LONG)),
+  NONE_OF("noneof", "is none of", ImmutableSet.of(ScalarType.LIST_OF_STRINGS)),
+  NOT_EQUAL_TO("!=", "is not equal to", ImmutableSet.of(ScalarType.LONG, ScalarType.STRING)),
+  NOT_IN("nin", "is not one of", ImmutableSet.of(ScalarType.STRING)),
+  SUBSET_OF("subsetof", "is a subset of", ImmutableSet.of(ScalarType.LIST_OF_STRINGS));
 
   private final String jsonPathOperator;
   private final String displayString;
+  private final ImmutableSet<ScalarType> operableTypes;
 
-  Operator(String jsonPathOperator, String displayString) {
+  Operator(String jsonPathOperator, String displayString, ImmutableSet<ScalarType> operableTypes) {
     this.jsonPathOperator = jsonPathOperator;
     this.displayString = displayString;
+    this.operableTypes = operableTypes;
   }
 
   public String toJsonPathOperator() {
@@ -28,5 +35,9 @@ public enum Operator {
 
   public String toDisplayString() {
     return this.displayString;
+  }
+
+  public ImmutableSet<ScalarType> getOperableTypes() {
+    return this.operableTypes;
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/types/ScalarType.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/ScalarType.java
@@ -8,6 +8,7 @@ package services.question.types;
  */
 public enum ScalarType {
   DATE,
+  LIST_OF_STRINGS,
   LONG,
   STRING;
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -205,7 +205,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
                     option(e.getKey().toDisplayString())
                         .withValue(e.getKey().name())
                         // Add the scalar type as data so we can determine which operators to allow.
-                        .withData("type", e.getValue().name()))
+                        .withData("type", e.getValue().name().toLowerCase()))
             .collect(toImmutableList());
 
     return new SelectWithLabel()
@@ -220,15 +220,15 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
         Arrays.stream(Operator.values())
             .map(
                 operator -> {
-                  // Add this operator's allowed scalar types as classes, so that we can determine
+                  // Add this operator's allowed scalar types as data, so that we can determine
                   // whether to show or hide each operator based on the current type of scalar
                   // selected.
-                  return option(operator.toDisplayString())
-                      .withValue(operator.name())
-                      .withClasses(
-                          operator.getOperableTypes().stream()
-                              .map(ScalarType::name)
-                              .toArray(String[]::new));
+                  ContainerTag option =
+                      option(operator.toDisplayString()).withValue(operator.name());
+                  operator
+                      .getOperableTypes()
+                      .forEach(type -> option.withData(type.name().toLowerCase(), type.name()));
+                  return option;
                 })
             .collect(toImmutableList());
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -227,7 +227,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
                       option(operator.toDisplayString()).withValue(operator.name());
                   operator
                       .getOperableTypes()
-                      .forEach(type -> option.withData(type.name().toLowerCase(), type.name()));
+                      .forEach(type -> option.attr("data-" + type.name().toLowerCase()));
                   return option;
                 })
             .collect(toImmutableList());

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -168,6 +168,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
                 .withClasses(Styles.FLEX, Styles.FLEX_ROW, Styles.GAP_1)
                 .with(
                     new SelectWithLabel()
+                        .setId("select-scalar")
                         .setLabelText("Scalar")
                         .setOptions(scalarOptions)
                         .getContainer())

--- a/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
@@ -86,15 +86,16 @@ public class SelectWithLabel extends FieldWithLabel {
 
   @Override
   public ContainerTag getContainer() {
+    Tag placeholder = option(placeholderText).withValue("").attr(Attr.HIDDEN);
+    if (this.fieldValue.isEmpty()) {
+      placeholder.attr(Attr.SELECTED);
+    }
+    ((ContainerTag) fieldTag).with(placeholder);
+
+    // Either set the options to be custom options or create options from the (text, value) pairs.
     if (!this.customOptions.isEmpty()) {
       this.customOptions.forEach(option -> ((ContainerTag) fieldTag).with(option));
     } else {
-      Tag placeholder = option(placeholderText).withValue("").attr(Attr.HIDDEN);
-      if (this.fieldValue.isEmpty()) {
-        placeholder.attr(Attr.SELECTED);
-      }
-      ((ContainerTag) fieldTag).with(placeholder);
-
       this.options.forEach(
           (text, value) -> {
             Tag optionTag = option(text).withValue(value);

--- a/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
@@ -3,6 +3,7 @@ package views.components;
 import static j2html.TagCreator.option;
 import static j2html.TagCreator.select;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
@@ -11,6 +12,7 @@ import j2html.tags.Tag;
 public class SelectWithLabel extends FieldWithLabel {
 
   private ImmutableMap<String, String> options = ImmutableMap.of();
+  private ImmutableList<ContainerTag> customOptions = ImmutableList.of();
 
   public SelectWithLabel() {
     super(select());
@@ -28,6 +30,15 @@ public class SelectWithLabel extends FieldWithLabel {
    */
   public SelectWithLabel setOptions(ImmutableMap<String, String> options) {
     this.options = options;
+    return this;
+  }
+
+  /**
+   * If you want more flexibility over your options (for example, if you want to add individual
+   * classes or other attributes), set custom options here.
+   */
+  public SelectWithLabel setCustomOptions(ImmutableList<ContainerTag> options) {
+    this.customOptions = options;
     return this;
   }
 
@@ -75,20 +86,24 @@ public class SelectWithLabel extends FieldWithLabel {
 
   @Override
   public ContainerTag getContainer() {
-    Tag placeholder = option(placeholderText).withValue("").attr(Attr.HIDDEN);
-    if (this.fieldValue.isEmpty()) {
-      placeholder.attr(Attr.SELECTED);
-    }
-    ((ContainerTag) fieldTag).with(placeholder);
+    if (!this.customOptions.isEmpty()) {
+      this.customOptions.forEach(option -> ((ContainerTag) fieldTag).with(option));
+    } else {
+      Tag placeholder = option(placeholderText).withValue("").attr(Attr.HIDDEN);
+      if (this.fieldValue.isEmpty()) {
+        placeholder.attr(Attr.SELECTED);
+      }
+      ((ContainerTag) fieldTag).with(placeholder);
 
-    this.options.forEach(
-        (text, value) -> {
-          Tag optionTag = option(text).withValue(value);
-          if (value.equals(this.fieldValue)) {
-            optionTag.attr(Attr.SELECTED);
-          }
-          ((ContainerTag) fieldTag).with(optionTag);
-        });
+      this.options.forEach(
+          (text, value) -> {
+            Tag optionTag = option(text).withValue(value);
+            if (value.equals(this.fieldValue)) {
+              optionTag.attr(Attr.SELECTED);
+            }
+            ((ContainerTag) fieldTag).with(optionTag);
+          });
+    }
 
     return super.getContainer();
   }

--- a/universal-application-tool-0.0.1/app/views/style/ReferenceClasses.java
+++ b/universal-application-tool-0.0.1/app/views/style/ReferenceClasses.java
@@ -14,6 +14,9 @@ public final class ReferenceClasses {
   public static final String ADMIN_TI_GROUP_ROW = "cf-ti-row";
   public static final String ADMIN_VERSION_CARD = "cf-admin-version-card";
   public static final String QUESTION_CONFIG = "cf-question-config";
+  public static final String PREDICATE_SCALAR_SELECT = "cf-scalar-select";
+  public static final String PREDICATE_OPERATOR_SELECT = "cf-operator-select";
+  public static final String PREDICATE_OPTIONS = "cf-predicate-options";
 
   public static final String QUESTION_BANK_ELEMENT = "cf-question-bank-element";
 


### PR DESCRIPTION
### Description
1. Allow setting custom options in `SelectWithLabel`
2. Add a `LIST_OF_STRINGS` scalar type - this is only used by multi-select questions but helps when filtering operators to just those that operate on lists
2. Add the `ScalarType` as a data attribute to each `Scalar`. When a scalar is selected, show only the operators that can act on that scalar's type
3. Add two operators for dates - we compare timestamps, so in reality they are just < and >, but are clearer to use for the admin

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#322 
