### PR TITLE
Parse number into integer on client-side

### DIFF
--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -196,7 +196,7 @@ public class FieldWithLabel {
         fieldTag.withValue(String.valueOf(this.fieldValueNumber.getAsLong()));
       }
       // We only allow integer input.
-      fieldTag.attr("oninput", "this.value=(parseInt(this.value)||0)");
+      fieldTag.attr("oninput", "n=parseInt(this.value);this.value=Number.isNaN(n)?'':n;");
     } else {
       fieldTag.withValue(this.fieldValue);
     }

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -195,6 +195,8 @@ public class FieldWithLabel {
       if (this.fieldValueNumber.isPresent()) {
         fieldTag.withValue(String.valueOf(this.fieldValueNumber.getAsLong()));
       }
+      // We only allow integer input.
+      fieldTag.attr("oninput", "this.value=(parseInt(this.value)||0)");
     } else {
       fieldTag.withValue(this.fieldValue);
     }

--- a/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
@@ -38,7 +38,7 @@ public class FieldWithLabelTest {
   @Test
   public void number_setsNoValueByDefault() {
     FieldWithLabel fieldWithLabel = FieldWithLabel.number();
-    assertThat(fieldWithLabel.getContainer().render()).doesNotContain("value");
+    assertThat(fieldWithLabel.getContainer().render()).doesNotContain(" value");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
@@ -38,6 +38,7 @@ public class FieldWithLabelTest {
   @Test
   public void number_setsNoValueByDefault() {
     FieldWithLabel fieldWithLabel = FieldWithLabel.number();
+    // No "value"="some-value" attribute. But allow "this.value" in script.
     assertThat(fieldWithLabel.getContainer().render()).doesNotContain(" value");
   }
 


### PR DESCRIPTION
### Description
User can only input integer in number input fields.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1391
