### PR TITLE
Add service method and routing endpoint for removing a block visibility predicate

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -106,4 +106,19 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
               "success", String.format("Saved visibility condition: %s", predicateDefinition));
     }
   }
+
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  public Result destroy(long programId, long blockDefinitionId) {
+    try {
+      programService.removeBlockPredicate(programId, blockDefinitionId);
+    } catch (ProgramNotFoundException e) {
+      return notFound(String.format("Program ID %d not found.", programId));
+    } catch (ProgramBlockDefinitionNotFoundException e) {
+      return notFound(
+          String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
+    }
+
+    return redirect(routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
+        .flashing("success", "Removed the visibility condition for this block.");
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -222,7 +222,7 @@ public interface ProgramService {
           QuestionNotFoundException;
 
   /**
-   * Set the hide {@link PredicateDefinition} for a block. This predicate describes under what
+   * Set the visibility {@link PredicateDefinition} for a block. This predicate describes under what
    * conditions the block should be hidden from an applicant filling out the program form.
    *
    * @param programId the ID of the program to update
@@ -235,6 +235,19 @@ public interface ProgramService {
    */
   ProgramDefinition setBlockPredicate(
       long programId, long blockDefinitionId, PredicateDefinition predicate)
+      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException;
+
+  /**
+   * Remove the visibility {@link PredicateDefinition} for a block.
+   *
+   * @param programId the ID of the program to update
+   * @param blockDefinitionId the ID of the block to update
+   * @return the updated {@link ProgramDefinition}
+   * @throws ProgramNotFoundException when programId does not correspond to a real Program.
+   * @throws ProgramBlockDefinitionNotFoundException when blockDefinitionId does not correspond to a
+   *     real Block.
+   */
+  ProgramDefinition removeBlockPredicate(long programId, long blockDefinitionId)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException;
 
   /**

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -414,10 +414,17 @@ public class ProgramServiceImpl implements ProgramService {
 
     BlockDefinition blockDefinition =
         programDefinition.getBlockDefinition(blockDefinitionId).toBuilder()
-            .setVisibilityPredicate(Optional.of(predicate))
+            .setVisibilityPredicate(Optional.ofNullable(predicate))
             .build();
 
     return updateProgramDefinitionWithBlockDefinition(programDefinition, blockDefinition);
+  }
+
+  @Override
+  @Transactional
+  public ProgramDefinition removeBlockPredicate(long programId, long blockDefinitionId)
+      throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
+    return setBlockPredicate(programId, blockDefinitionId, null);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import javax.annotation.Nullable;
 import models.Account;
 import models.Application;
 import models.Program;
@@ -408,7 +409,7 @@ public class ProgramServiceImpl implements ProgramService {
   @Override
   @Transactional
   public ProgramDefinition setBlockPredicate(
-      long programId, long blockDefinitionId, PredicateDefinition predicate)
+      long programId, long blockDefinitionId, @Nullable PredicateDefinition predicate)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
 

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -42,6 +42,7 @@ POST    /admin/programs/:programId/blocks/:blockDefinitionId/delete    controlle
 # A controller for pages for an admin to configure show/hide logic on blocks for a program
 GET     /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates/edit    controllers.admin.AdminProgramBlockPredicatesController.edit(request: Request, programId: Long, blockDefinitionId: Long)
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates         controllers.admin.AdminProgramBlockPredicatesController.update(request: Request, programId: Long, blockDefinitionId: Long)
+POST    /admin/programs/:programId/blocks/:blockDefinitionId/edit/predicates/delete  controllers.admin.AdminProgramBlockPredicatesController.destroy(programId: Long, blockDefinitionId: Long)
 
 # A controller for adding and removing questions from program blocks
 POST    /admin/programs/:programId/blocks/:blockDefinitionId/questions                                     controllers.admin.AdminProgramBlockQuestionsController.create(request: Request, programId: Long, blockDefinitionId: Long)

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -196,4 +196,40 @@ public class AdminProgramBlockPredicatesControllerTest extends WithPostgresConta
         controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
     assertThat(Helpers.contentAsString(redirectResult)).contains("This block is always shown.");
   }
+
+  @Test
+  public void destroy_removesPredicate() throws Exception {
+    // First add a predicate and assert its presence.
+    Http.Request request =
+        fakeRequest()
+            .bodyForm(
+                ImmutableMap.of(
+                    "predicateAction",
+                    "HIDE_BLOCK",
+                    "questionId",
+                    "1",
+                    "scalar",
+                    "FIRST_NAME",
+                    "operator",
+                    "EQUAL_TO",
+                    "predicateValue",
+                    "Hello"))
+            .build();
+    Result resultWithPredicate = controller.update(request, programWithThreeBlocks.id, 3L);
+    assertThat(resultWithPredicate.flash().get("success").get())
+        .contains("Saved visibility condition");
+
+    // Then use the destroy endpoint and confirm the predicate's absence.
+    Result resultWithoutPredicate = controller.destroy(programWithThreeBlocks.id, 3L);
+
+    assertThat(resultWithoutPredicate.status()).isEqualTo(SEE_OTHER);
+    assertThat(resultWithoutPredicate.flash().get("success").get())
+        .contains("Removed the visibility condition for this block.");
+
+    // For some reason the above result has an empty contents. So we test the new content of the
+    // edit page manually.
+    Result redirectResult =
+        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+    assertThat(Helpers.contentAsString(redirectResult)).contains("This block is always shown.");
+  }
 }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -632,6 +632,30 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
+  public void removeBlockPredicate() throws Exception {
+    Program program = ProgramBuilder.newDraftProgram().build();
+
+    // First set the predicate and assert its presence.
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of(""))),
+            PredicateAction.HIDE_BLOCK);
+    ps.setBlockPredicate(program.id, 1L, predicate);
+
+    ProgramDefinition foundWithPredicate = ps.getProgramDefinition(program.id);
+    assertThat(foundWithPredicate.blockDefinitions().get(0).visibilityPredicate())
+        .hasValue(predicate);
+
+    // Then remove that predicate and assert its absence.
+    ps.removeBlockPredicate(program.id, 1L);
+
+    ProgramDefinition foundWithoutPredicate = ps.getProgramDefinition(program.id);
+    assertThat(foundWithoutPredicate.blockDefinitions().get(0).visibilityPredicate()).isEmpty();
+  }
+
+  @Test
   public void setProgramQuestionDefinitionOptionality() throws Exception {
     QuestionDefinition question = nameQuestion;
     ProgramDefinition programDefinition =


### PR DESCRIPTION
### Description
This is part one of allowing admins to remove predicates. The next and final part is to add a button to the UI that calls the new `destroy` endpoint.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #322
