### PR TITLE
Check uniqueness of multi-option question options

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -16,6 +16,7 @@ import services.CiviFormError;
 import services.LocalizedStrings;
 import services.Path;
 import services.applicant.RepeatedEntity;
+import services.question.QuestionOption;
 
 /** Defines a single question. */
 public abstract class QuestionDefinition {
@@ -239,6 +240,16 @@ public abstract class QuestionDefinition {
       if (multiOptionQuestionDefinition.getOptions().stream()
           .anyMatch(option -> option.optionText().hasEmptyTranslation())) {
         errors.add(CiviFormError.of("Multi-option questions cannot have blank options"));
+      }
+      int numUniqueOptionDefaultValues =
+          multiOptionQuestionDefinition.getOptions().stream()
+              .map(QuestionOption::optionText)
+              .map(LocalizedStrings::getDefault)
+              .distinct()
+              .mapToInt(s -> 1)
+              .sum();
+      if (numUniqueOptionDefaultValues != multiOptionQuestionDefinition.getOptions().size()) {
+        errors.add(CiviFormError.of("Multi-option question options must be unique"));
       }
     }
     return errors.build();

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -447,6 +447,23 @@ public class QuestionDefinitionTest {
   }
 
   @Test
+  public void validate_multiOptionQuestion_withDuplicateOptions_returnsError() {
+    QuestionDefinition question =
+        new CheckboxQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "test",
+            LocalizedStrings.withDefaultValue("test"),
+            LocalizedStrings.empty(),
+            ImmutableList.of(
+                QuestionOption.create(1L, LocalizedStrings.withDefaultValue("a")),
+                QuestionOption.create(2L, LocalizedStrings.withDefaultValue("a"))),
+            MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create());
+    assertThat(question.validate())
+        .containsOnly(CiviFormError.of("Multi-option question options must be unique"));
+  }
+
+  @Test
   public void getSupportedLocales_onlyReturnsFullySupportedLocales() {
     QuestionDefinition definition =
         new TextQuestionDefinition(


### PR DESCRIPTION
### Description
QuestionDefinition validation now checks that multi-option question options have unique default localizations.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
