### PR TITLE
Store ProgramQuestionDefinition in Block

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -13,7 +13,6 @@ import services.Path;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.PresentsErrors;
 import services.program.BlockDefinition;
-import services.program.ProgramQuestionDefinition;
 import services.program.predicate.PredicateDefinition;
 import services.question.types.ScalarType;
 
@@ -108,7 +107,8 @@ public final class Block {
               blockDefinition.programQuestionDefinitions().stream()
                   .map(
                       programQuestionDefinition ->
-                          new ApplicantQuestion(programQuestionDefinition, applicantData, repeatedEntity))
+                          new ApplicantQuestion(
+                              programQuestionDefinition, applicantData, repeatedEntity))
                   .collect(toImmutableList()));
     }
     return questionsMemo.get();

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -106,10 +106,9 @@ public final class Block {
       this.questionsMemo =
           Optional.of(
               blockDefinition.programQuestionDefinitions().stream()
-                  .map(ProgramQuestionDefinition::getQuestionDefinition)
                   .map(
-                      questionDefinition ->
-                          new ApplicantQuestion(questionDefinition, applicantData, repeatedEntity))
+                      programQuestionDefinition ->
+                          new ApplicantQuestion(programQuestionDefinition, applicantData, repeatedEntity))
                   .collect(toImmutableList()));
     }
     return questionsMemo.get();

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -12,6 +12,7 @@ import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
 import services.applicant.ValidationErrorMessage;
+import services.program.ProgramQuestionDefinition;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
@@ -26,7 +27,7 @@ import services.question.types.ScalarType;
  */
 public class ApplicantQuestion {
 
-  private final QuestionDefinition questionDefinition;
+  private final ProgramQuestionDefinition programQuestionDefinition;
   private final ApplicantData applicantData;
   private final Optional<RepeatedEntity> repeatedEntity;
 
@@ -39,7 +40,21 @@ public class ApplicantQuestion {
       QuestionDefinition questionDefinition,
       ApplicantData applicantData,
       Optional<RepeatedEntity> repeatedEntity) {
-    this.questionDefinition = checkNotNull(questionDefinition);
+    this.programQuestionDefinition = ProgramQuestionDefinition.create(checkNotNull(questionDefinition));
+    this.applicantData = checkNotNull(applicantData);
+    this.repeatedEntity = checkNotNull(repeatedEntity);
+  }
+
+  /**
+   * If this is a repeated question, it should be created with the repeated entity associated with
+   * this question. If this is not a repeated question, then it should be created with an {@code
+   * Optional.empty()} repeated entity.
+   */
+  public ApplicantQuestion(
+      ProgramQuestionDefinition programQuestionDefinition,
+      ApplicantData applicantData,
+      Optional<RepeatedEntity> repeatedEntity) {
+    this.programQuestionDefinition = checkNotNull(programQuestionDefinition);
     this.applicantData = checkNotNull(applicantData);
     this.repeatedEntity = checkNotNull(repeatedEntity);
   }
@@ -49,11 +64,11 @@ public class ApplicantQuestion {
   }
 
   public QuestionDefinition getQuestionDefinition() {
-    return this.questionDefinition;
+    return this.programQuestionDefinition.getQuestionDefinition();
   }
 
   public QuestionType getType() {
-    return questionDefinition.getQuestionType();
+    return getQuestionDefinition().getQuestionType();
   }
 
   /**
@@ -62,7 +77,7 @@ public class ApplicantQuestion {
    */
   public String getQuestionText() {
     String text =
-        questionDefinition.getQuestionText().getOrDefault(applicantData.preferredLocale());
+        getQuestionDefinition().getQuestionText().getOrDefault(applicantData.preferredLocale());
     return repeatedEntity.map(r -> r.contextualize(text)).orElse(text);
   }
 
@@ -72,7 +87,7 @@ public class ApplicantQuestion {
    */
   public String getQuestionHelpText() {
     String helpText =
-        questionDefinition.getQuestionHelpText().getOrDefault(applicantData.preferredLocale());
+        getQuestionDefinition().getQuestionHelpText().getOrDefault(applicantData.preferredLocale());
     return repeatedEntity.map(r -> r.contextualize(helpText)).orElse(helpText);
   }
 
@@ -85,7 +100,7 @@ public class ApplicantQuestion {
    * "applicant.household_member[3].name".
    */
   public Path getContextualizedPath() {
-    return questionDefinition.getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
+    return getQuestionDefinition().getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
   }
 
   /**
@@ -123,7 +138,7 @@ public class ApplicantQuestion {
 
     // Metadata for enumerators is stored for each JSON array element, but we rely on metadata for
     // the first one.
-    if (questionDefinition.isEnumerator()) {
+    if (getQuestionDefinition().isEnumerator()) {
       contextualizedMetadataPath =
           getContextualizedPath().atIndex(0).join(Scalar.PROGRAM_UPDATED_IN);
     }
@@ -136,7 +151,7 @@ public class ApplicantQuestion {
 
     // Metadata for enumerators are stored for each JSON array element, but we rely on metadata for
     // the first one.
-    if (questionDefinition.isEnumerator()) {
+    if (getQuestionDefinition().isEnumerator()) {
       contextualizedMetadataPath = getContextualizedPath().atIndex(0).join(Scalar.UPDATED_AT);
     }
 
@@ -215,7 +230,7 @@ public class ApplicantQuestion {
   public boolean equals(@Nullable Object object) {
     if (object instanceof ApplicantQuestion) {
       ApplicantQuestion that = (ApplicantQuestion) object;
-      return this.questionDefinition.equals(that.questionDefinition)
+      return this.getQuestionDefinition().equals(that.getQuestionDefinition())
           && this.applicantData.equals(that.applicantData);
     }
     return false;
@@ -223,6 +238,6 @@ public class ApplicantQuestion {
 
   @Override
   public int hashCode() {
-    return Objects.hash(questionDefinition, applicantData);
+    return Objects.hash(getQuestionDefinition(), applicantData);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -40,7 +40,8 @@ public class ApplicantQuestion {
       QuestionDefinition questionDefinition,
       ApplicantData applicantData,
       Optional<RepeatedEntity> repeatedEntity) {
-    this.programQuestionDefinition = ProgramQuestionDefinition.create(checkNotNull(questionDefinition));
+    this.programQuestionDefinition =
+        ProgramQuestionDefinition.create(checkNotNull(questionDefinition));
     this.applicantData = checkNotNull(applicantData);
     this.repeatedEntity = checkNotNull(repeatedEntity);
   }
@@ -100,7 +101,8 @@ public class ApplicantQuestion {
    * "applicant.household_member[3].name".
    */
   public Path getContextualizedPath() {
-    return getQuestionDefinition().getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
+    return getQuestionDefinition()
+        .getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
@@ -26,9 +26,8 @@ public interface PresentsErrors {
   ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors();
 
   /**
-   * Returns true if the question has been answered by the applicant. If the question is optional,
-   * blank answers from the same program counts as answered. In general, if a question is not
-   * answered, it cannot have errors associated with it.
+   * Returns true if the question has been answered by the applicant, even if that answer was blank.
+   * In general, if a question is not answered, it cannot have errors associated with it.
    */
   boolean isAnswered();
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
@@ -27,8 +27,8 @@ public interface PresentsErrors {
 
   /**
    * Returns true if the question has been answered by the applicant. If the question is optional,
-   * blank answers from the same program counts as answered. In general, if a question is not answered,
-   * it cannot have errors associated with it.
+   * blank answers from the same program counts as answered. In general, if a question is not
+   * answered, it cannot have errors associated with it.
    */
   boolean isAnswered();
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
@@ -26,8 +26,9 @@ public interface PresentsErrors {
   ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors();
 
   /**
-   * Returns true if the question has been answered by the applicant, even if that answer was blank.
-   * In general, if a question is not answered, it cannot have errors associated with it.
+   * Returns true if the question has been answered by the applicant. If the question is optional,
+   * blank answers from the same program counts as answered. In general, if a question is not answered,
+   * it cannot have errors associated with it.
    */
   boolean isAnswered();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -56,6 +56,7 @@ public class ApplicantQuestionRendererFactory {
       throws UnsupportedQuestionTypeException {
     QuestionDefinitionBuilder builder =
         new QuestionDefinitionBuilder()
+            .setId(1L)
             .setName("")
             .setDescription("")
             .setQuestionText(LocalizedStrings.of(Locale.US, "Sample question text"))

--- a/universal-application-tool-0.0.1/test/services/applicant/question/AddressQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/AddressQuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.Applicant;
@@ -22,14 +23,17 @@ public class AddressQuestionTest {
 
   private static final AddressQuestionDefinition addressQuestionDefinition =
       new AddressQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",
           LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"));
+          LocalizedStrings.of(Locale.US, "help text"),
+          AddressQuestionDefinition.AddressValidationPredicates.create());
 
   private static final AddressQuestionDefinition noPoBoxAddressQuestionDefinition =
       new AddressQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/DateQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/DateQuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import models.Applicant;
 import org.junit.Before;
@@ -19,6 +20,7 @@ import support.QuestionAnswerer;
 public class DateQuestionTest extends WithPostgresContainer {
   private static final DateQuestionDefinition dateQuestionDefinition =
       new DateQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EmailQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EmailQuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import models.Applicant;
 import org.junit.Before;
@@ -19,6 +20,7 @@ import support.QuestionAnswerer;
 public class EmailQuestionTest extends WithPostgresContainer {
   private static final EmailQuestionDefinition emailQuestionDefinition =
       new EmailQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.Applicant;
@@ -27,6 +28,7 @@ import support.TestQuestionBank;
 public class EnumeratorQuestionTest extends WithPostgresContainer {
   private static final EnumeratorQuestionDefinition enumeratorQuestionDefinition =
       new EnumeratorQuestionDefinition(
+          OptionalLong.of(1),
           "household members",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/FileUploadQuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import models.Applicant;
 import org.junit.Before;
@@ -18,6 +19,7 @@ import support.QuestionAnswerer;
 public class FileUploadQuestionTest {
   private static final FileUploadQuestionDefinition fileUploadQuestionDefinition =
       new FileUploadQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import org.junit.Before;
 import org.junit.Test;
 import services.LocalizedStrings;
@@ -20,6 +21,7 @@ public class MultiSelectQuestionTest {
 
   private static final MultiOptionQuestionDefinition CHECKBOX_QUESTION =
       new CheckboxQuestionDefinition(
+          OptionalLong.of(1),
           "name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NameQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NameQuestionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.Applicant;
@@ -19,11 +20,13 @@ import support.QuestionAnswerer;
 public class NameQuestionTest {
   private static final NameQuestionDefinition nameQuestionDefinition =
       new NameQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",
           LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"));
+          LocalizedStrings.of(Locale.US, "help text"),
+          NameQuestionDefinition.NameValidationPredicates.create());
 
   private Applicant applicant;
   private ApplicantData applicantData;

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.Applicant;
@@ -25,14 +26,17 @@ public class NumberQuestionTest extends WithPostgresContainer {
 
   private static final NumberQuestionDefinition numberQuestionDefinition =
       new NumberQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",
           LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"));
+          LocalizedStrings.of(Locale.US, "help text"),
+          NumberQuestionDefinition.NumberValidationPredicates.create());
 
   private static final NumberQuestionDefinition minAndMaxNumberQuestionDefinition =
       new NumberQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +20,7 @@ public class SingleSelectQuestionTest {
 
   private static final DropdownQuestionDefinition dropdownQuestionDefinition =
       new DropdownQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.Applicant;
@@ -24,14 +25,17 @@ import support.QuestionAnswerer;
 public class TextQuestionTest extends WithPostgresContainer {
   private static final TextQuestionDefinition textQuestionDefinition =
       new TextQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",
           LocalizedStrings.of(Locale.US, "question?"),
-          LocalizedStrings.of(Locale.US, "help text"));
+          LocalizedStrings.of(Locale.US, "help text"),
+          TextQuestionDefinition.TextValidationPredicates.create());
 
   private static final TextQuestionDefinition minAndMaxLengthTextQuestionDefinition =
       new TextQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
+
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -25,6 +27,7 @@ public class CheckboxQuestionRendererTest extends WithPostgresContainer {
 
   private static final CheckboxQuestionDefinition CHECKBOX_QUESTION =
       new CheckboxQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -8,7 +8,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;

--- a/universal-application-tool-0.0.1/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -8,7 +8,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;

--- a/universal-application-tool-0.0.1/test/views/questiontypes/DropdownQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/DropdownQuestionRendererTest.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
+
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -24,6 +26,7 @@ public class DropdownQuestionRendererTest extends WithPostgresContainer {
 
   private static final DropdownQuestionDefinition QUESTION =
       new DropdownQuestionDefinition(
+          OptionalLong.of(1),
           "favorite ice cream",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
+
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -23,6 +25,7 @@ public class RadioButtonQuestionRendererTest {
 
   private static final RadioButtonQuestionDefinition QUESTION =
       new RadioButtonQuestionDefinition(
+          OptionalLong.of(1),
           "favorite ice cream",
           Optional.empty(),
           "description",

--- a/universal-application-tool-0.0.1/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -9,7 +9,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -7,7 +7,6 @@ import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
-
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;

--- a/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/TextQuestionRendererTest.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
+
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
@@ -22,6 +24,7 @@ import support.QuestionAnswerer;
 public class TextQuestionRendererTest extends WithPostgresContainer {
   private static final TextQuestionDefinition TEXT_QUESTION_DEFINITION =
       new TextQuestionDefinition(
+          OptionalLong.of(1),
           "question name",
           Optional.empty(),
           "description",


### PR DESCRIPTION
### Description
`Block` has `ProgramQuestionDefinition`s instead of just `QuestionDefinition`s, so that the blocks can eventually use the `ProgramQuestionDefinition#optiona()` field.

Question definition samples need to be created with a fake question definition ID so they can be turned into `ProgramQuestionDefinition`s for `ApplicantQuestion`. Similarly, tests had to be updated so `ApplicantQuestion`s were created with `QuestionDefinition`s with IDs so they could be turned into real `ProgramQuestionDefinition`s.

### Issue(s)
Progress towards #1307