### PR TITLE
Fix: add a default value for new AutoValue field

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
@@ -49,9 +49,14 @@ public abstract class PredicateValue {
         ScalarType.LIST_OF_STRINGS);
   }
 
+  /**
+   * Default to STRING type for values added before 2021-06-21 (this is before predicates were
+   * launched publicly, so no prod predicates were affected).
+   */
   @JsonCreator
   private static PredicateValue create(
-      @JsonProperty("value") String value, @JsonProperty("type") ScalarType type) {
+      @JsonProperty("value") String value,
+      @JsonProperty(value = "type", defaultValue = "STRING") ScalarType type) {
     return new AutoValue_PredicateValue(value, type);
   }
 

--- a/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
+++ b/universal-application-tool-0.0.1/app/services/program/predicate/PredicateValue.java
@@ -49,14 +49,14 @@ public abstract class PredicateValue {
         ScalarType.LIST_OF_STRINGS);
   }
 
-  /**
-   * Default to STRING type for values added before 2021-06-21 (this is before predicates were
-   * launched publicly, so no prod predicates were affected).
-   */
   @JsonCreator
   private static PredicateValue create(
-      @JsonProperty("value") String value,
-      @JsonProperty(value = "type", defaultValue = "STRING") ScalarType type) {
+      @JsonProperty("value") String value, @JsonProperty("type") ScalarType type) {
+    // Default to STRING type for values added before 2021-06-21 (this is before predicates were
+    // launched publicly, so no prod predicates were affected).
+    if (type == null) {
+      type = ScalarType.STRING;
+    }
     return new AutoValue_PredicateValue(value, type);
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
@@ -2,6 +2,8 @@ package services.program.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -12,6 +14,15 @@ import support.TestQuestionBank;
 public class PredicateValueTest {
 
   private final TestQuestionBank testQuestionBank = new TestQuestionBank(false);
+
+  @Test
+  public void oldValue_parsesCorrectly() throws Exception {
+    String valueWithoutType = "{\"value\":\"\\\"hello\\\"\"}";
+    ObjectMapper mapper = new ObjectMapper().registerModule(new GuavaModule());
+
+    assertThat(mapper.readValue(valueWithoutType, PredicateValue.class))
+        .isEqualTo(PredicateValue.of("hello"));
+  }
 
   @Test
   public void stringValue_escapedProperly() {


### PR DESCRIPTION
### Description
1. I added a `type` field in `PredicateValue` in #1395, but existing predicates don't have this field. It broke staging
2. Adds a default type value

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#322 
