### PR TITLE
Load inactive program definitions properly

### DIFF
--- a/browser-test/src/application_previous_version.test.ts
+++ b/browser-test/src/application_previous_version.test.ts
@@ -1,0 +1,53 @@
+import { startSession, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
+
+describe('view an application in an older version', () => {
+  it('create an application, and create a new version of the program, and view the application in the old version of the program', async () => {
+    const { browser, page } = await startSession()
+    page.setDefaultTimeout(5000);
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+    const adminPrograms = new AdminPrograms(page);
+
+    // Create a program with one question
+    const questionName = 'text-to-be-obsolete-q';
+    await adminQuestions.addTextQuestion(questionName);
+    const programName = 'program with previous applications';
+    await adminPrograms.addAndPublishProgramWithQuestions([questionName], programName);
+
+    await logout(page);
+    await loginAsTestUser(page);
+    await selectApplicantLanguage(page, 'English');
+    const applicantQuestions = new ApplicantQuestions(page);
+    await applicantQuestions.validateHeader('en-US');
+
+    // Submit an application to the program
+    await applicantQuestions.applyProgram(programName);
+    await applicantQuestions.answerTextQuestion('some text');
+    await applicantQuestions.clickNext();
+    await applicantQuestions.submitFromReviewPage(programName);
+
+    await logout(page);
+    await loginAsAdmin(page);
+
+    // See the application in admin page
+    await adminPrograms.viewApplications(programName);
+    await adminPrograms.viewApplicationForApplicant(userDisplayName());
+    await adminPrograms.expectApplicationAnswers('Block 1', questionName, 'some text');
+
+    await logout(page);
+    await loginAsAdmin(page);
+
+    // Create a new version of the question and program
+    await adminQuestions.createNewVersion(questionName);
+    await adminPrograms.publishProgram(programName);
+
+    // See the application in admin page in the old version
+    await adminPrograms.viewApplications(programName);
+    await adminPrograms.viewApplicationsInOldVersion();
+    await adminPrograms.viewApplicationForApplicant(userDisplayName());
+    await adminPrograms.expectApplicationAnswers('Block 1', questionName, 'some text');
+
+    await endSession(browser);
+  })
+})

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -177,7 +177,11 @@ export class AdminPrograms {
   }
 
   async viewApplications(programName: string) {
-    await this.page.click(this.selectWithinProgramCard(programName, 'ACTIVE', ':text("Applications")'));
+    await this.page.click(this.selectWithinProgramCard(programName, 'ACTIVE', 'a:text("Applications")'));
+  }
+
+  async viewApplicationsInOldVersion() {
+    await this.page.click('a:text("Applications")');
   }
 
   selectApplicationCardForApplicant(applicantName: string) {
@@ -197,7 +201,7 @@ export class AdminPrograms {
   }
 
   async viewApplicationForApplicant(applicantName: string) {
-    await this.page.click(this.selectWithinApplicationForApplicant(applicantName, ':text("View")'));
+    await this.page.click(this.selectWithinApplicationForApplicant(applicantName, 'a:text("View")'));
   }
 
   async expectApplicationAnswers(blockName: string, questionName: string, answer: string) {

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -27,7 +27,7 @@ public interface ProgramService {
    *
    * <p>This method loads question definitions for all block definitions from a version the program
    * is in. If the program contains a question that is not in any versions associated with the
-   * program, a {@link QuestionNotFoundException} is thrown.
+   * program, a `RuntimeException` is thrown caused by an unexpected QuestionNotFoundException.
    *
    * @param id the ID of the program to retrieve
    * @return the {@link ProgramDefinition} for the given ID if it exists

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -25,6 +25,10 @@ public interface ProgramService {
   /**
    * Get the definition for a given program.
    *
+   * <p>This method loads question definitions for all block definitions from a version the program
+   * is in. If the program contains a question that is not in any versions associated with the
+   * program, a {@link QuestionNotFoundException} is thrown.
+   *
    * @param id the ID of the program to retrieve
    * @return the {@link ProgramDefinition} for the given ID if it exists
    * @throws ProgramNotFoundException when ID does not correspond to a real Program

--- a/universal-application-tool-0.0.1/app/services/question/QuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import models.QuestionTag;
+import models.Version;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.question.exceptions.InvalidUpdateException;
@@ -21,9 +22,15 @@ public interface QuestionService {
 
   /**
    * Get a {@link ReadOnlyQuestionService} which implements synchronous, in-memory read behavior for
-   * questions.
+   * questions in current active and draft versions.
    */
   CompletionStage<ReadOnlyQuestionService> getReadOnlyQuestionService();
+
+  /**
+   * Get a {@link ReadOnlyQuestionService} which implements synchronous, in-memory read behavior for
+   * questions in a particular version.
+   */
+  ReadOnlyQuestionService getReadOnlyVersionedQuestionService(Version version);
 
   /**
    * Creates a new Question Definition. Returns a QuestionDefinition object on success and {@link

--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -16,13 +16,13 @@ import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
-public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionService {
+public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestionService {
 
   private final ImmutableMap<Long, QuestionDefinition> questionsById;
   private final ImmutableSet<QuestionDefinition> upToDateQuestions;
   private final ActiveAndDraftQuestions activeAndDraftQuestions;
 
-  public ReadOnlyQuestionServiceImpl(Version activeVersion, Version draftVersion) {
+  public ReadOnlyCurrentQuestionServiceImpl(Version activeVersion, Version draftVersion) {
     checkNotNull(activeVersion);
     checkState(
         activeVersion.getLifecycleStage().equals(LifecycleStage.ACTIVE),
@@ -91,9 +91,6 @@ public final class ReadOnlyQuestionServiceImpl implements ReadOnlyQuestionServic
         .map(questionDefinition -> (EnumeratorQuestionDefinition) questionDefinition)
         .collect(ImmutableList.toImmutableList());
   }
-
-  // TODO(https://github.com/seattle-uat/civiform/issues/673): delete this when question definitions
-  //  don't need paths
 
   @Override
   public QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException {

--- a/universal-application-tool-0.0.1/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -1,0 +1,60 @@
+package services.question;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import models.Question;
+import models.Version;
+import services.question.exceptions.QuestionNotFoundException;
+import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.QuestionDefinition;
+
+public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuestionService {
+
+  private final ImmutableMap<Long, QuestionDefinition> questionsById;
+
+  public ReadOnlyVersionedQuestionServiceImpl(Version version) {
+    questionsById =
+        version.getQuestions().stream()
+            .map(Question::getQuestionDefinition)
+            .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, qd -> qd));
+  }
+
+  @Override
+  public ActiveAndDraftQuestions getActiveAndDraftQuestions() {
+    throw new RuntimeException(
+        "ReadOnlyVersionedQuestionServiceImpl does not support getActiveAndDraftQuestions.");
+  }
+
+  @Override
+  public ImmutableList<QuestionDefinition> getAllQuestions() {
+    return questionsById.values().asList();
+  }
+
+  @Override
+  public ImmutableList<QuestionDefinition> getUpToDateQuestions() {
+    throw new RuntimeException(
+        "ReadOnlyVersionedQuestionServiceImpl does not support getUpToDateQuestions.");
+  }
+
+  @Override
+  public ImmutableList<EnumeratorQuestionDefinition> getUpToDateEnumeratorQuestions() {
+    throw new RuntimeException(
+        "ReadOnlyVersionedQuestionServiceImpl does not support getUpToDateEnumeratorQuestions.");
+  }
+
+  @Override
+  public ImmutableList<EnumeratorQuestionDefinition> getAllEnumeratorQuestions() {
+    return getAllQuestions().stream()
+        .filter(QuestionDefinition::isEnumerator)
+        .map(questionDefinition -> (EnumeratorQuestionDefinition) questionDefinition)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException {
+    if (questionsById.containsKey(id)) {
+      return questionsById.get(id);
+    }
+    throw new QuestionNotFoundException(id);
+  }
+}

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
@@ -15,12 +15,12 @@ import services.question.types.QuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.TestQuestionBank;
 
-public class ReadOnlyQuestionServiceImplTest {
+public class ReadOnlyCurrentQuestionServiceImplTest {
 
   private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
   private final ReadOnlyQuestionService emptyService =
-      new ReadOnlyQuestionServiceImpl(
+      new ReadOnlyCurrentQuestionServiceImpl(
           new Version(LifecycleStage.ACTIVE), new Version(LifecycleStage.DRAFT));
   private NameQuestionDefinition nameQuestion;
   private AddressQuestionDefinition addressQuestion;
@@ -40,7 +40,7 @@ public class ReadOnlyQuestionServiceImplTest {
         (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
     questions = ImmutableList.of(nameQuestion, addressQuestion, basicQuestion);
     service =
-        new ReadOnlyQuestionServiceImpl(
+        new ReadOnlyCurrentQuestionServiceImpl(
             new Version(LifecycleStage.ACTIVE) {
               @Override
               public ImmutableList<Question> getQuestions() {
@@ -68,7 +68,7 @@ public class ReadOnlyQuestionServiceImplTest {
         testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
 
     service =
-        new ReadOnlyQuestionServiceImpl(
+        new ReadOnlyCurrentQuestionServiceImpl(
             new Version(LifecycleStage.ACTIVE) {
               @Override
               public ImmutableList<Question> getQuestions() {

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyCurrentQuestionServiceImplTest.java
@@ -30,8 +30,6 @@ public class ReadOnlyCurrentQuestionServiceImplTest {
 
   @Before
   public void setupQuestions() {
-    // The tests mimic that the persisted questions are read into ReadOnlyQuestionService.
-    // Therefore, question ids cannot be empty.
     nameQuestion =
         (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
     addressQuestion =

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -1,0 +1,120 @@
+package services.question;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import models.LifecycleStage;
+import models.Question;
+import models.Version;
+import org.junit.Before;
+import org.junit.Test;
+import services.question.exceptions.QuestionNotFoundException;
+import services.question.types.AddressQuestionDefinition;
+import services.question.types.NameQuestionDefinition;
+import services.question.types.QuestionDefinition;
+import services.question.types.TextQuestionDefinition;
+import support.TestQuestionBank;
+
+public class ReadOnlyVersionedQuestionServiceImplTest {
+
+  private static final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+
+  private final ReadOnlyQuestionService emptyService =
+      new ReadOnlyVersionedQuestionServiceImpl(new Version(LifecycleStage.OBSOLETE));
+  private NameQuestionDefinition nameQuestion;
+  private AddressQuestionDefinition addressQuestion;
+  private TextQuestionDefinition basicQuestion;
+  private ImmutableList<QuestionDefinition> questions;
+  private ReadOnlyQuestionService service;
+
+  @Before
+  public void setupQuestions() {
+    // The tests mimic that the persisted questions are read into ReadOnlyQuestionService.
+    // Therefore, question ids cannot be empty.
+    nameQuestion =
+        (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
+    addressQuestion =
+        (AddressQuestionDefinition) testQuestionBank.applicantAddress().getQuestionDefinition();
+    basicQuestion =
+        (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+    questions = ImmutableList.of(nameQuestion, addressQuestion, basicQuestion);
+    service =
+        new ReadOnlyVersionedQuestionServiceImpl(
+            new Version(LifecycleStage.OBSOLETE) {
+              @Override
+              public ImmutableList<Question> getQuestions() {
+                return questions.stream()
+                    .map(q -> new Question(q))
+                    .collect(ImmutableList.toImmutableList());
+              }
+            });
+  }
+
+  @Test
+  public void getAll_returnsEmpty() {
+    assertThat(emptyService.getAllQuestions()).isEmpty();
+  }
+
+  @Test
+  public void getAllQuestions() {
+    assertThat(service.getAllQuestions().size()).isEqualTo(3);
+  }
+
+  @Test
+  public void getActiveAndDraftQuestions_notSupported() {
+    assertThatThrownBy(() -> service.getActiveAndDraftQuestions())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("does not support getActiveAndDraftQuestions");
+  }
+
+  @Test
+  public void getUpToDateQuestions_notSupported() {
+    assertThatThrownBy(() -> service.getUpToDateQuestions())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("does not support getUpToDateQuestions");
+  }
+
+  @Test
+  public void getUpToDateEnumeratorQuestions_notSupported() {
+    assertThatThrownBy(() -> service.getUpToDateEnumeratorQuestions())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("does not support getUpToDateEnumeratorQuestions");
+  }
+
+  @Test
+  public void getEnumeratorQuestions() {
+    QuestionDefinition enumeratorQuestion =
+        testQuestionBank.applicantHouseholdMembers().getQuestionDefinition();
+
+    service =
+        new ReadOnlyVersionedQuestionServiceImpl(
+            new Version(LifecycleStage.OBSOLETE) {
+              @Override
+              public ImmutableList<Question> getQuestions() {
+                return ImmutableList.<QuestionDefinition>builder()
+                    .addAll(questions)
+                    .add(enumeratorQuestion)
+                    .build()
+                    .stream()
+                    .map(q -> new Question(q))
+                    .collect(ImmutableList.toImmutableList());
+              }
+            });
+
+    assertThat(service.getAllEnumeratorQuestions().size()).isEqualTo(1);
+    assertThat(service.getAllEnumeratorQuestions().get(0)).isEqualTo(enumeratorQuestion);
+  }
+
+  @Test
+  public void getQuestionDefinition_byId() throws QuestionNotFoundException {
+    long questionId = nameQuestion.getId();
+    assertThat(service.getQuestionDefinition(questionId)).isEqualTo(nameQuestion);
+  }
+
+  @Test
+  public void getQuestionDefinition_notFound() throws QuestionNotFoundException {
+    assertThatThrownBy(() -> service.getQuestionDefinition(9999L))
+        .isInstanceOf(QuestionNotFoundException.class);
+  }
+}

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyVersionedQuestionServiceImplTest.java
@@ -30,8 +30,6 @@ public class ReadOnlyVersionedQuestionServiceImplTest {
 
   @Before
   public void setupQuestions() {
-    // The tests mimic that the persisted questions are read into ReadOnlyQuestionService.
-    // Therefore, question ids cannot be empty.
     nameQuestion =
         (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
     addressQuestion =


### PR DESCRIPTION
### Description
Create `ReadOnlyVersionedQuestionServiceImpl.java` to load all questions in a particular version. This enables loading inactive programs and questions.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Unblock #1334 
