### PR TITLE
ensure that updates to multi-option questions do not invalidate previous answers.

### DIFF
--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -56,7 +56,7 @@ describe('create dropdown question with options', () => {
     // Edit the question
     await adminQuestions.gotoQuestionEditPage(questionName);
     var questionSettingsDiv = await page.innerHTML('#question-settings');
-    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(2);
+    expect(questionSettingsDiv.match(/<input/g)).toHaveLength(4);
 
     await endSession(browser);
   })

--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -17,8 +17,10 @@ describe('normal application flow', () => {
 
     const programName = 'test program for csv export';
     await adminQuestions.addNameQuestion('name-csv');
+    await adminQuestions.addDropdownQuestion('dropdown-csv', ['op1', 'op2', 'op3']);
     await adminQuestions.exportQuestion('name-csv');
-    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv'], programName);
+    await adminQuestions.exportQuestion('dropdown-csv');
+    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv', 'dropdown-csv'], programName);
 
     await logout(page);
     await loginAsTestUser(page);
@@ -28,6 +30,7 @@ describe('normal application flow', () => {
 
     // Applicant fills out first application block.
     await applicantQuestions.answerNameQuestion('sarah', 'smith');
+    await applicantQuestions.answerDropdownQuestion('op2');
     await applicantQuestions.clickNext();
 
     // Application submits answers from review page.
@@ -38,15 +41,32 @@ describe('normal application flow', () => {
 
     await adminPrograms.viewApplications(programName);
     const csvContent = await adminPrograms.getCsv();
-    expect(csvContent).toContain('sarah,,smith');
+    expect(csvContent).toContain('sarah,,smith,op2');
+
+    await logout(page);
+    await loginAsAdmin(page)
+
+    await adminQuestions.createNewVersion('dropdown-csv');
+    await adminQuestions.gotoQuestionEditPage('dropdown-csv');
+    await page.click('button:text("Remove"):visible')
+    await page.click('text=Update');
+    await adminPrograms.publishProgram(programName);
+
+    await logout(page);
+    await loginAsProgramAdmin(page);
+
+    await adminPrograms.viewApplications(programName);
+    await adminPrograms.viewApplicationsInOldVersion();
+    const postEditCsvContent = await adminPrograms.getCsv();
+    expect(postEditCsvContent).toContain('sarah,,smith,op2');
 
     await logout(page);
     await loginAsAdmin(page)
 
     await adminPrograms.gotoAdminProgramsPage();
     const demographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,namecsv (first_name),namecsv (middle_name),namecsv (last_name)');
-    expect(demographicsCsvContent).toContain(',sarah,,smith');
+    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsv (selection),namecsv (first_name),namecsv (middle_name),namecsv (last_name)');
+    expect(demographicsCsvContent).toContain('op2,sarah,,smith');
 
     await adminQuestions.createNewVersion('name-csv');
     await adminQuestions.exportQuestionOpaque('name-csv');
@@ -54,8 +74,9 @@ describe('normal application flow', () => {
 
     await adminPrograms.gotoAdminProgramsPage();
     const newDemographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,namecsv (first_name),namecsv (middle_name),namecsv (last_name)');
+    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsv (selection),namecsv (first_name),namecsv (middle_name),namecsv (last_name)');
     expect(newDemographicsCsvContent).not.toContain(',sarah,,smith');
+    expect(newDemographicsCsvContent).toContain(',op2,');
     if (isLocalDevEnvironment()) {
       // The hashed values "sarah", empty value, "smith", with the dev secret key.
       expect(newDemographicsCsvContent).toContain('5009769596aa83552389143189cec81abfc8f56abc1bb966715c47ce4078c403,057ba03d6c44104863dc7361fe4578965d1887360f90a0895882e58a6248fc86,6eecddf47b5f7a90d41ccc978c4c785265242ce75fe50be10c824b73a25167ba');

--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -16,11 +16,11 @@ describe('normal application flow', () => {
     const applicantQuestions = new ApplicantQuestions(page);
 
     const programName = 'test program for csv export';
-    await adminQuestions.addNameQuestion('name-csv');
-    await adminQuestions.addDropdownQuestion('dropdown-csv', ['op1', 'op2', 'op3']);
-    await adminQuestions.exportQuestion('name-csv');
-    await adminQuestions.exportQuestion('dropdown-csv');
-    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv', 'dropdown-csv'], programName);
+    await adminQuestions.addNameQuestion('name-csv-download');
+    await adminQuestions.addDropdownQuestion('dropdown-csv-download', ['op1', 'op2', 'op3']);
+    await adminQuestions.exportQuestion('name-csv-download');
+    await adminQuestions.exportQuestion('dropdown-csv-download');
+    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv-download', 'dropdown-csv-download'], programName);
 
     await logout(page);
     await loginAsTestUser(page);
@@ -46,8 +46,8 @@ describe('normal application flow', () => {
     await logout(page);
     await loginAsAdmin(page)
 
-    await adminQuestions.createNewVersion('dropdown-csv');
-    await adminQuestions.gotoQuestionEditPage('dropdown-csv');
+    await adminQuestions.createNewVersion('dropdown-csv-download');
+    await adminQuestions.gotoQuestionEditPage('dropdown-csv-download');
     await page.click('button:text("Remove"):visible')
     await page.click('text=Update');
     await adminPrograms.publishProgram(programName);
@@ -65,16 +65,16 @@ describe('normal application flow', () => {
 
     await adminPrograms.gotoAdminProgramsPage();
     const demographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsv (selection),namecsv (first_name),namecsv (middle_name),namecsv (last_name)');
+    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
     expect(demographicsCsvContent).toContain('op2,sarah,,smith');
 
-    await adminQuestions.createNewVersion('name-csv');
-    await adminQuestions.exportQuestionOpaque('name-csv');
+    await adminQuestions.createNewVersion('name-csv-download');
+    await adminQuestions.exportQuestionOpaque('name-csv-download');
     await adminPrograms.publishProgram(programName);
 
     await adminPrograms.gotoAdminProgramsPage();
     const newDemographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsv (selection),namecsv (first_name),namecsv (middle_name),namecsv (last_name)');
+    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
     expect(newDemographicsCsvContent).not.toContain(',sarah,,smith');
     expect(newDemographicsCsvContent).toContain(',op2,');
     if (isLocalDevEnvironment()) {

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -118,6 +118,19 @@ describe('normal application flow', () => {
     await adminPrograms.expectApplicationAnswers('Block 2', 'number-q', '42');
     await adminPrograms.expectApplicationAnswers('Block 2', 'text-q', 'some text');
     await adminPrograms.expectApplicationAnswerLinks('Block 3', 'fileupload-q');
+
+    await logout(page);
+    await loginAsAdmin(page);
+    await adminQuestions.createNewVersion('favorite-trees-q');
+    await adminQuestions.gotoQuestionEditPage('favorite-trees-q');
+    await page.click('button:text("Remove"):visible')
+    await page.click('text=Update');
+    await adminPrograms.publishProgram(programName);
+
+    await adminPrograms.viewApplicationsForOldVersion(programName);
+    await adminPrograms.viewApplicationForApplicant(userDisplayName());
+    await adminPrograms.expectApplicationAnswers('Block 2', 'favorite-trees-q', 'pine cherry');
+
     await endSession(browser);
   })
 })

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -184,6 +184,11 @@ export class AdminPrograms {
     await this.page.click('a:text("Applications")');
   }
 
+  async viewApplicationsForOldVersion(programName: string) {
+    await this.page.click(this.selectWithinProgramCard(programName, 'ACTIVE', ':text("Applications")'));
+    await this.page.click("a:has-text(\"Applications\")");
+  }
+
   selectApplicationCardForApplicant(applicantName: string) {
     return `.cf-admin-application-card:has-text("${applicantName}")`;
   }
@@ -215,6 +220,7 @@ export class AdminPrograms {
   }
 
   async getCsv() {
+    await this.page.screenshot({path: 'tmp/download.png', fullPage: true});
     const [downloadEvent] = await Promise.all([
       this.page.waitForEvent('download'),
       this.page.click('text="Download all (CSV)"')

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -220,7 +220,6 @@ export class AdminPrograms {
   }
 
   async getCsv() {
-    await this.page.screenshot({path: 'tmp/download.png', fullPage: true});
     const [downloadEvent] = await Promise.all([
       this.page.waitForEvent('download'),
       this.page.click('text="Download all (CSV)"')

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -12,7 +12,6 @@ import forms.MultiOptionQuestionForm;
 import forms.QuestionForm;
 import forms.QuestionFormBuilder;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
@@ -324,11 +323,16 @@ public class AdminQuestionController extends CiviFormController {
           ((EnumeratorQuestionForm) questionForm).getEntityType());
     }
 
-    if (existing.getQuestionType().isMultiOptionType()) {
+    if (questionForm instanceof MultiOptionQuestionForm) {
+      MultiOptionQuestionDefinition definition = null;
+      try {
+        definition = (MultiOptionQuestionDefinition) questionForm.getBuilder().build();
+      } catch (UnsupportedQuestionTypeException e) {
+        // Impossible - we checked the type above.
+        throw new RuntimeException(e);
+      }
       updateDefaultLocalizationForOptions(
-          updated,
-          (MultiOptionQuestionDefinition) existing,
-          ((MultiOptionQuestionForm) questionForm).getOptions());
+          updated, (MultiOptionQuestionDefinition) existing, definition.getOptions());
     }
   }
 
@@ -347,7 +351,7 @@ public class AdminQuestionController extends CiviFormController {
   private void updateDefaultLocalizationForOptions(
       QuestionDefinitionBuilder updated,
       MultiOptionQuestionDefinition existing,
-      List<String> updatedDefaultOptions) {
+      ImmutableList<QuestionOption> updatedOptions) {
 
     ImmutableMap<String, QuestionOption> existingTranslations =
         existing.getOptions().stream()
@@ -356,14 +360,19 @@ public class AdminQuestionController extends CiviFormController {
     // translations. If we do not have existing translations for a given string, create
     // a new, empty set of translations.
     ImmutableList.Builder<QuestionOption> updatedOptionsBuilder = ImmutableList.builder();
-    for (int i = 0; i < updatedDefaultOptions.size(); i++) {
-      String updatedDefaultOption = updatedDefaultOptions.get(i);
-      if (existingTranslations.containsKey(updatedDefaultOption)) {
-        updatedOptionsBuilder.add(
-            existingTranslations.get(updatedDefaultOption).toBuilder().setId(i).build());
+    for (QuestionOption updatedOption : updatedOptions) {
+      if (existingTranslations.containsKey(updatedOption.optionText().getDefault())) {
+        QuestionOption existingOption =
+            existingTranslations.get(updatedOption.optionText().getDefault());
+        if (existingOption.id() == updatedOption.id()) {
+          updatedOptionsBuilder.add(
+              existingOption.toBuilder()
+                  .setId(updatedOption.id())
+                  .setDisplayOrder(updatedOption.displayOrder())
+                  .build());
+        }
       } else {
-        updatedOptionsBuilder.add(
-            QuestionOption.create(i, LocalizedStrings.withDefaultValue(updatedDefaultOption)));
+        updatedOptionsBuilder.add(updatedOption);
       }
     }
     updated.setQuestionOptions(updatedOptionsBuilder.build());

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -366,13 +366,11 @@ public class AdminQuestionController extends CiviFormController {
               == updatedOption.id()) {
         QuestionOption existingOption =
             existingTranslations.get(updatedOption.optionText().getDefault());
-        if (existingOption.id() == updatedOption.id()) {
-          updatedOptionsBuilder.add(
-              existingOption.toBuilder()
-                  .setId(updatedOption.id())
-                  .setDisplayOrder(updatedOption.displayOrder())
-                  .build());
-        }
+        updatedOptionsBuilder.add(
+            existingOption.toBuilder()
+                .setId(updatedOption.id())
+                .setDisplayOrder(updatedOption.displayOrder())
+                .build());
       } else {
         updatedOptionsBuilder.add(updatedOption);
       }

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -361,7 +361,9 @@ public class AdminQuestionController extends CiviFormController {
     // a new, empty set of translations.
     ImmutableList.Builder<QuestionOption> updatedOptionsBuilder = ImmutableList.builder();
     for (QuestionOption updatedOption : updatedOptions) {
-      if (existingTranslations.containsKey(updatedOption.optionText().getDefault())) {
+      if (existingTranslations.containsKey(updatedOption.optionText().getDefault())
+          && existingTranslations.get(updatedOption.optionText().getDefault()).id()
+              == updatedOption.id()) {
         QuestionOption existingOption =
             existingTranslations.get(updatedOption.optionText().getDefault());
         if (existingOption.id() == updatedOption.id()) {

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -154,9 +154,9 @@ public class DatabaseSeedController extends DevController {
                     Locale.US, "Which of the following kitchen instruments do you own?"),
                 LocalizedStrings.of(Locale.US, "help text"),
                 ImmutableList.of(
-                    QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "toaster")),
-                    QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "pepper grinder")),
-                    QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "garlic press")))))
+                    QuestionOption.create(1L, 1L, LocalizedStrings.of(Locale.US, "toaster")),
+                    QuestionOption.create(2L, 2L, LocalizedStrings.of(Locale.US, "pepper grinder")),
+                    QuestionOption.create(3L, 3L, LocalizedStrings.of(Locale.US, "garlic press")))))
         .getResult();
   }
 
@@ -171,10 +171,10 @@ public class DatabaseSeedController extends DevController {
                     Locale.US, "Select your favorite ice cream flavor from the following"),
                 LocalizedStrings.of(Locale.US, "this is sample help text"),
                 ImmutableList.of(
-                    QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "chocolate")),
-                    QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "strawberry")),
-                    QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "vanilla")),
-                    QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "coffee")))))
+                    QuestionOption.create(1L, 1L, LocalizedStrings.of(Locale.US, "chocolate")),
+                    QuestionOption.create(2L, 2L, LocalizedStrings.of(Locale.US, "strawberry")),
+                    QuestionOption.create(3L, 3L, LocalizedStrings.of(Locale.US, "vanilla")),
+                    QuestionOption.create(4L, 4L, LocalizedStrings.of(Locale.US, "coffee")))))
         .getResult();
   }
 
@@ -189,11 +189,11 @@ public class DatabaseSeedController extends DevController {
                 LocalizedStrings.of(Locale.US, "this is sample help text"),
                 ImmutableList.of(
                     QuestionOption.create(
-                        1L, LocalizedStrings.of(Locale.US, "winter (will hide next block)")),
-                    QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "spring")),
-                    QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "summer")),
+                        1L, 1L, LocalizedStrings.of(Locale.US, "winter (will hide next block)")),
+                    QuestionOption.create(2L, 2L, LocalizedStrings.of(Locale.US, "spring")),
+                    QuestionOption.create(3L, 3L, LocalizedStrings.of(Locale.US, "summer")),
                     QuestionOption.create(
-                        4L, LocalizedStrings.of(Locale.US, "fall (will hide next block)")))))
+                        4L, 4L, LocalizedStrings.of(Locale.US, "fall (will hide next block)")))))
         .getResult();
   }
 

--- a/universal-application-tool-0.0.1/app/forms/EmailQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/EmailQuestionForm.java
@@ -1,6 +1,6 @@
 package forms;
 
-import services.question.types.QuestionDefinition;
+import services.question.types.EmailQuestionDefinition;
 import services.question.types.QuestionType;
 
 public class EmailQuestionForm extends QuestionForm {
@@ -9,7 +9,7 @@ public class EmailQuestionForm extends QuestionForm {
     super();
   }
 
-  public EmailQuestionForm(QuestionDefinition qd) {
+  public EmailQuestionForm(EmailQuestionDefinition qd) {
     super(qd);
   }
 

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -145,7 +145,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     ImmutableList.Builder<QuestionOption> questionOptions = ImmutableList.builder();
     Preconditions.checkState(
         this.optionIds.size() == this.options.size(),
-        "Option indexes and options are not the same size.");
+        "Option ids and options are not the same size.");
 
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -1,10 +1,12 @@
 package forms;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
-import java.util.stream.Collectors;
+import java.util.OptionalLong;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
 import services.question.LocalizedQuestionOption;
@@ -17,14 +19,21 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   // the list. This means the constructors MUST set this field to a mutable List type, NOT
   // ImmutableList.
   private List<String> options;
+  // Options added to the list during the edit.
+  private List<String> newOptions;
+  private List<Long> optionIndexes;
+  private OptionalLong nextAvailableId;
   private OptionalInt minChoicesRequired;
   private OptionalInt maxChoicesAllowed;
 
   protected MultiOptionQuestionForm() {
     super();
     this.options = new ArrayList<>();
+    this.newOptions = new ArrayList<>();
+    this.optionIndexes = new ArrayList<>();
     this.minChoicesRequired = OptionalInt.empty();
     this.maxChoicesAllowed = OptionalInt.empty();
+    this.nextAvailableId = OptionalLong.empty();
   }
 
   protected MultiOptionQuestionForm(MultiOptionQuestionDefinition qd) {
@@ -33,16 +42,27 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.maxChoicesAllowed = qd.getMultiOptionValidationPredicates().maxChoicesAllowed();
 
     this.options = new ArrayList<>();
+    this.newOptions = new ArrayList<>();
+    this.optionIndexes = new ArrayList<>();
 
     try {
       // The first time a question is created, we only create for the default locale. The admin can
       // localize the options later.
       if (qd.getSupportedLocales().contains(LocalizedStrings.DEFAULT_LOCALE)) {
-        List<String> optionStrings =
-            qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
-                .map(LocalizedQuestionOption::optionText)
-                .collect(Collectors.toList());
-        this.options.addAll(optionStrings);
+        qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
+            .sorted(Comparator.comparing(LocalizedQuestionOption::order))
+            .forEachOrdered(
+                option -> {
+                  options.add(option.optionText());
+                  optionIndexes.add(option.id());
+                });
+        this.nextAvailableId =
+            OptionalLong.of(
+                qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
+                        .max(Comparator.comparing(LocalizedQuestionOption::id))
+                        .get()
+                        .id()
+                    + 1);
       }
     } catch (TranslationNotFoundException e) {
       throw new RuntimeException(e);
@@ -51,6 +71,22 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
   public List<String> getOptions() {
     return this.options;
+  }
+
+  public List<String> getNewOptions() {
+    return this.newOptions;
+  }
+
+  public List<Long> getOptionIndexes() {
+    return this.optionIndexes;
+  }
+
+  public void setOptionIndexes(List<Long> optionIndexes) {
+    this.optionIndexes = optionIndexes;
+  }
+
+  public void setNewOptions(List<String> options) {
+    this.newOptions = options;
   }
 
   public void setOptions(List<String> options) {
@@ -107,16 +143,34 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     }
 
     ImmutableList.Builder<QuestionOption> questionOptions = ImmutableList.builder();
-    long optionIndex = 0L;
+    Preconditions.checkState(
+        this.optionIndexes.size() == this.options.size(),
+        "Option indexes and options are not the same size.");
 
     // Note: the question edit form only sets or updates the default locale.
-    for (String optionText : getOptions()) {
+    for (int i = 0; i < options.size(); i++) {
       questionOptions.add(
-          QuestionOption.create(optionIndex++, LocalizedStrings.withDefaultValue(optionText)));
+          QuestionOption.create(
+              optionIndexes.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
+    }
+    for (int i = 0; i < newOptions.size(); i++) {
+      questionOptions.add(
+          QuestionOption.create(
+              nextAvailableId.orElse(0L) + i,
+              options.size() + i,
+              LocalizedStrings.withDefaultValue(newOptions.get(i))));
     }
 
     return super.getBuilder()
         .setQuestionOptions(questionOptions.build())
         .setValidationPredicates(predicateBuilder.build());
+  }
+
+  public OptionalLong getNextAvailableId() {
+    return nextAvailableId;
+  }
+
+  public void setNextAvailableId(long nextAvailableId) {
+    this.nextAvailableId = OptionalLong.of(nextAvailableId);
   }
 }

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -21,7 +21,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   private List<String> options;
   // Options added to the list during the edit.
   private List<String> newOptions;
-  private List<Long> optionIndexes;
+  private List<Long> optionIds;
   private OptionalLong nextAvailableId;
   private OptionalInt minChoicesRequired;
   private OptionalInt maxChoicesAllowed;
@@ -30,7 +30,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     super();
     this.options = new ArrayList<>();
     this.newOptions = new ArrayList<>();
-    this.optionIndexes = new ArrayList<>();
+    this.optionIds = new ArrayList<>();
     this.minChoicesRequired = OptionalInt.empty();
     this.maxChoicesAllowed = OptionalInt.empty();
     this.nextAvailableId = OptionalLong.empty();
@@ -43,7 +43,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
     this.options = new ArrayList<>();
     this.newOptions = new ArrayList<>();
-    this.optionIndexes = new ArrayList<>();
+    this.optionIds = new ArrayList<>();
 
     try {
       // The first time a question is created, we only create for the default locale. The admin can
@@ -54,14 +54,14 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
             .forEachOrdered(
                 option -> {
                   options.add(option.optionText());
-                  optionIndexes.add(option.id());
+                  optionIds.add(option.id());
                 });
         this.nextAvailableId =
             OptionalLong.of(
                 qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
-                        .max(Comparator.comparing(LocalizedQuestionOption::id))
-                        .get()
-                        .id()
+                        .mapToLong(LocalizedQuestionOption::id)
+                        .max()
+                        .getAsLong()
                     + 1);
       }
     } catch (TranslationNotFoundException e) {
@@ -77,12 +77,12 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     return this.newOptions;
   }
 
-  public List<Long> getOptionIndexes() {
-    return this.optionIndexes;
+  public List<Long> getOptionIds() {
+    return this.optionIds;
   }
 
-  public void setOptionIndexes(List<Long> optionIndexes) {
-    this.optionIndexes = optionIndexes;
+  public void setOptionIds(List<Long> optionIds) {
+    this.optionIds = optionIds;
   }
 
   public void setNewOptions(List<String> options) {
@@ -144,14 +144,14 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
     ImmutableList.Builder<QuestionOption> questionOptions = ImmutableList.builder();
     Preconditions.checkState(
-        this.optionIndexes.size() == this.options.size(),
+        this.optionIds.size() == this.options.size(),
         "Option indexes and options are not the same size.");
 
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       questionOptions.add(
           QuestionOption.create(
-              optionIndexes.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
+              optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
     }
     for (int i = 0; i < newOptions.size(); i++) {
       questionOptions.add(

--- a/universal-application-tool-0.0.1/app/models/Question.java
+++ b/universal-application-tool-0.0.1/app/models/Question.java
@@ -205,7 +205,9 @@ public class Question extends BaseModel {
                 legacyQuestionOptions.get(firstKey).stream(),
                 (optionText, i) ->
                     QuestionOption.create(
-                        Long.valueOf(i), LocalizedStrings.of(firstKey, optionText)))
+                        Long.valueOf(i),
+                        Long.valueOf(i),
+                        LocalizedStrings.of(firstKey, optionText)))
             .collect(toImmutableList());
 
     builder.setQuestionOptions(options);

--- a/universal-application-tool-0.0.1/app/services/question/LocalizedQuestionOption.java
+++ b/universal-application-tool-0.0.1/app/services/question/LocalizedQuestionOption.java
@@ -11,12 +11,16 @@ import java.util.Locale;
 public abstract class LocalizedQuestionOption {
 
   /** Create a LocalizedQuestionOption. */
-  public static LocalizedQuestionOption create(long id, String optionText, Locale locale) {
-    return new AutoValue_LocalizedQuestionOption(id, optionText, locale);
+  public static LocalizedQuestionOption create(
+      long id, long order, String optionText, Locale locale) {
+    return new AutoValue_LocalizedQuestionOption(id, order, optionText, locale);
   }
 
   /** The id for this option. */
   public abstract long id();
+
+  /** The order of the option. */
+  public abstract long order();
 
   /** The text strings to display to the user. */
   public abstract String optionText();

--- a/universal-application-tool-0.0.1/app/services/question/QuestionOption.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionOption.java
@@ -37,9 +37,12 @@ public abstract class QuestionOption {
   @JsonCreator
   public static QuestionOption jsonCreator(
       @JsonProperty("id") long id,
-      @JsonProperty("displayOrder") long displayOrder,
+      @JsonProperty(value = "displayOrder", defaultValue = "-1L") long displayOrder,
       @JsonProperty("localizedOptionText") LocalizedStrings localizedOptionText,
       @JsonProperty("optionText") ImmutableMap<Locale, String> legacyOptionText) {
+    if (displayOrder == -1) {
+      displayOrder = id;
+    }
     if (localizedOptionText != null) {
       return QuestionOption.create(id, displayOrder, localizedOptionText);
     }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionOption.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionOption.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
+import java.util.OptionalLong;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
 
@@ -24,6 +25,10 @@ public abstract class QuestionOption {
   @JsonProperty("localizedOptionText")
   public abstract LocalizedStrings optionText();
 
+  /** The display ordering of this option - if empty, do not display. */
+  @JsonProperty("displayOrder")
+  public abstract OptionalLong displayOrder();
+
   /**
    * Create a QuestionOption, used for JSON mapping to account for the legacy `optionText`.
    *
@@ -32,17 +37,31 @@ public abstract class QuestionOption {
   @JsonCreator
   public static QuestionOption jsonCreator(
       @JsonProperty("id") long id,
+      @JsonProperty("displayOrder") long displayOrder,
       @JsonProperty("localizedOptionText") LocalizedStrings localizedOptionText,
       @JsonProperty("optionText") ImmutableMap<Locale, String> legacyOptionText) {
     if (localizedOptionText != null) {
-      return QuestionOption.create(id, localizedOptionText);
+      return QuestionOption.create(id, displayOrder, localizedOptionText);
     }
-    return QuestionOption.create(id, LocalizedStrings.create(legacyOptionText));
+    return QuestionOption.create(id, displayOrder, LocalizedStrings.create(legacyOptionText));
+  }
+
+  /** Create a QuestionOption. */
+  public static QuestionOption create(long id, long displayOrder, LocalizedStrings optionText) {
+    return QuestionOption.builder()
+        .setId(id)
+        .setOptionText(optionText)
+        .setDisplayOrder(OptionalLong.of(displayOrder))
+        .build();
   }
 
   /** Create a QuestionOption. */
   public static QuestionOption create(long id, LocalizedStrings optionText) {
-    return QuestionOption.builder().setId(id).setOptionText(optionText).build();
+    return QuestionOption.builder()
+        .setId(id)
+        .setOptionText(optionText)
+        .setDisplayOrder(OptionalLong.empty())
+        .build();
   }
 
   public LocalizedQuestionOption localize(Locale locale) {
@@ -61,10 +80,14 @@ public abstract class QuestionOption {
   public LocalizedQuestionOption localizeOrDefault(Locale locale) {
     try {
       String localizedText = optionText().get(locale);
-      return LocalizedQuestionOption.create(id(), localizedText, locale);
+      return LocalizedQuestionOption.create(
+          id(), displayOrder().orElse(id()), localizedText, locale);
     } catch (TranslationNotFoundException e) {
       return LocalizedQuestionOption.create(
-          id(), optionText().getDefault(), LocalizedStrings.DEFAULT_LOCALE);
+          id(),
+          displayOrder().orElse(id()),
+          optionText().getDefault(),
+          LocalizedStrings.DEFAULT_LOCALE);
     }
   }
 
@@ -82,6 +105,9 @@ public abstract class QuestionOption {
 
     @JsonProperty("localizedOptionText")
     public abstract Builder setOptionText(LocalizedStrings optionText);
+
+    @JsonProperty("displayOrder")
+    public abstract Builder setDisplayOrder(OptionalLong displayOrder);
 
     public abstract QuestionOption build();
   }

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinitionBuilder.java
@@ -71,7 +71,8 @@ public class QuestionDefinitionBuilder {
     if (questionType.isMultiOptionType()) {
       builder.setQuestionOptions(
           ImmutableList.of(
-              QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "Sample question option"))));
+              QuestionOption.create(
+                  1L, 1L, LocalizedStrings.of(Locale.US, "Sample question option"))));
     }
 
     return builder;

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -4,6 +4,7 @@ import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.label;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -166,13 +167,13 @@ public class QuestionConfig {
             .getContainer()
             .withClasses(Styles.FLEX, Styles.ML_2);
     ContainerTag optionIndexInput =
-        existingOption.isEmpty()
-            ? div()
-            : FieldWithLabel.input()
+        existingOption.isPresent()
+            ? FieldWithLabel.input()
                 .setFieldName("optionIndexes[]")
                 .setValue(String.valueOf(existingOption.get().id()))
                 .getContainer()
-                .withClasses(Styles.HIDDEN);
+                .withClasses(Styles.HIDDEN)
+            : div();
     Tag removeOptionButton =
         button("Remove")
             .withType("button")
@@ -185,14 +186,18 @@ public class QuestionConfig {
 
   private QuestionConfig addMultiOptionQuestionFields(
       MultiOptionQuestionForm multiOptionQuestionForm) {
+    Preconditions.checkState(
+        multiOptionQuestionForm.getOptionIds().size()
+            == multiOptionQuestionForm.getOptions().size(),
+        "Options and Option Indexes need to be the same size.");
     ImmutableList.Builder<ContainerTag> existingOptionsBuilder = ImmutableList.builder();
     for (int i = 0; i < multiOptionQuestionForm.getOptions().size(); i++) {
       existingOptionsBuilder.add(
           multiOptionQuestionField(
               Optional.of(
                   LocalizedQuestionOption.create(
-                      multiOptionQuestionForm.getOptionIndexes().get(i),
-                      0L,
+                      multiOptionQuestionForm.getOptionIds().get(i),
+                      i,
                       multiOptionQuestionForm.getOptions().get(i),
                       LocalizedStrings.DEFAULT_LOCALE))));
     }

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -169,7 +169,7 @@ public class QuestionConfig {
     ContainerTag optionIndexInput =
         existingOption.isPresent()
             ? FieldWithLabel.input()
-                .setFieldName("optionIndexes[]")
+                .setFieldName("optionIds[]")
                 .setValue(String.valueOf(existingOption.get().id()))
                 .getContainer()
                 .withClasses(Styles.HIDDEN)

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -65,7 +65,8 @@ public class ApplicantQuestionRendererFactory {
     if (questionType.isMultiOptionType()) {
       builder.setQuestionOptions(
           ImmutableList.of(
-              QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "Sample question option"))));
+              QuestionOption.create(
+                  1L, 1L, LocalizedStrings.of(Locale.US, "Sample question option"))));
     }
 
     if (questionType.equals(QuestionType.ENUMERATOR)) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -1,13 +1,13 @@
 package views.questiontypes;
 
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.each;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Comparator;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.MultiSelectQuestion;
 import services.question.LocalizedQuestionOption;
@@ -42,13 +42,14 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
                     .condAttr(!multiOptionQuestion.hasValue(), Attr.CHECKED, "")
                     .withClasses(ReferenceClasses.RADIO_DEFAULT, Styles.HIDDEN))
             .with(
-                each(
-                    multiOptionQuestion.getOptions(),
-                    option ->
-                        renderCheckboxOption(
-                            multiOptionQuestion.getSelectionPathAsArray(),
-                            option,
-                            multiOptionQuestion.optionIsSelected(option))));
+                multiOptionQuestion.getOptions().stream()
+                    .sorted(Comparator.comparing(LocalizedQuestionOption::order))
+                    .map(
+                        option ->
+                            renderCheckboxOption(
+                                multiOptionQuestion.getSelectionPathAsArray(),
+                                option,
+                                multiOptionQuestion.optionIsSelected(option))));
 
     return renderInternal(params.messages(), checkboxQuestionFormContent);
   }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static j2html.TagCreator.div;
 
 import j2html.tags.Tag;
+import java.util.Comparator;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
@@ -34,6 +35,7 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
             .setPlaceholderText(messages.at(MessageKey.DROPDOWN_PLACEHOLDER.getKeyName()))
             .setOptions(
                 singleSelectQuestion.getOptions().stream()
+                    .sorted(Comparator.comparing(LocalizedQuestionOption::order))
                     .collect(
                         toImmutableMap(
                             LocalizedQuestionOption::optionText,

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -1,13 +1,13 @@
 package views.questiontypes;
 
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.each;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Comparator;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.SingleSelectQuestion;
 import services.question.LocalizedQuestionOption;
@@ -34,13 +34,14 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
     Tag radioQuestionFormContent =
         div()
             .with(
-                each(
-                    singleOptionQuestion.getOptions(),
-                    option ->
-                        renderRadioOption(
-                            singleOptionQuestion.getSelectionPath().toString(),
-                            option,
-                            singleOptionQuestion.optionIsSelected(option))));
+                singleOptionQuestion.getOptions().stream()
+                    .sorted(Comparator.comparing(LocalizedQuestionOption::order))
+                    .map(
+                        option ->
+                            renderRadioOption(
+                                singleOptionQuestion.getSelectionPath().toString(),
+                                option,
+                                singleOptionQuestion.optionIsSelected(option))));
 
     return renderInternal(params.messages(), radioQuestionFormContent);
   }

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -276,8 +276,8 @@ public class AdminQuestionControllerTest extends WithPostgresContainer {
             .put("options[0]", "coffee") // Unchanged but out of order
             .put("options[1]", "vanilla") // Unchanged and in order
             .put("newOptions[0]", "lavender") // New flavor
-            .put("optionIndexes[0]", "4")
-            .put("optionIndexes[1]", "3")
+            .put("optionIds[0]", "4")
+            .put("optionIds[1]", "3")
             .put("nextAvailableId", "5")
             .put("questionExportState", "NON_DEMOGRAPHIC")
             // Has one fewer than the original question

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -274,8 +274,11 @@ public class AdminQuestionControllerTest extends WithPostgresContainer {
             .put("questionText", "new question text")
             .put("questionHelpText", "new help text")
             .put("options[0]", "coffee") // Unchanged but out of order
-            .put("options[1]", "lavender") // New flavor
-            .put("options[2]", "vanilla") // Unchanged and in order
+            .put("options[1]", "vanilla") // Unchanged and in order
+            .put("newOptions[0]", "lavender") // New flavor
+            .put("optionIndexes[0]", "4")
+            .put("optionIndexes[1]", "3")
+            .put("nextAvailableId", "5")
             .put("questionExportState", "NON_DEMOGRAPHIC")
             // Has one fewer than the original question
             .build();
@@ -298,10 +301,10 @@ public class AdminQuestionControllerTest extends WithPostgresContainer {
     ImmutableList<QuestionOption> expectedOptions =
         ImmutableList.of(
             QuestionOption.create(
-                0, LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")),
-            QuestionOption.create(1, LocalizedStrings.withDefaultValue("lavender")),
+                4, 0, LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café")),
             QuestionOption.create(
-                2, LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")));
+                3, 1, LocalizedStrings.of(Locale.US, "vanilla", Locale.FRENCH, "vanille")),
+            QuestionOption.create(5, 2, LocalizedStrings.withDefaultValue("lavender")));
     assertThat(((MultiOptionQuestionDefinition) found.getQuestionDefinition()).getOptions())
         .isEqualTo(expectedOptions);
   }

--- a/universal-application-tool-0.0.1/test/forms/CheckboxQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/CheckboxQuestionFormTest.java
@@ -23,7 +23,7 @@ public class CheckboxQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
-    form.setOptionIndexes(ImmutableList.of(1L, 2L, 3L));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CheckboxQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/CheckboxQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/CheckboxQuestionFormTest.java
@@ -23,6 +23,7 @@ public class CheckboxQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
+    form.setOptionIndexes(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CheckboxQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/DropdownQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/DropdownQuestionFormTest.java
@@ -23,7 +23,7 @@ public class DropdownQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
-    form.setOptionIndexes(ImmutableList.of(1L, 2L, 3L));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     DropdownQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/DropdownQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/DropdownQuestionFormTest.java
@@ -23,6 +23,7 @@ public class DropdownQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
+    form.setOptionIndexes(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     DropdownQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
@@ -25,6 +25,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("1");
     form.setMaxChoicesAllowed("10");
     form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionIndexes(ImmutableList.of(4L, 1L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CheckboxQuestionDefinition expected =
@@ -73,6 +74,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
     form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionIndexes(ImmutableList.of(4L, 1L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CheckboxQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
@@ -25,7 +25,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("1");
     form.setMaxChoicesAllowed("10");
     form.setOptions(ImmutableList.of("one", "two"));
-    form.setOptionIndexes(ImmutableList.of(4L, 1L));
+    form.setOptionIds(ImmutableList.of(4L, 1L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CheckboxQuestionDefinition expected =
@@ -74,7 +74,7 @@ public class MultiOptionQuestionFormTest {
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
     form.setOptions(ImmutableList.of("one", "two"));
-    form.setOptionIndexes(ImmutableList.of(4L, 1L));
+    form.setOptionIds(ImmutableList.of(4L, 1L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CheckboxQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/RadioButtonQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/RadioButtonQuestionFormTest.java
@@ -23,7 +23,7 @@ public class RadioButtonQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
-    form.setOptionIndexes(ImmutableList.of(1L, 2L, 3L));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     RadioButtonQuestionDefinition expected =

--- a/universal-application-tool-0.0.1/test/forms/RadioButtonQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/RadioButtonQuestionFormTest.java
@@ -23,6 +23,7 @@ public class RadioButtonQuestionFormTest {
     form.setQuestionHelpText("help text");
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
+    form.setOptionIndexes(ImmutableList.of(1L, 2L, 3L));
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     RadioButtonQuestionDefinition expected =
@@ -34,8 +35,8 @@ public class RadioButtonQuestionFormTest {
             LocalizedStrings.of(Locale.US, "help text"),
             ImmutableList.of(
                 QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "cat")),
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "dog")),
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "rabbit"))));
+                QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "dog")),
+                QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "rabbit"))));
 
     assertThat(builder.build()).isEqualTo(expected);
   }

--- a/universal-application-tool-0.0.1/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
@@ -32,7 +32,7 @@ public class MultiOptionQuestionTranslationFormTest {
         (RadioButtonQuestionDefinition) form.builderWithUpdates(question, Locale.CHINA).build();
 
     assertThat(updated.getOptionsForLocale(Locale.CHINA))
-        .containsExactly(LocalizedQuestionOption.create(1L, "new", Locale.CHINA));
+        .containsExactly(LocalizedQuestionOption.create(1L, 1L, "new", Locale.CHINA));
   }
 
   @Test
@@ -53,6 +53,6 @@ public class MultiOptionQuestionTranslationFormTest {
         (RadioButtonQuestionDefinition) form.builderWithUpdates(question, Locale.FRANCE).build();
 
     assertThat(updated.getOptionsForLocale(Locale.FRANCE))
-        .containsExactly(LocalizedQuestionOption.create(1L, "new", Locale.FRANCE));
+        .containsExactly(LocalizedQuestionOption.create(1L, 1L, "new", Locale.FRANCE));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -48,8 +48,8 @@ public class SingleSelectQuestionTest {
 
     assertThat(singleSelectQuestion.getOptions())
         .containsOnly(
-            LocalizedQuestionOption.create(1L, "option 1", Locale.US),
-            LocalizedQuestionOption.create(2L, "option 2", Locale.US));
+            LocalizedQuestionOption.create(1L, 1L, "option 1", Locale.US),
+            LocalizedQuestionOption.create(2L, 2L, "option 2", Locale.US));
     assertThat(applicantQuestion.hasErrors()).isFalse();
   }
 
@@ -65,7 +65,7 @@ public class SingleSelectQuestionTest {
     assertThat(singleSelectQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(singleSelectQuestion.hasQuestionErrors()).isFalse();
     assertThat(singleSelectQuestion.getSelectedOptionValue())
-        .hasValue(LocalizedQuestionOption.create(1L, "option 1", Locale.US));
+        .hasValue(LocalizedQuestionOption.create(1L, 1L, "option 1", Locale.US));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -120,8 +120,8 @@ public class MultiOptionQuestionDefinitionTest {
 
     assertThat(multiOption.getOptionsForLocale(Locale.US))
         .containsExactly(
-            LocalizedQuestionOption.create(1L, "one", Locale.US),
-            LocalizedQuestionOption.create(2L, "two", Locale.US));
+            LocalizedQuestionOption.create(1L, 1L, "one", Locale.US),
+            LocalizedQuestionOption.create(2L, 2L, "two", Locale.US));
   }
 
   @Test
@@ -145,8 +145,8 @@ public class MultiOptionQuestionDefinitionTest {
 
     assertThat(multiOption.getOptionsForLocaleOrDefault(Locale.GERMAN))
         .containsExactly(
-            LocalizedQuestionOption.create(1L, "eins", Locale.GERMAN),
-            LocalizedQuestionOption.create(2L, "zwei", Locale.GERMAN),
-            LocalizedQuestionOption.create(3L, "three", Locale.US));
+            LocalizedQuestionOption.create(1L, 1L, "eins", Locale.GERMAN),
+            LocalizedQuestionOption.create(2L, 2L, "zwei", Locale.GERMAN),
+            LocalizedQuestionOption.create(3L, 3L, "three", Locale.US));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionOptionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionOptionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.util.Locale;
+import java.util.OptionalLong;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.LocalizedQuestionOption;
@@ -26,7 +27,7 @@ public class QuestionOptionTest {
     QuestionOption option = QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "default"));
 
     assertThat(option.localizeOrDefault(Locale.CHINESE))
-        .isEqualTo(LocalizedQuestionOption.create(1L, "default", Locale.US));
+        .isEqualTo(LocalizedQuestionOption.create(1L, 1L, "default", Locale.US));
   }
 
   @Test
@@ -35,9 +36,11 @@ public class QuestionOptionTest {
         QuestionOption.builder()
             .setId(123L)
             .setOptionText(LocalizedStrings.withDefaultValue("test"))
+            .setDisplayOrder(OptionalLong.of(1L))
             .build();
 
     assertThat(option.localize(LocalizedStrings.DEFAULT_LOCALE))
-        .isEqualTo(LocalizedQuestionOption.create(123L, "test", LocalizedStrings.DEFAULT_LOCALE));
+        .isEqualTo(
+            LocalizedQuestionOption.create(123L, 1L, "test", LocalizedStrings.DEFAULT_LOCALE));
   }
 }

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -188,9 +188,9 @@ public class TestQuestionBank {
                 Locale.US, "Which of the following kitchen instruments do you own?"),
             LocalizedStrings.of(Locale.US, "This is sample help text."),
             ImmutableList.of(
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "toaster")),
-                QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "pepper grinder")),
-                QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "garlic press"))));
+                QuestionOption.create(1L, 1L, LocalizedStrings.of(Locale.US, "toaster")),
+                QuestionOption.create(2L, 2L, LocalizedStrings.of(Locale.US, "pepper grinder")),
+                QuestionOption.create(3L, 3L, LocalizedStrings.of(Locale.US, "garlic press"))));
     return maybeSave(definition);
   }
 
@@ -205,10 +205,10 @@ public class TestQuestionBank {
                 Locale.US, "Select your favorite ice cream flavor from the following"),
             LocalizedStrings.of(Locale.US, "This is sample help text."),
             ImmutableList.of(
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "chocolate")),
-                QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "strawberry")),
-                QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "vanilla")),
-                QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "coffee"))));
+                QuestionOption.create(1L, 1L, LocalizedStrings.of(Locale.US, "chocolate")),
+                QuestionOption.create(2L, 2L, LocalizedStrings.of(Locale.US, "strawberry")),
+                QuestionOption.create(3L, 3L, LocalizedStrings.of(Locale.US, "vanilla")),
+                QuestionOption.create(4L, 4L, LocalizedStrings.of(Locale.US, "coffee"))));
     return maybeSave(definition);
   }
 
@@ -336,10 +336,10 @@ public class TestQuestionBank {
             LocalizedStrings.of(Locale.US, "What is your favorite season?"),
             LocalizedStrings.of(Locale.US, "This is sample help text."),
             ImmutableList.of(
-                QuestionOption.create(1L, LocalizedStrings.of(Locale.US, "winter")),
-                QuestionOption.create(2L, LocalizedStrings.of(Locale.US, "spring")),
-                QuestionOption.create(3L, LocalizedStrings.of(Locale.US, "summer")),
-                QuestionOption.create(4L, LocalizedStrings.of(Locale.US, "fall"))));
+                QuestionOption.create(1L, 1L, LocalizedStrings.of(Locale.US, "winter")),
+                QuestionOption.create(2L, 2L, LocalizedStrings.of(Locale.US, "spring")),
+                QuestionOption.create(3L, 3L, LocalizedStrings.of(Locale.US, "summer")),
+                QuestionOption.create(4L, 4L, LocalizedStrings.of(Locale.US, "fall"))));
     return maybeSave(definition);
   }
 


### PR DESCRIPTION
### Description
Maintain the ids of question options, as they change, using an ordering number instead.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1273.