### PR TITLE
Center the applicant program index view

### DIFF
--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -122,19 +122,27 @@ public class ProgramIndexView extends BaseHtmlView {
     ContainerTag content =
         div()
             .withId("main-content")
-            .withClasses(
-                Styles.MX_AUTO, Styles.MY_4, Styles.W_3_5, StyleUtils.responsiveSmall(Styles.M_10))
+            .withClasses(Styles.MX_AUTO, Styles.MY_4, StyleUtils.responsiveSmall(Styles.M_10))
             .with(
                 h2().withText(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName()))
-                    .withClasses(Styles.BLOCK, Styles.MB_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD));
+                    .withClasses(Styles.MB_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD));
+
+    // The different program card containers should have the same styling, by using the program
+    // count of the larger set of programs
+    String cardContainerStyles =
+        programCardsContainerStyles(
+            draftPrograms.size() > activePrograms.size()
+                ? draftPrograms.size()
+                : activePrograms.size());
+
     if (!draftPrograms.isEmpty()) {
       content
           .with(
               h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_IN_PROGRESS.getKeyName()))
-                  .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
+                  .withClasses(ApplicantStyles.PROGRAM_CARDS_SUBTITLE))
           .with(
               div()
-                  .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                  .withClasses(cardContainerStyles)
                   .with(
                       each(
                           draftPrograms,
@@ -142,16 +150,16 @@ public class ProgramIndexView extends BaseHtmlView {
                               programCard(messages, program, applicantId, preferredLocale, true))));
     }
     if (!draftPrograms.isEmpty() && !activePrograms.isEmpty()) {
-      content.with(hr());
+      content.with(hr().withClass(Styles.MY_16));
     }
     if (!activePrograms.isEmpty()) {
       content
           .with(
               h2().withText(messages.at(MessageKey.TITLE_PROGRAMS_ACTIVE.getKeyName()))
-                  .withClasses(Styles.MT_10, Styles.MB_4, Styles.TEXT_LG))
+                  .withClasses(ApplicantStyles.PROGRAM_CARDS_SUBTITLE))
           .with(
               div()
-                  .withClasses(ApplicantStyles.PROGRAM_CARDS_CONTAINER)
+                  .withClasses(cardContainerStyles)
                   .with(
                       each(
                           activePrograms,
@@ -160,7 +168,21 @@ public class ProgramIndexView extends BaseHtmlView {
                                   messages, program, applicantId, preferredLocale, false))));
     }
 
-    return div().withClasses(Styles.FLEX, Styles.JUSTIFY_CENTER).with(content);
+    return div().withClasses(Styles.FLEX, Styles.FLEX_COL, Styles.PLACE_ITEMS_CENTER).with(content);
+  }
+
+  /**
+   * This method generates a list of style classes with responsive column counts. The number of
+   * columns should not exceed the number of programs, or the program card container will not be
+   * centered.
+   */
+  private String programCardsContainerStyles(int numPrograms) {
+    return StyleUtils.joinStyles(
+        ApplicantStyles.PROGRAM_CARDS_CONTAINER_BASE,
+        numPrograms >= 2 ? StyleUtils.responsiveMedium(Styles.GRID_COLS_2) : "",
+        numPrograms >= 3 ? StyleUtils.responsiveLarge(Styles.GRID_COLS_3) : "",
+        numPrograms >= 4 ? StyleUtils.responsiveXLarge(Styles.GRID_COLS_4) : "",
+        numPrograms >= 5 ? StyleUtils.responsive2XLarge(Styles.GRID_COLS_5) : "");
   }
 
   private ContainerTag programCard(

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -40,11 +40,18 @@ public final class ApplicantStyles {
   public static final String H2_PROGRAM_TITLE =
       StyleUtils.joinStyles(BaseStyles.TEXT_SEATTLE_BLUE, Styles.TEXT_LG, Styles.FONT_BOLD);
 
-  public static final String PROGRAM_CARDS_CONTAINER =
-      StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_WRAP, Styles.GAP_4, Styles.MB_16);
+  public static final String PROGRAM_CARDS_SUBTITLE =
+      StyleUtils.joinStyles(Styles.MY_4, Styles.TEXT_LG);
+  public static final String PROGRAM_CARDS_CONTAINER_BASE =
+      StyleUtils.joinStyles(
+          Styles.GRID,
+          Styles.GRID_COLS_1,
+          Styles.GAP_4,
+          Styles.PLACE_ITEMS_CENTER,
+          StyleUtils.responsiveSmall(Styles.GRID_COLS_1),
+          StyleUtils.responsiveLarge(Styles.GAP_8));
   public static final String PROGRAM_CARD =
       StyleUtils.joinStyles(
-          Styles.INLINE_BLOCK,
           Styles.W_FULL,
           StyleUtils.responsiveSmall(Styles.W_72),
           Styles.H_72,

--- a/universal-application-tool-0.0.1/app/views/style/StyleUtils.java
+++ b/universal-application-tool-0.0.1/app/views/style/StyleUtils.java
@@ -93,6 +93,22 @@ public class StyleUtils {
     return applyUtilityClass(RESPONSIVE_LG, styles);
   }
 
+  public static String responsiveXLarge(String... styles) {
+    return applyUtilityClass(RESPONSIVE_XL, styles);
+  }
+
+  public static String responsiveXLarge(ImmutableList<String> styles) {
+    return applyUtilityClass(RESPONSIVE_XL, styles);
+  }
+
+  public static String responsive2XLarge(String... styles) {
+    return applyUtilityClass(RESPONSIVE_2XL, styles);
+  }
+
+  public static String responsive2XLarge(ImmutableList<String> styles) {
+    return applyUtilityClass(RESPONSIVE_2XL, styles);
+  }
+
   public static String joinStyles(String... styles) {
     return String.join(" ", styles);
   }


### PR DESCRIPTION
### Description
Actually center the applicant program index view by using a grid and using responsive grid column size. The reason for the `programCardsContainerStyles` method is to limit how many columns the program cards container can have when there are only 1-5 programs.

![image](https://user-images.githubusercontent.com/12072571/122511859-c3c1ee80-cfbc-11eb-8323-00fef0dc6c8f.png)
![image](https://user-images.githubusercontent.com/12072571/122514207-69c32800-cfc0-11eb-880d-4697ebcfe2e4.png)
