### PR TITLE
Clean up `Scalar` enum to use its new built-in scalar types

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -117,15 +116,14 @@ public class ApplicantQuestion {
    */
   public ImmutableMap<Path, ScalarType> getContextualizedScalars() {
     try {
-      return ImmutableMap.<Scalar, ScalarType>builder()
-          .putAll(Scalar.getScalars(getType()))
-          .putAll(Scalar.getMetadataScalars())
+      return ImmutableSet.<Scalar>builder()
+          .addAll(Scalar.getScalars(getType()))
+          .addAll(Scalar.getMetadataScalars())
           .build()
-          .entrySet()
           .stream()
           .collect(
               ImmutableMap.toImmutableMap(
-                  entry -> getContextualizedPath().join(entry.getKey()), Map.Entry::getValue));
+                  scalar -> getContextualizedPath().join(scalar), scalar -> scalar.toScalarType()));
     } catch (InvalidQuestionTypeException | UnsupportedQuestionTypeException e) {
       throw new RuntimeException(e);
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Scalar.java
@@ -1,6 +1,5 @@
 package services.applicant.question;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -59,48 +58,28 @@ public enum Scalar {
     return this.scalarType;
   }
 
-  // TODO(natsid): Refactor the following (ADDRESS_SCALARS, etc) to take advantage of the fact that
-  //  the scalar type is now stored on the scalar itself.
+  private static final ImmutableSet<Scalar> ADDRESS_SCALARS =
+      ImmutableSet.of(STREET, LINE2, CITY, STATE, ZIP);
 
-  private static final ImmutableMap<Scalar, ScalarType> ADDRESS_SCALARS =
-      ImmutableMap.of(
-          STREET, ScalarType.STRING,
-          LINE2, ScalarType.STRING,
-          CITY, ScalarType.STRING,
-          STATE, ScalarType.STRING,
-          ZIP, ScalarType.STRING);
+  private static final ImmutableSet<Scalar> DATE_SCALARS = ImmutableSet.of(DATE);
 
-  private static final ImmutableMap<Scalar, ScalarType> DATE_SCALARS =
-      ImmutableMap.of(DATE, ScalarType.DATE);
+  private static final ImmutableSet<Scalar> EMAIL_SCALARS = ImmutableSet.of(EMAIL);
 
-  private static final ImmutableMap<Scalar, ScalarType> EMAIL_SCALARS =
-      ImmutableMap.of(EMAIL, ScalarType.STRING);
+  private static final ImmutableSet<Scalar> FILE_UPLOAD_SCALARS = ImmutableSet.of(FILE_KEY);
 
-  private static final ImmutableMap<Scalar, ScalarType> FILE_UPLOAD_SCALARS =
-      ImmutableMap.of(FILE_KEY, ScalarType.STRING);
+  private static final ImmutableSet<Scalar> MULTI_SELECT_SCALARS = ImmutableSet.of(SELECTION);
 
-  private static final ImmutableMap<Scalar, ScalarType> MULTI_SELECT_SCALARS =
-      ImmutableMap.of(SELECTION, ScalarType.LIST_OF_STRINGS);
+  private static final ImmutableSet<Scalar> NAME_SCALARS =
+      ImmutableSet.of(FIRST_NAME, MIDDLE_NAME, LAST_NAME);
 
-  private static final ImmutableMap<Scalar, ScalarType> NAME_SCALARS =
-      ImmutableMap.of(
-          FIRST_NAME, ScalarType.STRING,
-          MIDDLE_NAME, ScalarType.STRING,
-          LAST_NAME, ScalarType.STRING);
+  private static final ImmutableSet<Scalar> NUMBER_SCALARS = ImmutableSet.of(NUMBER);
 
-  private static final ImmutableMap<Scalar, ScalarType> NUMBER_SCALARS =
-      ImmutableMap.of(NUMBER, ScalarType.LONG);
+  private static final ImmutableSet<Scalar> SINGLE_SELECT_SCALARS = ImmutableSet.of(SELECTION);
 
-  private static final ImmutableMap<Scalar, ScalarType> SINGLE_SELECT_SCALARS =
-      ImmutableMap.of(SELECTION, ScalarType.STRING);
+  private static final ImmutableSet<Scalar> TEXT_SCALARS = ImmutableSet.of(TEXT);
 
-  private static final ImmutableMap<Scalar, ScalarType> TEXT_SCALARS =
-      ImmutableMap.of(TEXT, ScalarType.STRING);
-
-  private static final ImmutableMap<Scalar, ScalarType> METADATA_SCALARS =
-      ImmutableMap.of(
-          UPDATED_AT, ScalarType.LONG,
-          PROGRAM_UPDATED_IN, ScalarType.LONG);
+  private static final ImmutableSet<Scalar> METADATA_SCALARS =
+      ImmutableSet.of(UPDATED_AT, PROGRAM_UPDATED_IN);
 
   private static ImmutableSet<String> metadataScalarKeys;
 
@@ -110,7 +89,7 @@ public enum Scalar {
    * <p>The {@link QuestionType#ENUMERATOR} does not have scalars. Use {@link Scalar#ENTITY_NAME}
    * instead.
    */
-  public static ImmutableMap<Scalar, ScalarType> getScalars(QuestionType questionType)
+  public static ImmutableSet<Scalar> getScalars(QuestionType questionType)
       throws InvalidQuestionTypeException, UnsupportedQuestionTypeException {
     switch (questionType) {
       case ADDRESS:
@@ -144,7 +123,7 @@ public enum Scalar {
     }
   }
 
-  public static ImmutableMap<Scalar, ScalarType> getMetadataScalars() {
+  public static ImmutableSet<Scalar> getMetadataScalars() {
     return METADATA_SCALARS;
   }
 
@@ -152,7 +131,7 @@ public enum Scalar {
   public static ImmutableSet<String> getMetadataScalarKeys() {
     if (metadataScalarKeys == null) {
       metadataScalarKeys =
-          METADATA_SCALARS.keySet().stream()
+          METADATA_SCALARS.stream()
               .map(Scalar::name)
               .map(String::toLowerCase)
               .collect(ImmutableSet.toImmutableSet());

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -15,6 +15,7 @@ import static play.mvc.Http.HttpVerbs.POST;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import controllers.admin.routes;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
@@ -32,7 +33,6 @@ import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
-import services.question.types.ScalarType;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -276,7 +276,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
   }
 
   private ContainerTag createScalarDropdown(QuestionDefinition questionDefinition) {
-    ImmutableMap<Scalar, ScalarType> scalars;
+    ImmutableSet<Scalar> scalars;
     try {
       scalars = Scalar.getScalars(questionDefinition.getQuestionType());
     } catch (InvalidQuestionTypeException | UnsupportedQuestionTypeException e) {
@@ -286,13 +286,13 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
     }
 
     ImmutableList<ContainerTag> options =
-        scalars.entrySet().stream()
+        scalars.stream()
             .map(
-                e ->
-                    option(e.getKey().toDisplayString())
-                        .withValue(e.getKey().name())
+                scalar ->
+                    option(scalar.toDisplayString())
+                        .withValue(scalar.name())
                         // Add the scalar type as data so we can determine which operators to allow.
-                        .withData("type", e.getValue().name().toLowerCase()))
+                        .withData("type", scalar.toScalarType().name().toLowerCase()))
             .collect(toImmutableList());
 
     return new SelectWithLabel()

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -198,7 +198,7 @@ public class AdminProgramBlockPredicatesControllerTest extends WithPostgresConta
   }
 
   @Test
-  public void destroy_removesPredicate() throws Exception {
+  public void destroy_removesPredicate() {
     // First add a predicate and assert its presence.
     Http.Request request =
         fakeRequest()


### PR DESCRIPTION
This is an overdue cleanup from when I updated `Scalar` in a previous PR to take its `ScalarType` in the constructor.