### PR TITLE
Dedupe active programs and programs with draft applications

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
@@ -68,7 +68,7 @@ public class ApplicantProgramsController extends CiviFormController {
             allPrograms -> {
               Set<String> programsWithDraftApplication =
                   allPrograms.get(LifecycleStage.DRAFT).stream()
-                      .map(programDefinition -> programDefinition.adminName())
+                      .map(ProgramDefinition::adminName)
                       .collect(Collectors.toSet());
               ImmutableList<ProgramDefinition> dedupedActivePrograms =
                   allPrograms.get(LifecycleStage.ACTIVE).stream()
@@ -110,7 +110,7 @@ public class ApplicantProgramsController extends CiviFormController {
             allPrograms -> {
               Optional<ProgramDefinition> programDefinition =
                   allPrograms.values().stream()
-                      .flatMap(programs -> programs.stream())
+                      .flatMap(ImmutableList::stream)
                       .filter(program -> program.id() == programId)
                       .findFirst();
               if (programDefinition.isPresent()) {

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -79,11 +79,11 @@ public class UserRepository {
                   .endOr()
                   .findList()
                   .stream()
-                  .map(program -> program.getProgramDefinition())
+                  .map(Program::getProgramDefinition)
                   .collect(ImmutableList.toImmutableList());
           ImmutableList<ProgramDefinition> activePrograms =
               versionRepositoryProvider.get().getActiveVersion().getPrograms().stream()
-                  .map(program -> program.getProgramDefinition())
+                  .map(Program::getProgramDefinition)
                   .collect(ImmutableList.toImmutableList());
           return ImmutableMap.of(
               LifecycleStage.DRAFT, inProgressPrograms,

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -62,6 +62,8 @@ public enum MessageKey {
   TITLE_APPLICATION_CONFIRMATION("title.applicationConfirmation"),
   TITLE_CREATE_AN_ACCOUNT("title.createAnAccount"),
   TITLE_PROGRAMS("title.programs"),
+  TITLE_PROGRAMS_ACTIVE("title.activePrograms"),
+  TITLE_PROGRAMS_IN_PROGRESS("title.inProgressPrograms"),
   TITLE_PROGRAM_PREVIEW("title.programPreview"),
   TITLE_PROGRAM_REVIEW("title.programReview"),
   TOAST_APPLICATION_SAVED("toast.applicationSaved"),

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import models.Applicant;
 import models.Application;
+import models.LifecycleStage;
 import services.applicant.exception.ApplicationSubmissionException;
 import services.program.ProgramDefinition;
 
@@ -81,7 +82,8 @@ public interface ApplicantService {
    * Return all programs that are appropriate to serve to an applicant - which is any active
    * program, plus any program where they have an application in the draft stage.
    */
-  CompletionStage<ImmutableList<ProgramDefinition>> relevantPrograms(long applicantId);
+  CompletionStage<ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>>> relevantPrograms(
+      long applicantId);
 
   /** Return the name of the given applicant id. */
   CompletionStage<String> getName(long applicantId);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -81,6 +81,8 @@ public interface ApplicantService {
   /**
    * Return all programs that are appropriate to serve to an applicant - which is any active
    * program, plus any program where they have an application in the draft stage.
+   *
+   * <p>The programs do not have question definitions loaded into its program question definitions.
    */
   CompletionStage<ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>>> relevantPrograms(
       long applicantId);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.Applicant;
 import models.Application;
+import models.LifecycleStage;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.ApplicationRepository;
 import repository.UserRepository;
@@ -234,7 +235,8 @@ public class ApplicantServiceImpl implements ApplicantService {
   }
 
   @Override
-  public CompletionStage<ImmutableList<ProgramDefinition>> relevantPrograms(long applicantId) {
+  public CompletionStage<ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>>>
+      relevantPrograms(long applicantId) {
     return userRepository.programsForApplicant(applicantId);
   }
 

--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.h2;
+import static j2html.TagCreator.hr;
 import static j2html.attributes.Attr.HREF;
 
 import com.google.common.collect.ImmutableList;
@@ -46,8 +47,10 @@ public class ProgramIndexView extends BaseHtmlView {
    *
    * @param messages the localized {@link Messages} for the current applicant
    * @param applicantId the ID of the current applicant
-   * @param programs an {@link ImmutableList} of {@link ProgramDefinition}s with the most recent
-   *     published versions
+   * @param draftPrograms an {@link ImmutableList} of {@link ProgramDefinition}s which the applicant
+   *     has draft applications of
+   * @param activePrograms an {@link ImmutableList} of {@link ProgramDefinition}s with the most
+   *     recent published versions
    * @return HTML content for rendering the list of available programs
    */
   public Content render(
@@ -55,7 +58,8 @@ public class ProgramIndexView extends BaseHtmlView {
       Http.Request request,
       long applicantId,
       String userName,
-      ImmutableList<ProgramDefinition> programs,
+      ImmutableList<ProgramDefinition> draftPrograms,
+      ImmutableList<ProgramDefinition> activePrograms,
       Optional<String> banner) {
     HtmlBundle bundle = layout.getBundle();
     if (banner.isPresent()) {
@@ -66,7 +70,8 @@ public class ProgramIndexView extends BaseHtmlView {
             messages.at(MessageKey.CONTENT_GET_BENEFITS.getKeyName()),
             messages.at(MessageKey.CONTENT_CIVIFORM_DESCRIPTION_1.getKeyName()),
             messages.at(MessageKey.CONTENT_CIVIFORM_DESCRIPTION_2.getKeyName())),
-        mainContent(messages, programs, applicantId, messages.lang().toLocale()));
+        mainContent(
+            messages, draftPrograms, activePrograms, applicantId, messages.lang().toLocale()));
 
     return layout.renderWithNav(request, userName, messages, bundle);
   }
@@ -110,26 +115,53 @@ public class ProgramIndexView extends BaseHtmlView {
 
   private ContainerTag mainContent(
       Messages messages,
-      ImmutableList<ProgramDefinition> programs,
+      ImmutableList<ProgramDefinition> draftPrograms,
+      ImmutableList<ProgramDefinition> activePrograms,
       long applicantId,
       Locale preferredLocale) {
     return div()
-        .withId("main-content")
-        .withClasses(Styles.MX_6, Styles.MY_4, StyleUtils.responsiveSmall(Styles.M_10))
-        .with(
-            h2().withText(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName()))
-                .withClasses(Styles.BLOCK, Styles.MB_4, Styles.TEXT_LG, Styles.FONT_SEMIBOLD))
+        .withClasses(Styles.FLEX, Styles.JUSTIFY_CENTER)
         .with(
             div()
-                .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                .withId("main-content")
+                .withClasses(Styles.MX_AUTO, Styles.MY_4, StyleUtils.responsiveSmall(Styles.M_10))
                 .with(
-                    each(
-                        programs,
-                        program -> programCard(messages, program, applicantId, preferredLocale))));
+                    h2().withText(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName()))
+                        .withClasses(
+                            Styles.BLOCK, Styles.MB_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD))
+                .with(
+                    h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_IN_PROGRESS.getKeyName()))
+                        .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
+                .with(
+                    div()
+                        .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                        .with(
+                            each(
+                                draftPrograms,
+                                program ->
+                                    programCard(
+                                        messages, program, applicantId, preferredLocale, true))))
+                .with(hr())
+                .with(
+                    h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_ACTIVE.getKeyName()))
+                        .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
+                .with(
+                    div()
+                        .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                        .with(
+                            each(
+                                activePrograms,
+                                program ->
+                                    programCard(
+                                        messages, program, applicantId, preferredLocale, false)))));
   }
 
   private ContainerTag programCard(
-      Messages messages, ProgramDefinition program, Long applicantId, Locale preferredLocale) {
+      Messages messages,
+      ProgramDefinition program,
+      Long applicantId,
+      Locale preferredLocale,
+      boolean isDraft) {
     String baseId = ReferenceClasses.APPLICATION_CARD + "-" + program.id();
 
     ContainerTag title =
@@ -187,7 +219,10 @@ public class ProgramIndexView extends BaseHtmlView {
             .url();
     ContainerTag applyButton =
         a().attr(HREF, applyUrl)
-            .withText(messages.at(MessageKey.BUTTON_APPLY.getKeyName()))
+            .withText(
+                isDraft
+                    ? messages.at(MessageKey.BUTTON_CONTINUE.getKeyName())
+                    : messages.at(MessageKey.BUTTON_APPLY.getKeyName()))
             .withId(baseId + "-apply")
             .withClasses(ReferenceClasses.APPLY_BUTTON, ApplicantStyles.BUTTON_PROGRAM_APPLY);
 

--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -119,41 +119,48 @@ public class ProgramIndexView extends BaseHtmlView {
       ImmutableList<ProgramDefinition> activePrograms,
       long applicantId,
       Locale preferredLocale) {
-    return div()
-        .withClasses(Styles.FLEX, Styles.JUSTIFY_CENTER)
-        .with(
-            div()
-                .withId("main-content")
-                .withClasses(Styles.MX_AUTO, Styles.MY_4, StyleUtils.responsiveSmall(Styles.M_10))
-                .with(
-                    h2().withText(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName()))
-                        .withClasses(
-                            Styles.BLOCK, Styles.MB_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD))
-                .with(
-                    h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_IN_PROGRESS.getKeyName()))
-                        .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
-                .with(
-                    div()
-                        .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
-                        .with(
-                            each(
-                                draftPrograms,
-                                program ->
-                                    programCard(
-                                        messages, program, applicantId, preferredLocale, true))))
-                .with(hr())
-                .with(
-                    h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_ACTIVE.getKeyName()))
-                        .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
-                .with(
-                    div()
-                        .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
-                        .with(
-                            each(
-                                activePrograms,
-                                program ->
-                                    programCard(
-                                        messages, program, applicantId, preferredLocale, false)))));
+    ContainerTag content =
+        div()
+            .withId("main-content")
+            .withClasses(
+                Styles.MX_AUTO, Styles.MY_4, Styles.W_3_5, StyleUtils.responsiveSmall(Styles.M_10))
+            .with(
+                h2().withText(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName()))
+                    .withClasses(Styles.BLOCK, Styles.MB_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD));
+    if (!draftPrograms.isEmpty()) {
+      content
+          .with(
+              h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_IN_PROGRESS.getKeyName()))
+                  .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
+          .with(
+              div()
+                  .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                  .with(
+                      each(
+                          draftPrograms,
+                          program ->
+                              programCard(messages, program, applicantId, preferredLocale, true))));
+    }
+    if (!draftPrograms.isEmpty() && !activePrograms.isEmpty()) {
+      content.with(hr());
+    }
+    if (!activePrograms.isEmpty()) {
+      content
+          .with(
+              h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_ACTIVE.getKeyName()))
+                  .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
+          .with(
+              div()
+                  .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                  .with(
+                      each(
+                          activePrograms,
+                          program ->
+                              programCard(
+                                  messages, program, applicantId, preferredLocale, false))));
+    }
+
+    return div().withClasses(Styles.FLEX, Styles.JUSTIFY_CENTER).with(content);
   }
 
   private ContainerTag programCard(

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -41,7 +41,7 @@ public final class ApplicantStyles {
       StyleUtils.joinStyles(BaseStyles.TEXT_SEATTLE_BLUE, Styles.TEXT_LG, Styles.FONT_BOLD);
 
   public static final String PROGRAM_CARDS_CONTAINER =
-      StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_WRAP, Styles.GAP_4);
+      StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_WRAP, Styles.GAP_4, Styles.MB_16);
   public static final String PROGRAM_CARD =
       StyleUtils.joinStyles(
           Styles.INLINE_BLOCK,

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -75,7 +75,7 @@ title.programs=Programs & services
 # Subtitle for the list of programs with draft applications
 titles.inProgressPrograms=Continue
 
-# Subtitle for the list of active programs
+# Subtitle for the list of programs for which the applicant has no draft applications
 titles.activePrograms=New Programs
 
 # A toast message that displays when an applicant submits an application.

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -72,6 +72,12 @@ link.externalLink=External site
 # The title of the page for the list of programs.
 title.programs=Programs & services
 
+# Subtitle for the list of programs with draft applications
+titles.inProgressPrograms=Continue
+
+# Subtitle for the list of active programs
+titles.activePrograms=New Programs
+
 # A toast message that displays when an applicant submits an application.
 toast.applicationSaved=Successfully saved application: application ID {0}
 

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -31,6 +31,8 @@ title.programPreview=Program application preview
 title.programReview=Program application review
 
 title.programs=Programs & services
+title.inProgressPrograms=Continue
+title.activePrograms=New Programs
 link.programDetails=Program details
 link.externalLink=External site
 content.benefits=Get benefits

--- a/universal-application-tool-0.0.1/conf/messages.es-US
+++ b/universal-application-tool-0.0.1/conf/messages.es-US
@@ -29,6 +29,8 @@ title.programPreview=Vista previa del programa
 title.programReview=Revisión del programa
 
 title.programs=Programas y servicios
+title.inProgressPrograms=Seguir
+title.activePrograms=Nuevos Programas
 link.programDetails=Detalles del programa
 link.externalLink=Sitio externo
 content.benefits=Obtener beneficios

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -552,7 +552,8 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>> programs =
         subject.relevantPrograms(applicant.id).toCompletableFuture().join();
 
-    assertThat(programs.get(LifecycleStage.DRAFT).stream().map(ProgramDefinition::id)).containsExactly(p1.id);
+    assertThat(programs.get(LifecycleStage.DRAFT).stream().map(ProgramDefinition::id))
+        .containsExactly(p1.id);
     assertThat(programs.get(LifecycleStage.ACTIVE).stream().map(ProgramDefinition::id))
         .containsExactly(p1.id, p2.id);
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -535,18 +535,26 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void relevantPrograms_hasNoDuplicates() {
+  public void relevantPrograms() {
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
-    Program p1 = ProgramBuilder.newActiveProgram()
-        .withBlock().withQuestion(testQuestionBank.applicantName()).build();
-    Program p2 = ProgramBuilder.newActiveProgram()
-        .withBlock().withQuestion(testQuestionBank.applicantFavoriteColor()).build();
+    Program p1 =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantName())
+            .build();
+    Program p2 =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withQuestion(testQuestionBank.applicantFavoriteColor())
+            .build();
     applicationRepository.createOrUpdateDraft(applicant.id, p1.id).toCompletableFuture().join();
 
-    ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>> programs = subject.relevantPrograms(applicant.id).toCompletableFuture().join();
+    ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>> programs =
+        subject.relevantPrograms(applicant.id).toCompletableFuture().join();
 
-    assertThat(programs.get(LifecycleStage.DRAFT)).containsExactly(p1.getProgramDefinition());
-    assertThat(programs.get(LifecycleStage.ACTIVE)).containsExactly(p2.getProgramDefinition());
+    assertThat(programs.get(LifecycleStage.DRAFT).stream().map(p -> p.id())).containsExactly(p1.id);
+    assertThat(programs.get(LifecycleStage.ACTIVE).stream().map(p -> p.id()))
+        .containsExactly(p1.id, p2.id);
   }
 
   private void createQuestions() {

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -552,8 +552,8 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>> programs =
         subject.relevantPrograms(applicant.id).toCompletableFuture().join();
 
-    assertThat(programs.get(LifecycleStage.DRAFT).stream().map(p -> p.id())).containsExactly(p1.id);
-    assertThat(programs.get(LifecycleStage.ACTIVE).stream().map(p -> p.id()))
+    assertThat(programs.get(LifecycleStage.DRAFT).stream().map(ProgramDefinition::id)).containsExactly(p1.id);
+    assertThat(programs.get(LifecycleStage.ACTIVE).stream().map(ProgramDefinition::id))
         .containsExactly(p1.id, p2.id);
   }
 


### PR DESCRIPTION
### Description

If an applicant started a program but did not submit it, it would appear twice in the applicant's program index view. This is because it would appear as a program that the applicant had a draft application open for, and then again as an active program. This PR dedupes the list of programs an applicant sees, prioritizing programs that they have draft applications open for.

### UI changes:
* center the main content
* distinguish between applications the applicant can continue, or new programs they can apply for

![image](https://user-images.githubusercontent.com/12072571/122301041-ff719100-ceb4-11eb-89cb-f69821e3a7b5.png)

### OUT OF SCOPE
This PR does not fix the bug that's being fixed by #1368. If an applicant has a draft program open, and then a new version is published with updated questions, the applicant is currently unable to access their draft application because some questions in that program are now obsolete and cannot be found in the read only question service.