### PR TITLE
Reordering block with predicate gives warning for illegal move

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -122,11 +122,11 @@ public class AdminProgramBlocksController extends CiviFormController {
     Direction direction = Direction.valueOf(requestData.get("direction"));
     try {
       programService.moveBlock(programId, blockId, direction);
-    } catch (ProgramNotFoundException e) {
-      return notFound(e.toString());
     } catch (IllegalBlockMoveException e) {
       return redirect(routes.AdminProgramBlocksController.edit(programId, blockId))
           .flashing("error", e.getLocalizedMessage());
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
     }
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
   }

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -16,6 +16,7 @@ import play.mvc.Result;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.program.BlockDefinition;
+import services.program.IllegalBlockMoveException;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
 import services.program.ProgramDefinition.Direction;
@@ -123,6 +124,9 @@ public class AdminProgramBlocksController extends CiviFormController {
       programService.moveBlock(programId, blockId, direction);
     } catch (ProgramNotFoundException e) {
       return notFound(e.toString());
+    } catch (IllegalBlockMoveException e) {
+      return redirect(routes.AdminProgramBlocksController.edit(programId, blockId))
+          .flashing("error", e.getLocalizedMessage());
     }
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
   }

--- a/universal-application-tool-0.0.1/app/services/program/IllegalBlockMoveException.java
+++ b/universal-application-tool-0.0.1/app/services/program/IllegalBlockMoveException.java
@@ -1,0 +1,8 @@
+package services.program;
+
+public class IllegalBlockMoveException extends Exception {
+
+  public IllegalBlockMoveException(String message) {
+    super(message);
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -191,6 +191,12 @@ public abstract class ProgramDefinition {
         blockSlice.startsBefore(otherBlockSlice) ? otherBlockSlice : blockSlice;
     ImmutableList.Builder<BlockDefinition> blocksBuilder = ImmutableList.builder();
 
+    ImmutableSet<Long> predicateQuestions =
+        blockDefinitions().subList(blockSlice.startIndex(), blockSlice.endIndex()).stream()
+            .filter(b -> b.visibilityPredicate().isPresent())
+            .flatMap(b -> b.visibilityPredicate().get().getQuestions().stream())
+            .collect(toImmutableSet());
+
     // Swap the two slices, assuming these slices are consecutive slices
     blockDefinitions().stream()
         .limit(earlierSlice.startIndex())

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -193,7 +193,7 @@ public abstract class ProgramDefinition {
     // An illegal move is when a predicate in a later block depends on an earlier block.
     // Get the questions used in any predicate in the latter block.
     ImmutableSet<Long> predicateQuestions =
-        blockDefinitions().subList(latterSlice.startIndex(), blockSlice.endIndex()).stream()
+        blockDefinitions().subList(latterSlice.startIndex(), latterSlice.endIndex()).stream()
             .filter(b -> b.visibilityPredicate().isPresent())
             .flatMap(b -> b.visibilityPredicate().get().getQuestions().stream())
             .collect(toImmutableSet());

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -147,7 +147,7 @@ public interface ProgramService {
    * @return the program definition, with the block moved if it is allowed.
    */
   ProgramDefinition moveBlock(long programId, long blockId, ProgramDefinition.Direction direction)
-      throws ProgramNotFoundException;
+      throws ProgramNotFoundException, IllegalBlockMoveException;
 
   /**
    * Update a {@link BlockDefinition}'s attributes.

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -261,7 +261,7 @@ public class ProgramServiceImpl implements ProgramService {
   @Transactional
   public ProgramDefinition moveBlock(
       long programId, long blockId, ProgramDefinition.Direction direction)
-      throws ProgramNotFoundException {
+      throws ProgramNotFoundException, IllegalBlockMoveException {
     Program program;
     try {
       program = getProgramDefinition(programId).moveBlock(blockId, direction).toProgram();

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
@@ -1,8 +1,11 @@
 package services.program.predicate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.collect.ImmutableSet;
 
 @AutoValue
 public abstract class PredicateDefinition {
@@ -19,4 +22,10 @@ public abstract class PredicateDefinition {
 
   @JsonProperty("action")
   public abstract PredicateAction action();
+
+  @JsonIgnore
+  @Memoized
+  public ImmutableSet<Long> getQuestions() {
+    return rootNode().getQuestions();
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
@@ -1,5 +1,7 @@
 package services.program.predicate;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -62,28 +64,19 @@ public abstract class PredicateExpressionNode {
   @JsonIgnore
   @Memoized
   public ImmutableSet<Long> getQuestions() {
-    ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
-    getQuestions(builder, this);
-    return builder.build();
-  }
-
-  private void getQuestions(
-      ImmutableSet.Builder<Long> builder, PredicateExpressionNode currentNode) {
-    switch (currentNode.getType()) {
-      case AND:
-        currentNode.getAndNode().children().stream()
-            .flatMap(child -> child.getQuestions().stream())
-            .forEach(builder::add);
-        break;
-      case OR:
-        currentNode.getOrNode().children().stream()
-            .flatMap(child -> child.getQuestions().stream())
-            .forEach(builder::add);
-        break;
+    switch (getType()) {
       case LEAF_OPERATION:
-        builder.add(currentNode.getLeafNode().questionId());
-        break;
+        return ImmutableSet.of(getLeafNode().questionId());
+      case AND:
+        return getAndNode().children().stream()
+            .flatMap(n -> n.getQuestions().stream())
+            .collect(toImmutableSet());
+      case OR:
+        return getOrNode().children().stream()
+            .flatMap(n -> n.getQuestions().stream())
+            .collect(toImmutableSet());
       default:
+        return ImmutableSet.of();
     }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.collect.ImmutableSet;
 
 /** Represents a predicate that can be evaluated over {@link services.applicant.ApplicantData}. */
 @AutoValue
@@ -56,5 +57,33 @@ public abstract class PredicateExpressionNode {
           String.format("Expected an OR node but received %s node", getType()));
     }
     return (OrNode) node();
+  }
+
+  @JsonIgnore
+  @Memoized
+  public ImmutableSet<Long> getQuestions() {
+    ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
+    getQuestions(builder, this);
+    return builder.build();
+  }
+
+  private void getQuestions(
+      ImmutableSet.Builder<Long> builder, PredicateExpressionNode currentNode) {
+    switch (currentNode.getType()) {
+      case AND:
+        currentNode.getAndNode().children().stream()
+            .flatMap(child -> child.getQuestions().stream())
+            .forEach(builder::add);
+        break;
+      case OR:
+        currentNode.getOrNode().children().stream()
+            .flatMap(child -> child.getQuestions().stream())
+            .forEach(builder::add);
+        break;
+      case LEAF_OPERATION:
+        builder.add(currentNode.getLeafNode().questionId());
+        break;
+      default:
+    }
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -112,6 +112,11 @@ public class ProgramBlockEditView extends BaseHtmlView {
                         questionBankPanel(questions, programDefinition, blockDefinition, csrfTag)))
             .addModals(blockDescriptionEditModal);
 
+    // Add toast messages
+    if (request.flash().get("error").isPresent()) {
+      htmlBundle.addToastMessages(
+          ToastMessage.error(request.flash().get("error").get()).setDuration(-1));
+    }
     if (message.length() > 0) {
       htmlBundle.addToastMessages(ToastMessage.error(message).setDismissible(false));
     }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -530,4 +530,29 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             "This move is not possible - it would move a block condition before the question it"
                 + " depends on");
   }
+
+  @Test
+  public void hasValidPredicateOrdering() {
+    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    predicateQuestion.id,
+                    Scalar.TEXT,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of("yellow"))),
+            PredicateAction.SHOW_BLOCK);
+
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(predicateQuestion)
+            .withBlock()
+            .withPredicate(predicate)
+            .build()
+            .getProgramDefinition();
+
+    assertThat(programDefinition.hasValidPredicateOrdering()).isTrue();
+  }
 }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -554,5 +554,40 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .getProgramDefinition();
 
     assertThat(programDefinition.hasValidPredicateOrdering()).isTrue();
+
+    programDefinition =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withPredicate(predicate)
+            .withBlock()
+            .withQuestion(predicateQuestion)
+            .build()
+            .getProgramDefinition();
+
+    assertThat(programDefinition.hasValidPredicateOrdering()).isFalse();
+  }
+
+  @Test
+  public void hasValidPredicateOrdering_returnsFalseIfQuestionsAreInSameBlockAsPredicate() {
+    Question predicateQuestion = testQuestionBank.applicantFavoriteColor();
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    predicateQuestion.id,
+                    Scalar.TEXT,
+                    Operator.EQUAL_TO,
+                    PredicateValue.of("yellow"))),
+            PredicateAction.SHOW_BLOCK);
+
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(predicateQuestion)
+            .withPredicate(predicate)
+            .build()
+            .getProgramDefinition();
+
+    assertThat(programDefinition.hasValidPredicateOrdering()).isFalse();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateExpressionNodeTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateExpressionNodeTest.java
@@ -1,0 +1,57 @@
+package services.program.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import services.applicant.question.Scalar;
+
+public class PredicateExpressionNodeTest {
+
+  @Test
+  public void getQuestions_leaf() {
+    LeafOperationExpressionNode leaf =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+
+    PredicateExpressionNode node = PredicateExpressionNode.create(leaf);
+
+    assertThat(node.getQuestions()).containsExactly(123L);
+  }
+
+  @Test
+  public void getQuestions_and() {
+    LeafOperationExpressionNode leaf1 =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+    LeafOperationExpressionNode leaf2 =
+        LeafOperationExpressionNode.create(
+            456L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+    AndNode and =
+        AndNode.create(
+            ImmutableSet.of(
+                PredicateExpressionNode.create(leaf1), PredicateExpressionNode.create(leaf2)));
+
+    PredicateExpressionNode node = PredicateExpressionNode.create(and);
+
+    assertThat(node.getQuestions()).containsExactly(123L, 456L);
+  }
+
+  @Test
+  public void getQuestions_or() {
+    LeafOperationExpressionNode leaf1 =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+    LeafOperationExpressionNode leaf2 =
+        LeafOperationExpressionNode.create(
+            456L, Scalar.SELECTION, Operator.EQUAL_TO, PredicateValue.of("hello"));
+    OrNode or =
+        OrNode.create(
+            ImmutableSet.of(
+                PredicateExpressionNode.create(leaf1), PredicateExpressionNode.create(leaf2)));
+
+    PredicateExpressionNode node = PredicateExpressionNode.create(or);
+
+    assertThat(node.getQuestions()).containsExactly(123L, 456L);
+  }
+}


### PR DESCRIPTION
### Description
Moving a block fails and gives an error in the following cases:
  1. I try to move a block with a predicate before its predicate question(s)
  1. I try to move block A, which has predicate question(s), after block B that has the predicate which depends on block A's questions

Details
1. Adds `getQuestions` to predicate definition, so we can get all the questions used for a particular block's predicate
2. Shows an error message if a block move fails

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#322 
<img width="1110" alt="Screen Shot 2021-06-16 at 3 44 11 PM" src="https://user-images.githubusercontent.com/8559046/122304267-cbe53580-ceb9-11eb-8af7-523244efcc26.png">
