### PR TITLE
Fix operator/scalar mismatch 

### DIFF
--- a/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
+++ b/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
@@ -1,5 +1,6 @@
 package forms;
 
+import com.google.common.collect.Sets;
 import play.data.validation.Constraints;
 import play.data.validation.Constraints.Validatable;
 import play.data.validation.Constraints.Validate;
@@ -54,7 +55,7 @@ public class BlockVisibilityPredicateForm implements Validatable<String> {
     Scalar scalar = Scalar.valueOf(getScalar());
 
     // This should never happen since we only expose the usable operators for the given scalar.
-    if (!operator.getOperableTypes().contains(scalar.toScalarType())) {
+    if (Sets.intersection(operator.getOperableTypes(), scalar.toScalarType()).isEmpty()) {
       return String.format(
           "Cannot use operator \"%s\" on scalar \"%s\".",
           operator.toDisplayString(), scalar.toDisplayString());

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -27,7 +27,8 @@ public enum Scalar {
   LINE2("address line 2", ScalarType.STRING),
   MIDDLE_NAME("middle name", ScalarType.STRING),
   NUMBER("number", ScalarType.LONG),
-  SELECTION("selection", ScalarType.LIST_OF_STRINGS),
+  // Selection may be either STRING (single-select) or LIST_OF_STRINGS (multi-select)
+  SELECTION("selection", ScalarType.LIST_OF_STRINGS, ScalarType.STRING),
   STATE("state", ScalarType.STRING),
   STREET("street", ScalarType.STRING),
   TEXT("text", ScalarType.STRING),
@@ -43,19 +44,19 @@ public enum Scalar {
   PROGRAM_UPDATED_IN("program updated in", ScalarType.LONG);
 
   private final String displayString;
-  private final ScalarType scalarType;
+  private final ImmutableSet<ScalarType> scalarType;
 
   /** The displayString should only be used in the Admin UI, since it is not localized. */
-  Scalar(String displayString, ScalarType scalarType) {
+  Scalar(String displayString, ScalarType... scalarType) {
     this.displayString = displayString;
-    this.scalarType = scalarType;
+    this.scalarType = ImmutableSet.copyOf(scalarType);
   }
 
   public String toDisplayString() {
     return this.displayString;
   }
 
-  public ScalarType toScalarType() {
+  public ImmutableSet<ScalarType> toScalarType() {
     return this.scalarType;
   }
 


### PR DESCRIPTION
### Description
Single-select questions are stored as STRINGs, but we had `LIST_OF_STRINGS` as the type for all `selection`s in `Scalar`. This prevented us from being able to submit the predicate form for single-select questions

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#322
