### PR TITLE
Pretty print existing predicates

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -5,6 +5,7 @@ import static play.mvc.Results.notFound;
 import static play.mvc.Results.ok;
 
 import auth.Authorizers;
+import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import forms.BlockVisibilityPredicateForm;
 import javax.inject.Inject;
@@ -82,14 +83,15 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
       //  question). In the future we should support logical statements that combine multiple "leaf
       //  node" predicates with ANDs and ORs.
       BlockVisibilityPredicateForm predicateForm = predicateFormWrapper.get();
+      LeafOperationExpressionNode leafExpression =
+          LeafOperationExpressionNode.create(
+              predicateForm.getQuestionId(),
+              Scalar.valueOf(predicateForm.getScalar()),
+              Operator.valueOf(predicateForm.getOperator()),
+              PredicateValue.of(predicateForm.getPredicateValue()));
       PredicateDefinition predicateDefinition =
           PredicateDefinition.create(
-              PredicateExpressionNode.create(
-                  LeafOperationExpressionNode.create(
-                      predicateForm.getQuestionId(),
-                      Scalar.valueOf(predicateForm.getScalar()),
-                      Operator.valueOf(predicateForm.getOperator()),
-                      PredicateValue.of(predicateForm.getPredicateValue()))),
+              PredicateExpressionNode.create(leafExpression),
               PredicateAction.valueOf(predicateForm.getPredicateAction()));
 
       try {
@@ -108,7 +110,10 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
       return redirect(
               routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
           .flashing(
-              "success", String.format("Saved visibility condition: %s", predicateDefinition));
+              "success",
+              String.format(
+                  "Saved visibility condition: %s",
+                  leafExpression.toDisplayString(ImmutableList.of())));
     }
   }
 

--- a/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -28,5 +30,12 @@ public abstract class AndNode implements ConcretePredicateExpressionNode {
   @JsonIgnore
   public PredicateExpressionNodeType getType() {
     return PredicateExpressionNodeType.AND;
+  }
+
+  @Override
+  @Memoized
+  public String toDisplayString() {
+    return Joiner.on(" and ")
+        .join(children().stream().map(c -> c.node().toDisplayString()).toArray());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/AndNode.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import services.question.types.QuestionDefinition;
 
 /**
  * Represents the boolean operator AND. Each of the child predicates must evaluate to true for the
@@ -33,9 +34,8 @@ public abstract class AndNode implements ConcretePredicateExpressionNode {
   }
 
   @Override
-  @Memoized
-  public String toDisplayString() {
+  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
     return Joiner.on(" and ")
-        .join(children().stream().map(c -> c.node().toDisplayString()).toArray());
+        .join(children().stream().map(c -> c.node().toDisplayString(questions)).toArray());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/ConcretePredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/ConcretePredicateExpressionNode.java
@@ -9,4 +9,7 @@ public interface ConcretePredicateExpressionNode {
 
   /** Returns the type of this node, as a {@link PredicateExpressionNodeType}. */
   PredicateExpressionNodeType getType();
+
+  /** Returns a human-readable interpretation of this node. */
+  String toDisplayString();
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/ConcretePredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/ConcretePredicateExpressionNode.java
@@ -2,6 +2,8 @@ package services.program.predicate;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.ImmutableList;
+import services.question.types.QuestionDefinition;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(value = LeafOperationExpressionNode.class, name = "leaf")})
@@ -11,5 +13,5 @@ public interface ConcretePredicateExpressionNode {
   PredicateExpressionNodeType getType();
 
   /** Returns a human-readable interpretation of this node. */
-  String toDisplayString();
+  String toDisplayString(ImmutableList<QuestionDefinition> questions);
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/ConcretePredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/ConcretePredicateExpressionNode.java
@@ -12,6 +12,17 @@ public interface ConcretePredicateExpressionNode {
   /** Returns the type of this node, as a {@link PredicateExpressionNodeType}. */
   PredicateExpressionNodeType getType();
 
-  /** Returns a human-readable interpretation of this node. */
+  /**
+   * Returns a human-readable representation of this node. The list of questions is used to
+   * determine the context for particular expressions - for example, translating option IDs to
+   * human-readable text for multi-option questions. Additionally, question names are used in the
+   * expression phrase. If the predicate question is not found, the name is omitted.
+   *
+   * <p>We pass in a list rather than a single question, since some nodes (such as AND/OR) may use
+   * several different questions.
+   *
+   * @param questions the list of questions this predicate may use
+   * @return a human-readable representation of this node
+   */
   String toDisplayString(ImmutableList<QuestionDefinition> questions);
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -58,6 +58,11 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
     return PredicateExpressionNodeType.LEAF_OPERATION;
   }
 
+  /**
+   * Displays a human-readable representation of this expression, in the format "[question name]'s
+   * [scalar] [operator] [value]". For example: "home address's city is one of ["Seattle",
+   * "Tacoma"]"
+   */
   @Override
   public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
     Optional<QuestionDefinition> question =

--- a/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.base.Joiner;
 import services.applicant.question.Scalar;
 
 /**
@@ -52,6 +54,16 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   @JsonIgnore
   public PredicateExpressionNodeType getType() {
     return PredicateExpressionNodeType.LEAF_OPERATION;
+  }
+
+  @Override
+  @Memoized
+  public String toDisplayString() {
+    return Joiner.on(" ")
+        .join(
+            scalar().toDisplayString(),
+            operator().toDisplayString(),
+            comparedValue().toDisplayString());
   }
 
   public static Builder builder() {

--- a/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import services.applicant.question.Scalar;
+import services.question.types.QuestionDefinition;
 
 /**
  * Represents a JsonPath (https://github.com/json-path/JsonPath) expression for a single scalar in
@@ -57,13 +59,16 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
   }
 
   @Override
-  @Memoized
-  public String toDisplayString() {
-    return Joiner.on(" ")
-        .join(
-            scalar().toDisplayString(),
-            operator().toDisplayString(),
-            comparedValue().toDisplayString());
+  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
+    Optional<QuestionDefinition> question =
+        questions.stream().filter(q -> q.getId() == questionId()).findFirst();
+    String phrase =
+        Joiner.on(" ")
+            .join(
+                scalar().toDisplayString(),
+                operator().toDisplayString(),
+                comparedValue().toDisplayString(question));
+    return question.isEmpty() ? phrase : question.get().getName() + "'s " + phrase;
   }
 
   public static Builder builder() {

--- a/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/LeafOperationExpressionNode.java
@@ -63,7 +63,7 @@ public abstract class LeafOperationExpressionNode implements ConcretePredicateEx
     Optional<QuestionDefinition> question =
         questions.stream().filter(q -> q.getId() == questionId()).findFirst();
     String phrase =
-        Joiner.on(" ")
+        Joiner.on(' ')
             .join(
                 scalar().toDisplayString(),
                 operator().toDisplayString(),

--- a/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import services.question.types.QuestionDefinition;
 
 /**
  * Represents the boolean operator OR. At least one of the child predicates must evaluate to true
@@ -32,9 +33,8 @@ public abstract class OrNode implements ConcretePredicateExpressionNode {
   }
 
   @Override
-  @Memoized
-  public String toDisplayString() {
+  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
     return Joiner.on(" or ")
-        .join(children().stream().map(c -> c.node().toDisplayString()).toArray());
+        .join(children().stream().map(c -> c.node().toDisplayString(questions)).toArray());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/OrNode.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -27,5 +29,12 @@ public abstract class OrNode implements ConcretePredicateExpressionNode {
   @JsonIgnore
   public PredicateExpressionNodeType getType() {
     return PredicateExpressionNodeType.OR;
+  }
+
+  @Override
+  @Memoized
+  public String toDisplayString() {
+    return Joiner.on(" or ")
+        .join(children().stream().map(c -> c.node().toDisplayString()).toArray());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import services.question.types.QuestionDefinition;
@@ -31,7 +32,8 @@ public abstract class PredicateDefinition {
     return rootNode().getQuestions();
   }
 
-  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
-    return action().toDisplayString() + " " + rootNode().toDisplayString(questions);
+  public String toDisplayString(String blockName, ImmutableList<QuestionDefinition> questions) {
+    return Joiner.on(' ')
+        .join(blockName, "is", action().toDisplayString(), rootNode().toDisplayString(questions));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
@@ -29,6 +29,8 @@ public abstract class PredicateDefinition {
     return rootNode().getQuestions();
   }
 
-  // TODO(https://github.com/seattle-uat/civiform/issues/322): Override toString method and/or add a
-  //  different getDisplayString method to pretty print a predicate definition for an admin.
+  @Memoized
+  public String toDisplayString() {
+    return action().toDisplayString() + " " + rootNode().toDisplayString();
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
@@ -32,6 +32,11 @@ public abstract class PredicateDefinition {
     return rootNode().getQuestions();
   }
 
+  /**
+   * Formats this predicate definition as a human-readable sentence, in the format "[block name] is
+   * [hidden or shown if] [predicate expression]" - ex: "My Block is hidden if applicant address's
+   * city is equal to 'Seattle'".
+   */
   public String toDisplayString(String blockName, ImmutableList<QuestionDefinition> questions) {
     return Joiner.on(' ')
         .join(blockName, "is", action().toDisplayString(), rootNode().toDisplayString(questions));

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateDefinition.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import services.question.types.QuestionDefinition;
 
 @AutoValue
 public abstract class PredicateDefinition {
@@ -29,8 +31,7 @@ public abstract class PredicateDefinition {
     return rootNode().getQuestions();
   }
 
-  @Memoized
-  public String toDisplayString() {
-    return action().toDisplayString() + " " + rootNode().toDisplayString();
+  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
+    return action().toDisplayString() + " " + rootNode().toDisplayString(questions);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
@@ -79,4 +79,9 @@ public abstract class PredicateExpressionNode {
         return ImmutableSet.of();
     }
   }
+
+  @Memoized
+  public String toDisplayString() {
+    return node().toDisplayString();
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateExpressionNode.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import services.question.types.QuestionDefinition;
 
 /** Represents a predicate that can be evaluated over {@link services.applicant.ApplicantData}. */
 @AutoValue
@@ -80,8 +82,7 @@ public abstract class PredicateExpressionNode {
     }
   }
 
-  @Memoized
-  public String toDisplayString() {
-    return node().toDisplayString();
+  public String toDisplayString(ImmutableList<QuestionDefinition> questions) {
+    return node().toDisplayString(questions);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
@@ -5,7 +5,14 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import services.question.types.ScalarType;
 
 /**
  * Represents the value on the right side of a JsonPath (https://github.com/json-path/JsonPath)
@@ -16,12 +23,18 @@ import com.google.common.collect.ImmutableList;
 public abstract class PredicateValue {
 
   public static PredicateValue of(long value) {
-    return create(String.valueOf(value));
+    return create(String.valueOf(value), ScalarType.LONG);
   }
 
   public static PredicateValue of(String value) {
     // Escape the string value
-    return create(surroundWithQuotes(value));
+    return create(surroundWithQuotes(value), ScalarType.STRING);
+  }
+
+  public static PredicateValue of(LocalDate value) {
+    return create(
+        String.valueOf(value.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli()),
+        ScalarType.DATE);
   }
 
   public static PredicateValue of(ImmutableList<String> value) {
@@ -29,16 +42,32 @@ public abstract class PredicateValue {
         value.stream()
             .map(PredicateValue::surroundWithQuotes)
             .collect(toImmutableList())
-            .toString());
+            .toString(),
+        ScalarType.LIST_OF_STRINGS);
   }
 
   @JsonCreator
-  private static PredicateValue create(@JsonProperty("value") String value) {
-    return new AutoValue_PredicateValue(value);
+  private static PredicateValue create(
+      @JsonProperty("value") String value, @JsonProperty ScalarType type) {
+    return new AutoValue_PredicateValue(value, type);
   }
 
   @JsonProperty("value")
   public abstract String value();
+
+  @JsonProperty("type")
+  public abstract ScalarType type();
+
+  @Memoized
+  public String toDisplayString() {
+    if (type() == ScalarType.DATE) {
+      return Instant.ofEpochMilli(Long.parseLong(value()))
+              .atZone(ZoneId.systemDefault())
+              .toLocalDate()
+              .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+    return value();
+  }
 
   private static String surroundWithQuotes(String s) {
     return "\"" + s + "\"";

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
@@ -51,7 +51,7 @@ public abstract class PredicateValue {
 
   @JsonCreator
   private static PredicateValue create(
-      @JsonProperty("value") String value, @JsonProperty ScalarType type) {
+      @JsonProperty("value") String value, @JsonProperty("type") ScalarType type) {
     return new AutoValue_PredicateValue(value, type);
   }
 
@@ -77,6 +77,7 @@ public abstract class PredicateValue {
       MultiOptionQuestionDefinition multiOptionQuestion =
           (MultiOptionQuestionDefinition) question.get();
       // Convert the quote-escaped string IDs to their corresponding default option text.
+      // If an ID is not valid, show "<obsolete>". An obsolete ID does not affect evaluation.
       return Splitter.on(", ")
           .splitToStream(value().substring(1, value().length() - 1))
           .map(stringId -> Long.valueOf(stringId.substring(1, stringId.length() - 1)))

--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -155,6 +155,7 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
     }
   }
 
+  /** Get the default locale representation of the option with the given ID. */
   public Optional<String> getDefaultLocaleOptionForId(long id) {
     return getOptionsForDefaultLocale().stream()
         .filter(o -> o.id() == id)

--- a/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -155,6 +155,13 @@ public abstract class MultiOptionQuestionDefinition extends QuestionDefinition {
     }
   }
 
+  public Optional<String> getDefaultLocaleOptionForId(long id) {
+    return getOptionsForDefaultLocale().stream()
+        .filter(o -> o.id() == id)
+        .map(LocalizedQuestionOption::optionText)
+        .findFirst();
+  }
+
   public MultiOptionValidationPredicates getMultiOptionValidationPredicates() {
     return (MultiOptionValidationPredicates) getValidationPredicates();
   }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -92,7 +92,10 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
                     .with(
                         div(
                             blockDefinition.visibilityPredicate().isPresent()
-                                ? blockDefinition.visibilityPredicate().get().toString()
+                                ? blockDefinition
+                                    .visibilityPredicate()
+                                    .get()
+                                    .toDisplayString(potentialPredicateQuestions)
                                 : TEXT_NO_VISIBILITY_CONDITIONS)))
             .with(
                 div()

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -95,7 +95,8 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
                                 ? blockDefinition
                                     .visibilityPredicate()
                                     .get()
-                                    .toDisplayString(potentialPredicateQuestions)
+                                    .toDisplayString(
+                                        blockDefinition.name(), potentialPredicateQuestions)
                                 : TEXT_NO_VISIBILITY_CONDITIONS)))
             .with(
                 div()

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateDefinitionTest.java
@@ -1,0 +1,23 @@
+package services.program.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import services.applicant.question.Scalar;
+
+public class PredicateDefinitionTest {
+
+  @Test
+  public void toDisplayString() {
+    PredicateDefinition predicate =
+        PredicateDefinition.create(
+            PredicateExpressionNode.create(
+                LeafOperationExpressionNode.create(
+                    1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Phoenix"))),
+            PredicateAction.HIDE_BLOCK);
+
+    assertThat(predicate.toDisplayString(ImmutableList.of()))
+        .isEqualTo("hidden if city is equal to \"Phoenix\"");
+  }
+}

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateDefinitionTest.java
@@ -17,7 +17,7 @@ public class PredicateDefinitionTest {
                     1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Phoenix"))),
             PredicateAction.HIDE_BLOCK);
 
-    assertThat(predicate.toDisplayString(ImmutableList.of()))
-        .isEqualTo("hidden if city is equal to \"Phoenix\"");
+    assertThat(predicate.toDisplayString("My Block", ImmutableList.of()))
+        .isEqualTo("My Block is hidden if city is equal to \"Phoenix\"");
   }
 }

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateExpressionNodeTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateExpressionNodeTest.java
@@ -2,7 +2,10 @@ package services.program.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 import services.applicant.question.Scalar;
 
@@ -53,5 +56,58 @@ public class PredicateExpressionNodeTest {
     PredicateExpressionNode node = PredicateExpressionNode.create(or);
 
     assertThat(node.getQuestions()).containsExactly(123L, 456L);
+  }
+
+  @Test
+  public void toDisplayString_leafNodeOnly() {
+    LeafOperationExpressionNode leaf =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of("Seattle"));
+
+    assertThat(PredicateExpressionNode.create(leaf).toDisplayString())
+        .isEqualTo("city is equal to \"Seattle\"");
+  }
+
+  @Test
+  public void toDisplayString_andNode() {
+    LeafOperationExpressionNode leaf1 =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.NUMBER, Operator.GREATER_THAN, PredicateValue.of(45));
+    LeafOperationExpressionNode leaf2 =
+        LeafOperationExpressionNode.create(
+            456L, Scalar.NUMBER, Operator.LESS_THAN_OR_EQUAL_TO, PredicateValue.of(72));
+    AndNode and =
+        AndNode.create(
+            ImmutableSet.of(
+                PredicateExpressionNode.create(leaf1), PredicateExpressionNode.create(leaf2)));
+
+    PredicateExpressionNode node = PredicateExpressionNode.create(and);
+
+    assertThat(node.toDisplayString())
+        .isEqualTo("number is greater than 45 and number is less than or equal to 72");
+  }
+
+  @Test
+  public void toDisplayString_orNode() {
+    LeafOperationExpressionNode leaf1 =
+        LeafOperationExpressionNode.create(
+            123L, Scalar.SELECTION, Operator.ANY_OF, PredicateValue.of(ImmutableList.of("a", "b")));
+    LeafOperationExpressionNode leaf2 =
+        LeafOperationExpressionNode.create(
+            456L,
+            Scalar.DATE,
+            Operator.IS_BEFORE,
+            PredicateValue.of(
+                LocalDate.parse("2021-01-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"))));
+    OrNode or =
+        OrNode.create(
+            ImmutableSet.of(
+                PredicateExpressionNode.create(leaf1), PredicateExpressionNode.create(leaf2)));
+
+    PredicateExpressionNode node = PredicateExpressionNode.create(or);
+
+    assertThat(node.toDisplayString())
+        .isEqualTo(
+            "selection contains any of [\"a\", \"b\"] or date is earlier than 2021-01-01");
   }
 }

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
@@ -34,6 +34,13 @@ public class PredicateValueTest {
   }
 
   @Test
+  public void toDisplayString_simpleList() {
+    PredicateValue value = PredicateValue.of(ImmutableList.of("kangaroo", "turtle"));
+
+    assertThat(value.toDisplayString(Optional.empty())).isEqualTo("[\"kangaroo\", \"turtle\"]");
+  }
+
+  @Test
   public void toDisplayString_multiOptionList() {
     QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
 
@@ -41,5 +48,15 @@ public class PredicateValueTest {
 
     assertThat(value.toDisplayString(Optional.of(multiOption)))
         .isEqualTo("[chocolate, strawberry]");
+  }
+
+  @Test
+  public void toDisplayString_multiOptionList_missingIdDefaultsToObsolete() {
+    QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
+
+    PredicateValue value = PredicateValue.of(ImmutableList.of("1", "100")); // 100 is not a valid ID
+
+    assertThat(value.toDisplayString(Optional.of(multiOption)))
+        .isEqualTo("[chocolate, <obsolete>]");
   }
 }

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
@@ -3,9 +3,15 @@ package services.program.predicate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.time.LocalDate;
+import java.util.Optional;
 import org.junit.Test;
+import services.question.types.QuestionDefinition;
+import support.TestQuestionBank;
 
 public class PredicateValueTest {
+
+  private final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
 
   @Test
   public void stringValue_escapedProperly() {
@@ -17,5 +23,23 @@ public class PredicateValueTest {
   public void listOfStringsValue_escapedProperly() {
     PredicateValue value = PredicateValue.of(ImmutableList.of("hello", "world"));
     assertThat(value.value()).isEqualTo("[\"hello\", \"world\"]");
+  }
+
+  @Test
+  public void toDisplayString_date() {
+    PredicateValue value = PredicateValue.of(LocalDate.ofYearDay(2021, 1));
+
+    assertThat(value.value()).isEqualTo("1609459200000");
+    assertThat(value.toDisplayString(Optional.empty())).isEqualTo("2021-01-01");
+  }
+
+  @Test
+  public void toDisplayString_multiOptionList() {
+    QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
+
+    PredicateValue value = PredicateValue.of(ImmutableList.of("1", "2"));
+
+    assertThat(value.toDisplayString(Optional.of(multiOption)))
+        .isEqualTo("[chocolate, strawberry]");
   }
 }


### PR DESCRIPTION
### Description
1. Adds `toDisplayString` methods for predicate nodes that are human-readable
2. Uses question definitions to convert values to readable representations
3. Shows pretty-printed phrase in block predicate edit view

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#322 
<img width="892" alt="Screen Shot 2021-06-21 at 2 13 48 PM" src="https://user-images.githubusercontent.com/8559046/122829093-615a3e00-d29b-11eb-8172-507d6fb7c50e.png">
<img width="890" alt="Screen Shot 2021-06-21 at 3 42 54 PM" src="https://user-images.githubusercontent.com/8559046/122837601-3971d700-d2a9-11eb-9ed0-723a00e69e06.png">
