### PR TITLE
Revert "Revert "Minify prod css (#1386)" (#1392)"

### DIFF
--- a/bin/refresh-styles
+++ b/bin/refresh-styles
@@ -1,0 +1,7 @@
+#! /bin/bash
+pushd $(git rev-parse --show-toplevel)
+
+# allocate a tty for better test output even though not strictly needed.
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 --entrypoint npx civiform tailwindcss build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css
+
+popd

--- a/bin/refresh-styles
+++ b/bin/refresh-styles
@@ -1,7 +1,10 @@
 #! /bin/bash
 pushd $(git rev-parse --show-toplevel)
 
-# allocate a tty for better test output even though not strictly needed.
-docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 --entrypoint npx civiform tailwindcss build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \
+	-v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 \
+	--entrypoint npx \
+	civiform \
+	tailwindcss build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css
 
 popd

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -1,5 +1,12 @@
 package views.style;
 
+/**
+ * Constant class containing the names of styles that we have added to tailwind.
+ *
+ * <p>This file is special - strings in this file, within double quotes, are *not* stripped from the
+ * tailwind CSS during production optimization. If you add a string here, run bin/refresh-styles or
+ * restart bin/run-dev.
+ */
 public final class BaseStyles {
 
   public static final String LINK_TEXT = Styles.TEXT_BLUE_400;

--- a/universal-application-tool-0.0.1/app/views/style/Styles.java
+++ b/universal-application-tool-0.0.1/app/views/style/Styles.java
@@ -3,6 +3,10 @@ package views.style;
 /**
  * Class to hold constants for Tailwind CSS class names. see https://tailwindcss.com/docs for more
  * info.
+ *
+ * <p>This file is special - strings in this file, within double quotes, are *not* stripped from the
+ * tailwind CSS during production optimization. If you add a string here, run bin/refresh-styles or
+ * restart bin/run-dev.
  */
 public final class Styles {
   public static final String CONTAINER = "container";

--- a/universal-application-tool-0.0.1/project/TailwindBuilder.scala
+++ b/universal-application-tool-0.0.1/project/TailwindBuilder.scala
@@ -10,7 +10,7 @@ object TailwindBuilder {
 
       override def beforeStarted() = {
         process = Option(
-          Process("npx tailwindcss-cli@latest build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css", base).run()
+          Process("npx tailwindcss build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css", base).run()
         )
       }
 

--- a/universal-application-tool-0.0.1/tailwind.config.js
+++ b/universal-application-tool-0.0.1/tailwind.config.js
@@ -1,8 +1,31 @@
 module.exports = {
-  purge: [
-    './**/*.html',
-    './**/*.js',
-  ],
+  purge: {
+    enabled: true,
+    content: [
+      './app/assets/javascripts/*.ts',
+      './app/views/style/Styles.java',
+      './app/views/style/BaseStyles.java'
+    ],
+    extract: {
+      java: (content) => {
+        return content;
+      }
+    },
+    transform: {
+      java: (content) => {
+        var output = [];
+        for (const match of content.matchAll(/"([\w-/:]+)"/g)) {
+           output.push(match[1]);
+           // We don't know which, if any, of these prefixes are in use for any class in particular.
+           // We therefore have to use every combination of them.
+           for (const prefix of ['even', 'focus', 'focus-within', 'hover', 'disabled', 'sm', 'md', 'lg', 'xl', '2xl']) {
+             output.push(prefix + ':' + match[1]);
+           }
+        }
+        return output;
+      }
+    }
+  },
   darkMode: false,  // or 'media' or 'class'
   theme: {
     extend: {

--- a/universal-application-tool-0.0.1/tailwindbuilder.sbt
+++ b/universal-application-tool-0.0.1/tailwindbuilder.sbt
@@ -3,7 +3,7 @@ import scala.sys.process.Process
 lazy val tailwindCli = TaskKey[Unit]("run tailwindCLI when packaging the application")
 
 def runTailwindCli(file: File) = {
-  Process("npx tailwindcss-cli@latest build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css", file) !
+  Process("npx tailwindcss build -i ./app/assets/stylesheets/styles.css -o ./public/stylesheets/tailwind.css", file) !
 }
 
 tailwindCli := {


### PR DESCRIPTION
This reverts commit a2d9bfe95a788daef5255a6ee5d05972fc574e6c.

### Description
This solution is only okay.  Because we have copied every class - including very many that we do not use - into `Styles.java`, and because we programmatically create utility classes, we have to keep an awful lot of CSS that we don't actually need.  Still, this brings us from 4.6 MB to 1.6 MB, which is something - and eliminates the prod/dev distinction, so we can see if we're about to screw up the styles in prod.

It also adds a tool to refresh styles without restarting `bin/run-dev`, which is a little helpful for development here.

We can get down to below a megabyte by removing all the styles from `Styles.java` that we do not use.  What we cannot do is analyze that file at minification-time to see which variables are in use.  I'll leave that choice - whether to delete all the classes we don't need - to someone else.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)