### PR TITLE
Rename UAT to CivoForm in auth library

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/stylesheets/styles.css
+++ b/universal-application-tool-0.0.1/app/assets/stylesheets/styles.css
@@ -4,8 +4,6 @@
 
 /**
  * Add global styles and classes here.
- *
- * TODO: Note that the following styles are meant as how-to illustrations and do not yet reflect official UAT styles.
  */
 @layer base {
   h1 {

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -34,7 +34,7 @@ public class AdfsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  protected ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile) {
+  protected ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
     if (this.isGlobalAdmin(oidcProfile)) {
       return ImmutableSet.of(Roles.ROLE_UAT_ADMIN);
     }
@@ -42,7 +42,7 @@ public class AdfsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  protected void adaptForRole(UatProfile profile, ImmutableSet<Roles> roles) {
+  protected void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles) {
     if (roles.contains(Roles.ROLE_UAT_ADMIN)) {
       profile
           .getAccount()

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -15,7 +15,7 @@ import repository.UserRepository;
  * Right now this is only extracting the email address, since that is all that AD provides right
  * now.
  */
-public class AdfsProfileAdapter extends UatProfileAdapter {
+public class AdfsProfileAdapter extends CiviFormProfileAdapter {
   private final String adminGroupName;
 
   public AdfsProfileAdapter(

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -63,10 +63,10 @@ public class AdfsProfileAdapter extends CiviFormProfileAdapter {
   @Override
   public CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile profile) {
     if (this.isGlobalAdmin(profile)) {
-      return mergeUatProfile(
+      return mergeCiviFormProfile(
           profileFactory.wrapProfileData(profileFactory.createNewAdmin()), profile);
     }
-    return mergeUatProfile(
+    return mergeCiviFormProfile(
         profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin()), profile);
   }
 

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -61,7 +61,7 @@ public class AdfsProfileAdapter extends CiviFormProfileAdapter {
   }
 
   @Override
-  public CiviFormProfileData uatProfileFromOidcProfile(OidcProfile profile) {
+  public CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile profile) {
     if (this.isGlobalAdmin(profile)) {
       return mergeUatProfile(
           profileFactory.wrapProfileData(profileFactory.createNewAdmin()), profile);

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -61,7 +61,7 @@ public class AdfsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  public UatProfileData uatProfileFromOidcProfile(OidcProfile profile) {
+  public CiviFormProfileData uatProfileFromOidcProfile(OidcProfile profile) {
     if (this.isGlobalAdmin(profile)) {
       return mergeUatProfile(
           profileFactory.wrapProfileData(profileFactory.createNewAdmin()), profile);

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -11,9 +11,9 @@ import org.pac4j.oidc.profile.OidcProfile;
 import repository.UserRepository;
 
 /**
- * This class takes an existing UAT profile and augments it with the information from an AD profile.
- * Right now this is only extracting the email address, since that is all that AD provides right
- * now.
+ * This class takes an existing CiviForm profile and augments it with the information from an AD
+ * profile. Right now this is only extracting the email address, since that is all that AD provides
+ * right now.
  */
 public class AdfsProfileAdapter extends CiviFormProfileAdapter {
   private final String adminGroupName;

--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -36,14 +36,14 @@ public class AdfsProfileAdapter extends CiviFormProfileAdapter {
   @Override
   protected ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
     if (this.isGlobalAdmin(oidcProfile)) {
-      return ImmutableSet.of(Roles.ROLE_UAT_ADMIN);
+      return ImmutableSet.of(Roles.ROLE_CIVIFORM_ADMIN);
     }
     return ImmutableSet.of(Roles.ROLE_PROGRAM_ADMIN);
   }
 
   @Override
   protected void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles) {
-    if (roles.contains(Roles.ROLE_UAT_ADMIN)) {
+    if (roles.contains(Roles.ROLE_CIVIFORM_ADMIN)) {
       profile
           .getAccount()
           .thenAccept(

--- a/universal-application-tool-0.0.1/app/auth/Authorizers.java
+++ b/universal-application-tool-0.0.1/app/auth/Authorizers.java
@@ -7,7 +7,7 @@ package auth;
  */
 public enum Authorizers {
   APPLICANT(Labels.APPLICANT),
-  UAT_ADMIN(Labels.UAT_ADMIN),
+  CIVIFORM_ADMIN(Labels.CIVIFORM_ADMIN),
   TI(Labels.TI),
   PROGRAM_ADMIN(Labels.PROGRAM_ADMIN),
   ANY_ADMIN(Labels.ANY_ADMIN);
@@ -19,7 +19,7 @@ public enum Authorizers {
    */
   public static final class Labels {
     public static final String APPLICANT = "applicant";
-    public static final String UAT_ADMIN = "uatadmin";
+    public static final String CIVIFORM_ADMIN = "civiformadmin";
     public static final String TI = "trustedintermediary";
     public static final String PROGRAM_ADMIN = "programadmin";
     public static final String ANY_ADMIN = "anyadmin";

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
@@ -22,14 +22,14 @@ import repository.ProgramRepository;
  * about a profile, this class should not store any data that should be serialized. It should
  * contain only server-local information, like execution contexts, database connections, etc.
  */
-public class UatProfile {
+public class CiviFormProfile {
   private DatabaseExecutionContext dbContext;
   private HttpExecutionContext httpContext;
   private CiviFormProfileData profileData;
   private ProgramRepository programRepository;
 
   @Inject
-  public UatProfile(
+  public CiviFormProfile(
       DatabaseExecutionContext dbContext,
       HttpExecutionContext httpContext,
       CiviFormProfileData profileData,

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
@@ -78,7 +78,7 @@ public class CiviFormProfile {
     return getRoles().contains(Roles.ROLE_TI.toString());
   }
 
-  public boolean isUatAdmin() {
+  public boolean isCiviFormAdmin() {
     return profileData.getRoles().contains(Roles.ROLE_CIVIFORM_ADMIN.toString());
   }
 

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
@@ -79,7 +79,7 @@ public class CiviFormProfile {
   }
 
   public boolean isUatAdmin() {
-    return profileData.getRoles().contains(Roles.ROLE_UAT_ADMIN.toString());
+    return profileData.getRoles().contains(Roles.ROLE_CIVIFORM_ADMIN.toString());
   }
 
   public boolean isProgramAdmin() {

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfileAdapter.java
@@ -26,13 +26,13 @@ import repository.UserRepository;
  * - pac4j doesn't come with it. It's abstract because AD and IDCS need slightly different
  * implementations of the two abstract methods.
  */
-public abstract class UatProfileAdapter extends OidcProfileCreator {
+public abstract class CiviFormProfileAdapter extends OidcProfileCreator {
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
 
-  private static Logger LOG = LoggerFactory.getLogger(UatProfileAdapter.class);
+  private static Logger LOG = LoggerFactory.getLogger(CiviFormProfileAdapter.class);
 
-  public UatProfileAdapter(
+  public CiviFormProfileAdapter(
       OidcConfiguration configuration,
       OidcClient client,
       ProfileFactory profileFactory,

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfileAdapter.java
@@ -49,7 +49,7 @@ public abstract class CiviFormProfileAdapter extends OidcProfileCreator {
   protected abstract void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles);
 
   /** Merge the two provided profiles into a new CiviFormProfileData. */
-  public CiviFormProfileData mergeUatProfile(
+  public CiviFormProfileData mergeCiviFormProfile(
       CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
     String emailAddress = oidcProfile.getAttribute(emailAttributeName(), String.class);
     civiformProfile.setEmailAddress(emailAddress).join();
@@ -125,7 +125,7 @@ public abstract class CiviFormProfileAdapter extends OidcProfileCreator {
       LOG.debug("Found no existing profile in session cookie.");
       return Optional.of(civiformProfileFromOidcProfile(profile));
     } else {
-      return Optional.of(mergeUatProfile(existingProfile.get(), profile));
+      return Optional.of(mergeCiviFormProfile(existingProfile.get(), profile));
     }
   }
 

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfileAdapter.java
@@ -64,7 +64,7 @@ public abstract class CiviFormProfileAdapter extends OidcProfileCreator {
   }
 
   /** Create a totally new CiviForm profile from the provided OidcProfile. */
-  public abstract CiviFormProfileData uatProfileFromOidcProfile(OidcProfile oidcProfile);
+  public abstract CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile oidcProfile);
 
   @Override
   public Optional<UserProfile> create(
@@ -123,7 +123,7 @@ public abstract class CiviFormProfileAdapter extends OidcProfileCreator {
     // Now merge in the information sent to us by the OIDC server.
     if (existingProfile.isEmpty()) {
       LOG.debug("Found no existing profile in session cookie.");
-      return Optional.of(uatProfileFromOidcProfile(profile));
+      return Optional.of(civiformProfileFromOidcProfile(profile));
     } else {
       return Optional.of(mergeUatProfile(existingProfile.get(), profile));
     }

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfileData.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfileData.java
@@ -15,13 +15,13 @@ import repository.DatabaseExecutionContext;
  *
  * <p>It is wrapped by UatProfile, which is what we should use server-side.
  */
-public class UatProfileData extends CommonProfile {
+public class CiviFormProfileData extends CommonProfile {
 
-  public UatProfileData() {
+  public CiviFormProfileData() {
     super();
   }
 
-  public UatProfileData(Long accountId) {
+  public CiviFormProfileData(Long accountId) {
     this();
     this.setId(accountId.toString());
   }

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfileData.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfileData.java
@@ -13,7 +13,7 @@ import repository.DatabaseExecutionContext;
  * cookie. It cannot contain anything that's not serializable - this includes database connections,
  * thread pools, etc.
  *
- * <p>It is wrapped by UatProfile, which is what we should use server-side.
+ * <p>It is wrapped by CiviFormProfile, which is what we should use server-side.
  */
 public class CiviFormProfileData extends CommonProfile {
 

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
 /**
- * This class takes an existing UAT profile and augments it with the information from an IDCS
+ * This class takes an existing CiviForm profile and augments it with the information from an IDCS
  * profile.
  */
 public class IdcsProfileAdapter extends CiviFormProfileAdapter {

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -84,7 +84,7 @@ public class IdcsProfileAdapter extends CiviFormProfileAdapter {
   }
 
   @Override
-  public CiviFormProfileData uatProfileFromOidcProfile(OidcProfile profile) {
+  public CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile profile) {
     return mergeUatProfile(
         profileFactory.wrapProfileData(profileFactory.createNewApplicant()), profile);
   }

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -56,7 +56,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  public UatProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
+  public CiviFormProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
     final String locale = oidcProfile.getAttribute("user_locale", String.class);
     final boolean hasLocale = locale != null && !locale.isEmpty();
     final String displayName = oidcProfile.getAttribute("user_displayname", String.class);
@@ -83,7 +83,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  public UatProfileData uatProfileFromOidcProfile(OidcProfile profile) {
+  public CiviFormProfileData uatProfileFromOidcProfile(OidcProfile profile) {
     return mergeUatProfile(
         profileFactory.wrapProfileData(profileFactory.createNewApplicant()), profile);
   }

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -43,7 +43,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  protected ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile) {
+  protected ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile) {
     if (profile.getAccount().join().getMemberOfGroup().isPresent()) {
       return ImmutableSet.of(Roles.ROLE_APPLICANT, Roles.ROLE_TI);
     }
@@ -51,18 +51,19 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
   }
 
   @Override
-  protected void adaptForRole(UatProfile profile, ImmutableSet<Roles> roles) {
+  protected void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles) {
     // not needed
   }
 
   @Override
-  public CiviFormProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
+  public CiviFormProfileData mergeUatProfile(
+      CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
     final String locale = oidcProfile.getAttribute("user_locale", String.class);
     final boolean hasLocale = locale != null && !locale.isEmpty();
     final String displayName = oidcProfile.getAttribute("user_displayname", String.class);
     final boolean hasDisplayName = displayName != null && !displayName.isEmpty();
     if (hasLocale || hasDisplayName) {
-      uatProfile
+      civiformProfile
           .getApplicant()
           .thenApplyAsync(
               applicant -> {
@@ -79,7 +80,7 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
           .join();
     }
 
-    return super.mergeUatProfile(uatProfile, oidcProfile);
+    return super.mergeUatProfile(civiformProfile, oidcProfile);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -26,7 +26,7 @@ import repository.UserRepository;
  * This class takes an existing UAT profile and augments it with the information from an IDCS
  * profile.
  */
-public class IdcsProfileAdapter extends UatProfileAdapter {
+public class IdcsProfileAdapter extends CiviFormProfileAdapter {
   public static final Logger LOG = LoggerFactory.getLogger(IdcsProfileAdapter.class);
 
   public IdcsProfileAdapter(

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -56,7 +56,7 @@ public class IdcsProfileAdapter extends CiviFormProfileAdapter {
   }
 
   @Override
-  public CiviFormProfileData mergeUatProfile(
+  public CiviFormProfileData mergeCiviFormProfile(
       CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
     final String locale = oidcProfile.getAttribute("user_locale", String.class);
     final boolean hasLocale = locale != null && !locale.isEmpty();
@@ -80,12 +80,12 @@ public class IdcsProfileAdapter extends CiviFormProfileAdapter {
           .join();
     }
 
-    return super.mergeUatProfile(civiformProfile, oidcProfile);
+    return super.mergeCiviFormProfile(civiformProfile, oidcProfile);
   }
 
   @Override
   public CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile profile) {
-    return mergeUatProfile(
+    return mergeCiviFormProfile(
         profileFactory.wrapProfileData(profileFactory.createNewApplicant()), profile);
   }
 

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -46,8 +46,8 @@ public class ProfileFactory {
     return p;
   }
 
-  public UatProfile wrapProfileData(CiviFormProfileData p) {
-    return new UatProfile(dbContext, httpContext, p, programRepositoryProvider.get());
+  public CiviFormProfile wrapProfileData(CiviFormProfileData p) {
+    return new CiviFormProfile(dbContext, httpContext, p, programRepositoryProvider.get());
   }
 
   private CiviFormProfileData create(Roles role) {
@@ -57,11 +57,11 @@ public class ProfileFactory {
     return p;
   }
 
-  public UatProfile wrap(Account account) {
+  public CiviFormProfile wrap(Account account) {
     return wrapProfileData(new CiviFormProfileData(account.id));
   }
 
-  public UatProfile wrap(Applicant applicant) {
+  public CiviFormProfile wrap(Applicant applicant) {
     return wrapProfileData(new CiviFormProfileData(applicant.getAccount().id));
   }
 

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -34,7 +34,7 @@ public class ProfileFactory {
   }
 
   public CiviFormProfileData createNewAdmin() {
-    CiviFormProfileData p = create(Roles.ROLE_UAT_ADMIN);
+    CiviFormProfileData p = create(Roles.ROLE_CIVIFORM_ADMIN);
     wrapProfileData(p)
         .getAccount()
         .thenAccept(

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -29,12 +29,12 @@ public class ProfileFactory {
     this.versionRepositoryProvider = Preconditions.checkNotNull(versionRepositoryProvider);
   }
 
-  public UatProfileData createNewApplicant() {
+  public CiviFormProfileData createNewApplicant() {
     return create(Roles.ROLE_APPLICANT);
   }
 
-  public UatProfileData createNewAdmin() {
-    UatProfileData p = create(Roles.ROLE_UAT_ADMIN);
+  public CiviFormProfileData createNewAdmin() {
+    CiviFormProfileData p = create(Roles.ROLE_UAT_ADMIN);
     wrapProfileData(p)
         .getAccount()
         .thenAccept(
@@ -46,26 +46,26 @@ public class ProfileFactory {
     return p;
   }
 
-  public UatProfile wrapProfileData(UatProfileData p) {
+  public UatProfile wrapProfileData(CiviFormProfileData p) {
     return new UatProfile(dbContext, httpContext, p, programRepositoryProvider.get());
   }
 
-  private UatProfileData create(Roles role) {
-    UatProfileData p = new UatProfileData();
+  private CiviFormProfileData create(Roles role) {
+    CiviFormProfileData p = new CiviFormProfileData();
     p.init(dbContext);
     p.addRole(role.toString());
     return p;
   }
 
   public UatProfile wrap(Account account) {
-    return wrapProfileData(new UatProfileData(account.id));
+    return wrapProfileData(new CiviFormProfileData(account.id));
   }
 
   public UatProfile wrap(Applicant applicant) {
-    return wrapProfileData(new UatProfileData(applicant.getAccount().id));
+    return wrapProfileData(new CiviFormProfileData(applicant.getAccount().id));
   }
 
-  public UatProfileData createNewProgramAdmin() {
+  public CiviFormProfileData createNewProgramAdmin() {
     return create(Roles.ROLE_PROGRAM_ADMIN);
   }
 
@@ -73,8 +73,8 @@ public class ProfileFactory {
    * This creates a program admin who is automatically the admin of all programs currently live,
    * with a fake email address.
    */
-  public UatProfileData createFakeProgramAdmin() {
-    UatProfileData p = create(Roles.ROLE_PROGRAM_ADMIN);
+  public CiviFormProfileData createFakeProgramAdmin() {
+    CiviFormProfileData p = create(Roles.ROLE_PROGRAM_ADMIN);
     wrapProfileData(p)
         .getAccount()
         .thenAccept(

--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -43,7 +43,7 @@ public class ProfileUtils {
   }
 
   /** Return true if the account referenced by the profile exists. */
-  public boolean validUatProfile(CiviFormProfile profile) {
+  public boolean validCiviFormProfile(CiviFormProfile profile) {
     try {
       profile.getAccount().join();
       return true;

--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -24,7 +24,7 @@ public class ProfileUtils {
    * Fetch the current profile from the session cookie, which the ProfileManager will fetch from the
    * request's cookies, using the injected session store to decrypt it.
    */
-  public Optional<UatProfile> currentUserProfile(Http.RequestHeader request) {
+  public Optional<CiviFormProfile> currentUserProfile(Http.RequestHeader request) {
     PlayWebContext webContext = new PlayWebContext(request);
     return currentUserProfile(webContext);
   }
@@ -33,7 +33,7 @@ public class ProfileUtils {
    * Fetch the current profile from the session cookie, which the ProfileManager will fetch from the
    * context's cookies, using the injected session store to decrypt it.
    */
-  public Optional<UatProfile> currentUserProfile(WebContext webContext) {
+  public Optional<CiviFormProfile> currentUserProfile(WebContext webContext) {
     ProfileManager profileManager = new ProfileManager(webContext, sessionStore);
     Optional<CiviFormProfileData> p = profileManager.getProfile(CiviFormProfileData.class);
     if (p.isEmpty()) {
@@ -43,7 +43,7 @@ public class ProfileUtils {
   }
 
   /** Return true if the account referenced by the profile exists. */
-  public boolean validUatProfile(UatProfile profile) {
+  public boolean validUatProfile(CiviFormProfile profile) {
     try {
       profile.getAccount().join();
       return true;

--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -35,7 +35,7 @@ public class ProfileUtils {
    */
   public Optional<UatProfile> currentUserProfile(WebContext webContext) {
     ProfileManager profileManager = new ProfileManager(webContext, sessionStore);
-    Optional<UatProfileData> p = profileManager.getProfile(UatProfileData.class);
+    Optional<CiviFormProfileData> p = profileManager.getProfile(CiviFormProfileData.class);
     if (p.isEmpty()) {
       return Optional.empty();
     }

--- a/universal-application-tool-0.0.1/app/auth/Roles.java
+++ b/universal-application-tool-0.0.1/app/auth/Roles.java
@@ -3,7 +3,7 @@ package auth;
 public enum Roles {
   ROLE_APPLICANT("ROLE_APPLICANT"),
   ROLE_TI("ROLE_TI"),
-  ROLE_UAT_ADMIN("ROLE_UAT_ADMIN"),
+  ROLE_CIVIFORM_ADMIN("ROLE_CIVIFORM_ADMIN"),
   ROLE_PROGRAM_ADMIN("ROLE_PROGRAM_ADMIN");
 
   private final String roleName;

--- a/universal-application-tool-0.0.1/app/auth/UatProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfile.java
@@ -18,21 +18,21 @@ import repository.DatabaseExecutionContext;
 import repository.ProgramRepository;
 
 /**
- * This is a "pure" wrapper of UatProfileData. Since UatProfileData is the serialized data about a
- * profile, this class should not store any data that should be serialized. It should contain only
- * server-local information, like execution contexts, database connections, etc.
+ * This is a "pure" wrapper of CiviFormProfileData. Since CiviFormProfileData is the serialized data
+ * about a profile, this class should not store any data that should be serialized. It should
+ * contain only server-local information, like execution contexts, database connections, etc.
  */
 public class UatProfile {
   private DatabaseExecutionContext dbContext;
   private HttpExecutionContext httpContext;
-  private UatProfileData profileData;
+  private CiviFormProfileData profileData;
   private ProgramRepository programRepository;
 
   @Inject
   public UatProfile(
       DatabaseExecutionContext dbContext,
       HttpExecutionContext httpContext,
-      UatProfileData profileData,
+      CiviFormProfileData profileData,
       ProgramRepository programRepository) {
     this.dbContext = Preconditions.checkNotNull(dbContext);
     this.httpContext = Preconditions.checkNotNull(httpContext);
@@ -114,7 +114,7 @@ public class UatProfile {
     return this.getAccount().thenApplyAsync(Account::getEmailAddress, httpContext.current());
   }
 
-  public UatProfileData getProfileData() {
+  public CiviFormProfileData getProfileData() {
     return this.profileData;
   }
 

--- a/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
@@ -48,8 +48,8 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
 
   protected abstract void adaptForRole(UatProfile profile, ImmutableSet<Roles> roles);
 
-  /** Merge the two provided profiles into a new UatProfileData. */
-  public UatProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
+  /** Merge the two provided profiles into a new CiviFormProfileData. */
+  public CiviFormProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
     String emailAddress = oidcProfile.getAttribute(emailAttributeName(), String.class);
     uatProfile.setEmailAddress(emailAddress).join();
     uatProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
@@ -63,7 +63,7 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
   }
 
   /** Create a totally new UAT profile from the provided OidcProfile. */
-  public abstract UatProfileData uatProfileFromOidcProfile(OidcProfile oidcProfile);
+  public abstract CiviFormProfileData uatProfileFromOidcProfile(OidcProfile oidcProfile);
 
   @Override
   public Optional<UserProfile> create(

--- a/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfileAdapter.java
@@ -21,10 +21,10 @@ import repository.UserRepository;
 
 /**
  * This class ensures that the OidcProfileCreator that both the AD and IDCS clients use will
- * generate a UatProfile object. This is necessary for merging those accounts with existing accounts
- * - that's not usually needed in web applications which is why we have to write this class - pac4j
- * doesn't come with it. It's abstract because AD and IDCS need slightly different implementations
- * of the two abstract methods.
+ * generate a CiviFormProfile object. This is necessary for merging those accounts with existing
+ * accounts - that's not usually needed in web applications which is why we have to write this class
+ * - pac4j doesn't come with it. It's abstract because AD and IDCS need slightly different
+ * implementations of the two abstract methods.
  */
 public abstract class UatProfileAdapter extends OidcProfileCreator {
   protected final ProfileFactory profileFactory;
@@ -44,25 +44,26 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
 
   protected abstract String emailAttributeName();
 
-  protected abstract ImmutableSet<Roles> roles(UatProfile profile, OidcProfile oidcProfile);
+  protected abstract ImmutableSet<Roles> roles(CiviFormProfile profile, OidcProfile oidcProfile);
 
-  protected abstract void adaptForRole(UatProfile profile, ImmutableSet<Roles> roles);
+  protected abstract void adaptForRole(CiviFormProfile profile, ImmutableSet<Roles> roles);
 
   /** Merge the two provided profiles into a new CiviFormProfileData. */
-  public CiviFormProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
+  public CiviFormProfileData mergeUatProfile(
+      CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
     String emailAddress = oidcProfile.getAttribute(emailAttributeName(), String.class);
-    uatProfile.setEmailAddress(emailAddress).join();
-    uatProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
+    civiformProfile.setEmailAddress(emailAddress).join();
+    civiformProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
     // Meaning: whatever you signed in with most recently is the role you have.
-    ImmutableSet<Roles> roles = roles(uatProfile, oidcProfile);
+    ImmutableSet<Roles> roles = roles(civiformProfile, oidcProfile);
     for (Roles role : roles) {
-      uatProfile.getProfileData().addRole(role.toString());
+      civiformProfile.getProfileData().addRole(role.toString());
     }
-    adaptForRole(uatProfile, roles);
-    return uatProfile.getProfileData();
+    adaptForRole(civiformProfile, roles);
+    return civiformProfile.getProfileData();
   }
 
-  /** Create a totally new UAT profile from the provided OidcProfile. */
+  /** Create a totally new CiviForm profile from the provided OidcProfile. */
   public abstract CiviFormProfileData uatProfileFromOidcProfile(OidcProfile oidcProfile);
 
   @Override
@@ -98,7 +99,7 @@ public abstract class UatProfileAdapter extends OidcProfileCreator {
     // 3) an OIDC account in the callback from the OIDC server (`profile`).
     // We will merge 1 and 2, if present, into `existingProfile`, then merge in `profile`.
 
-    Optional<UatProfile> existingProfile = profileUtils.currentUserProfile(context);
+    Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
     if (existingApplicant.isPresent()) {
       if (existingProfile.isEmpty()) {
         // Easy merge case - we have an existing applicant, but no guest profile.

--- a/universal-application-tool-0.0.1/app/controllers/HomeController.java
+++ b/universal-application-tool-0.0.1/app/controllers/HomeController.java
@@ -2,8 +2,8 @@ package controllers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -38,14 +38,14 @@ public class HomeController extends Controller {
   }
 
   public CompletionStage<Result> index(Http.Request request) {
-    Optional<UatProfile> maybeProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> maybeProfile = profileUtils.currentUserProfile(request);
 
     if (maybeProfile.isEmpty()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.routes.HomeController.loginForm(Optional.empty())));
     }
 
-    UatProfile profile = maybeProfile.get();
+    CiviFormProfile profile = maybeProfile.get();
 
     if (profile.isUatAdmin()) {
       return CompletableFuture.completedFuture(

--- a/universal-application-tool-0.0.1/app/controllers/HomeController.java
+++ b/universal-application-tool-0.0.1/app/controllers/HomeController.java
@@ -47,7 +47,7 @@ public class HomeController extends Controller {
 
     CiviFormProfile profile = maybeProfile.get();
 
-    if (profile.isUatAdmin()) {
+    if (profile.isCiviFormAdmin()) {
       return CompletableFuture.completedFuture(
           redirect(controllers.admin.routes.AdminProgramController.index()));
     } else if (profile.isProgramAdmin()) {

--- a/universal-application-tool-0.0.1/app/controllers/ProfileController.java
+++ b/universal-application-tool-0.0.1/app/controllers/ProfileController.java
@@ -2,8 +2,8 @@ package controllers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -31,7 +31,7 @@ public class ProfileController extends Controller {
   }
 
   public CompletionStage<Result> myProfile(Http.Request request) {
-    Optional<UatProfile> maybeProfile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> maybeProfile = profileUtils.currentUserProfile(request);
 
     if (maybeProfile.isEmpty()) {
       return CompletableFuture.completedFuture(ok(profileView.renderNoProfile()));

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
@@ -79,7 +79,7 @@ public class AdminApplicationController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result downloadDemographics() {
     String filename = String.format("demographics-%s.csv", clock.instant().toString());
     String csv = exporterService.getDemographicsCsv();

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -44,7 +44,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     this.formFactory = checkNotNull(formFactory);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(Request request, long programId, long blockDefinitionId) {
     try {
       ProgramDefinition programDefinition = programService.getProgramDefinition(programId);
@@ -63,7 +63,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Request request, long programId, long blockDefinitionId) {
     Form<BlockVisibilityPredicateForm> predicateFormWrapper =
         formFactory.form(BlockVisibilityPredicateForm.class).bindFromRequest(request);
@@ -117,7 +117,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result destroy(long programId, long blockDefinitionId) {
     try {
       programService.removeBlockPredicate(programId, blockDefinitionId);

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -32,7 +32,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
     this.formFactory = checkNotNull(formFactory);
   }
 
-  @Secure(authorizers = Labels.UAT_ADMIN)
+  @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result create(Request request, long programId, long blockId) {
     DynamicForm requestData = formFactory.form().bindFromRequest(request);
     ImmutableList<Long> questionIds =
@@ -58,7 +58,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
     return redirect(controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId));
   }
 
-  @Secure(authorizers = Labels.UAT_ADMIN)
+  @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result destroy(long programId, long blockDefinitionId, long questionDefinitionId) {
     try {
       programService.removeQuestionsFromBlock(
@@ -81,7 +81,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
         controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockDefinitionId));
   }
 
-  @Secure(authorizers = Labels.UAT_ADMIN)
+  @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result setOptional(
       Request request, long programId, long blockDefinitionId, long questionDefinitionId) {
     ProgramQuestionDefinitionOptionalityForm programQuestionDefinitionOptionalityForm =

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -46,7 +46,7 @@ public class AdminProgramBlocksController extends CiviFormController {
     this.formFactory = checkNotNull(formFactory);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(long programId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
@@ -57,7 +57,7 @@ public class AdminProgramBlocksController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result create(Request request, long programId) {
     Optional<Long> enumeratorId =
         Optional.ofNullable(
@@ -85,7 +85,7 @@ public class AdminProgramBlocksController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(Request request, long programId, long blockId) {
     try {
       ProgramDefinition program = programService.getProgramDefinition(programId);
@@ -96,7 +96,7 @@ public class AdminProgramBlocksController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Request request, long programId, long blockId) {
     Form<BlockForm> blockFormWrapper = formFactory.form(BlockForm.class);
     BlockForm blockForm = blockFormWrapper.bindFromRequest(request).get();
@@ -116,7 +116,7 @@ public class AdminProgramBlocksController extends CiviFormController {
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result move(Request request, long programId, long blockId) {
     DynamicForm requestData = formFactory.form().bindFromRequest(request);
     Direction direction = Direction.valueOf(requestData.get("direction"));
@@ -131,7 +131,7 @@ public class AdminProgramBlocksController extends CiviFormController {
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result destroy(long programId, long blockId) {
     try {
       programService.deleteBlock(programId, blockId);

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -3,8 +3,8 @@ package controllers.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.Authorizers;
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import controllers.CiviFormController;
 import forms.ProgramForm;
 import java.util.Optional;
@@ -56,7 +56,7 @@ public class AdminProgramController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result index(Request request) {
-    Optional<UatProfile> profileMaybe = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profileMaybe = profileUtils.currentUserProfile(request);
     return ok(listView.render(this.service.getActiveAndDraftPrograms(), request, profileMaybe));
   }
 

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -54,18 +54,18 @@ public class AdminProgramController extends CiviFormController {
     this.formFactory = checkNotNull(formFactory);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Request request) {
     Optional<CiviFormProfile> profileMaybe = profileUtils.currentUserProfile(request);
     return ok(listView.render(this.service.getActiveAndDraftPrograms(), request, profileMaybe));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result newOne(Request request) {
     return ok(newOneView.render(request));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result create(Request request) {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();
@@ -83,7 +83,7 @@ public class AdminProgramController extends CiviFormController {
     return redirect(routes.AdminProgramController.index().url());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(Request request, long id) {
     try {
       ProgramDefinition program = service.getProgramDefinition(id);
@@ -93,7 +93,7 @@ public class AdminProgramController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result publish() {
     try {
       versionRepository.publishNewSynchronizedVersion();
@@ -103,7 +103,7 @@ public class AdminProgramController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result newVersionFrom(Request request, long id) {
     try {
       return redirect(routes.AdminProgramController.edit(service.newDraftOf(id).id()));
@@ -114,7 +114,7 @@ public class AdminProgramController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Request request, long id) {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramTranslationsController.java
@@ -42,7 +42,7 @@ public class AdminProgramTranslationsController extends CiviFormController {
    * @return a rendered {@link ProgramTranslationView} pre-populated with any existing translations
    *     for the given locale
    */
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(Http.Request request, long id, String locale) {
     try {
       ProgramDefinition program = service.getProgramDefinition(id);
@@ -69,7 +69,7 @@ public class AdminProgramTranslationsController extends CiviFormController {
    * @return redirects to the admin's home page if updates were successful; otherwise, renders the
    *     same {@link ProgramTranslationView} with error messages
    */
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Http.Request request, long id, String locale) {
     Form<ProgramTranslationForm> translationForm = formFactory.form(ProgramTranslationForm.class);
     if (translationForm.hasErrors()) {

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionController.java
@@ -60,7 +60,7 @@ public class AdminQuestionController extends CiviFormController {
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public CompletionStage<Result> index(Request request) {
     Optional<String> maybeFlash = request.flash().get("message");
     return service
@@ -73,7 +73,7 @@ public class AdminQuestionController extends CiviFormController {
             httpExecutionContext.current());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public CompletionStage<Result> show(long id) {
     return service
         .getReadOnlyQuestionService()
@@ -99,7 +99,7 @@ public class AdminQuestionController extends CiviFormController {
             httpExecutionContext.current());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result newOne(Request request, String type) {
     QuestionType questionType;
     try {
@@ -123,7 +123,7 @@ public class AdminQuestionController extends CiviFormController {
     }
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result create(Request request, String questionType) {
     QuestionForm questionForm;
     try {
@@ -158,7 +158,7 @@ public class AdminQuestionController extends CiviFormController {
     return withMessage(redirect(routes.AdminQuestionController.index()), successMessage);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result restore(Request request, Long id) {
     try {
       service.restoreQuestion(id);
@@ -168,7 +168,7 @@ public class AdminQuestionController extends CiviFormController {
     return redirect(routes.AdminQuestionController.index());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result archive(Request request, Long id) {
     try {
       service.archiveQuestion(id);
@@ -178,7 +178,7 @@ public class AdminQuestionController extends CiviFormController {
     return redirect(routes.AdminQuestionController.index());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result discardDraft(Request request, Long id) {
     try {
       service.discardDraft(id);
@@ -188,7 +188,7 @@ public class AdminQuestionController extends CiviFormController {
     return redirect(routes.AdminQuestionController.index());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public CompletionStage<Result> edit(Request request, Long id) {
     return service
         .getReadOnlyQuestionService()
@@ -215,7 +215,7 @@ public class AdminQuestionController extends CiviFormController {
             httpExecutionContext.current());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Request request, Long id, String questionType) {
     QuestionForm questionForm;
     try {

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionTranslationsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminQuestionTranslationsController.java
@@ -53,7 +53,7 @@ public class AdminQuestionTranslationsController extends CiviFormController {
    * @return a rendered {@link QuestionTranslationView} pre-populated with any existing translations
    *     for the given locale
    */
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public CompletionStage<Result> edit(Http.Request request, long id, String locale) {
     return questionService
         .getReadOnlyQuestionService()
@@ -79,7 +79,7 @@ public class AdminQuestionTranslationsController extends CiviFormController {
    * @return redirects to the admin's home page if updates were successful; otherwise, renders the
    *     same {@link QuestionTranslationView} with error messages
    */
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public CompletionStage<Result> update(Http.Request request, long id, String locale) {
     Locale updatedLocale = Locale.forLanguageTag(locale);
 

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminVersionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminVersionController.java
@@ -20,12 +20,12 @@ public class AdminVersionController extends Controller {
     this.versionListView = versionListView;
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Http.Request request) {
     return ok(versionListView.render(versionRepository.listAllVersions(), request));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result setVersionLive(long versionId, Http.Request request) {
     versionRepository.setLive(versionId);
     return redirect(routes.AdminVersionController.index());

--- a/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminController.java
@@ -1,8 +1,8 @@
 package controllers.admin;
 
 import auth.Authorizers;
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
@@ -32,7 +32,7 @@ public class ProgramAdminController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.PROGRAM_ADMIN)
   public Result index(Http.Request request) {
-    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
 
     if (!profile.isPresent()) {
       throw new RuntimeException("No profile found for program admin");

--- a/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminManagementController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/ProgramAdminManagementController.java
@@ -45,7 +45,7 @@ public class ProgramAdminManagementController {
   }
 
   /** Displays a form for managing program admins of a given program. */
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(Http.Request request, long programId) {
     Optional<Program> program =
         programRepository.lookupProgram(programId).toCompletableFuture().join();
@@ -69,7 +69,7 @@ public class ProgramAdminManagementController {
    * Promotes the given account emails to the role of PROGRAM_ADMIN. If there are errors, return a
    * redirect with flashing error message.
    */
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result update(Http.Request request, long programId) {
     Form<ManageProgramAdminsForm> form = formFactory.form(ManageProgramAdminsForm.class);
     if (form.hasErrors()) {

--- a/universal-application-tool-0.0.1/app/controllers/admin/TrustedIntermediaryManagementController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/TrustedIntermediaryManagementController.java
@@ -40,14 +40,14 @@ public class TrustedIntermediaryManagementController extends Controller {
     this.editView = Preconditions.checkNotNull(editView);
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Http.Request request) {
     LoggerFactory.getLogger(TrustedIntermediaryManagementController.class)
         .info(request.flash().data().toString());
     return ok(listView.render(userRepository.listTrustedIntermediaryGroups(), request));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result create(Http.Request request) {
     Form<CreateTrustedIntermediaryGroupForm> form =
         formFactory.form(CreateTrustedIntermediaryGroupForm.class).bindFromRequest(request);
@@ -87,7 +87,7 @@ public class TrustedIntermediaryManagementController extends Controller {
     return result;
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result edit(long id, Http.Request request) {
     Optional<TrustedIntermediaryGroup> tiGroup = userRepository.getTrustedIntermediaryGroup(id);
     if (tiGroup.isEmpty()) {
@@ -96,7 +96,7 @@ public class TrustedIntermediaryManagementController extends Controller {
     return ok(editView.render(tiGroup.get(), request));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result delete(long id, Http.Request request) {
     try {
       userRepository.deleteTrustedIntermediaryGroup(id);
@@ -106,7 +106,7 @@ public class TrustedIntermediaryManagementController extends Controller {
     return redirect(routes.TrustedIntermediaryManagementController.index());
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result addIntermediary(long id, Http.Request request) {
     Form<AddTrustedIntermediaryForm> form =
         formFactory.form(AddTrustedIntermediaryForm.class).bindFromRequest(request);
@@ -122,7 +122,7 @@ public class TrustedIntermediaryManagementController extends Controller {
     return redirect(routes.TrustedIntermediaryManagementController.edit(id));
   }
 
-  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
+  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result removeIntermediary(long id, Http.Request request) {
     try {
       Form<RemoveTrustedIntermediaryForm> form =

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -2,8 +2,8 @@ package controllers.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
 import java.util.Optional;
@@ -142,7 +142,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
   private CompletionStage<Result> submitInternal(
       Request request, long applicantId, long programId) {
-    UatProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
+    CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request).orElseThrow();
 
     CompletionStage<Application> submitApp =
         applicantService.submitApplication(applicantId, programId, submittingProfile);

--- a/universal-application-tool-0.0.1/app/controllers/applicant/RedirectController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/RedirectController.java
@@ -2,8 +2,8 @@ package controllers.applicant;
 
 import static autovalue.shaded.com.google$.common.base.$Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import controllers.CiviFormController;
 import controllers.routes;
 import java.util.Optional;
@@ -50,7 +50,7 @@ public class RedirectController extends CiviFormController {
 
   @Secure
   public CompletionStage<Result> programByName(Http.Request request, String programName) {
-    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
     if (profile.isEmpty()) {
       return CompletableFuture.completedFuture(
           redirect(routes.CallbackController.callback("GuestClient")));
@@ -79,7 +79,7 @@ public class RedirectController extends CiviFormController {
       long programId,
       long applicationId,
       String redirectTo) {
-    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
     if (profile.isEmpty()) {
       // should definitely never happen.
       return CompletableFuture.completedFuture(

--- a/universal-application-tool-0.0.1/app/controllers/ti/TrustedIntermediaryController.java
+++ b/universal-application-tool-0.0.1/app/controllers/ti/TrustedIntermediaryController.java
@@ -6,8 +6,8 @@ import static play.mvc.Results.redirect;
 import static play.mvc.Results.unauthorized;
 
 import auth.Authorizers;
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -55,12 +55,12 @@ public class TrustedIntermediaryController {
     if (page.isEmpty()) {
       return redirect(routes.TrustedIntermediaryController.dashboard(search, Optional.of(1)));
     }
-    Optional<UatProfile> uatProfile = profileUtils.currentUserProfile(request);
-    if (uatProfile.isEmpty()) {
+    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    if (civiformProfile.isEmpty()) {
       return unauthorized();
     }
     Optional<TrustedIntermediaryGroup> trustedIntermediaryGroup =
-        userRepository.getTrustedIntermediaryGroup(uatProfile.get());
+        userRepository.getTrustedIntermediaryGroup(civiformProfile.get());
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }
@@ -71,7 +71,7 @@ public class TrustedIntermediaryController {
     return ok(
         tiDashboardView.render(
             trustedIntermediaryGroup.get(),
-            uatProfile.get().getApplicant().join().getApplicantData().getApplicantName(),
+            civiformProfile.get().getApplicant().join().getApplicantData().getApplicantName(),
             pageInfo.getPageItems(),
             pageInfo.getPageCount(),
             pageInfo.getPage(),
@@ -82,12 +82,12 @@ public class TrustedIntermediaryController {
 
   @Secure(authorizers = Authorizers.Labels.TI)
   public Result addApplicant(Long id, Http.Request request) {
-    Optional<UatProfile> uatProfile = profileUtils.currentUserProfile(request);
-    if (uatProfile.isEmpty()) {
+    Optional<CiviFormProfile> civiformProfile = profileUtils.currentUserProfile(request);
+    if (civiformProfile.isEmpty()) {
       return unauthorized();
     }
     Optional<TrustedIntermediaryGroup> trustedIntermediaryGroup =
-        userRepository.getTrustedIntermediaryGroup(uatProfile.get());
+        userRepository.getTrustedIntermediaryGroup(civiformProfile.get());
     if (trustedIntermediaryGroup.isEmpty()) {
       return notFound();
     }

--- a/universal-application-tool-0.0.1/app/filters/ValidAccountFilter.java
+++ b/universal-application-tool-0.0.1/app/filters/ValidAccountFilter.java
@@ -28,7 +28,7 @@ public class ValidAccountFilter extends EssentialFilter {
     return EssentialAction.of(
         request -> {
           Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
-          if (profile.isPresent() && !profileUtils.validUatProfile(profile.get())) {
+          if (profile.isPresent() && !profileUtils.validCiviFormProfile(profile.get())) {
             // The cookie is present but the profile is not valid, redirect to logout and clear the
             // cookie.
             if (!allowedEndpoint(request.uri())) {

--- a/universal-application-tool-0.0.1/app/filters/ValidAccountFilter.java
+++ b/universal-application-tool-0.0.1/app/filters/ValidAccountFilter.java
@@ -2,8 +2,8 @@ package filters;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.libs.streams.Accumulator;
@@ -27,7 +27,7 @@ public class ValidAccountFilter extends EssentialFilter {
   public EssentialAction apply(EssentialAction next) {
     return EssentialAction.of(
         request -> {
-          Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+          Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
           if (profile.isPresent() && !profileUtils.validUatProfile(profile.get())) {
             // The cookie is present but the profile is not valid, redirect to logout and clear the
             // cookie.

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -206,7 +206,7 @@ public class SecurityModule extends AbstractModule {
         Authorizers.PROGRAM_ADMIN.toString(),
         new RequireAllRolesAuthorizer(Roles.ROLE_PROGRAM_ADMIN.toString()));
     config.addAuthorizer(
-        Authorizers.UAT_ADMIN.toString(),
+        Authorizers.CIVIFORM_ADMIN.toString(),
         new RequireAllRolesAuthorizer(Roles.ROLE_UAT_ADMIN.toString()));
     config.addAuthorizer(
         Authorizers.APPLICANT.toString(),

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -7,13 +7,13 @@ import static play.mvc.Results.redirect;
 import auth.AdOidcClient;
 import auth.AdfsProfileAdapter;
 import auth.Authorizers;
+import auth.CiviFormProfileData;
 import auth.FakeAdminClient;
 import auth.GuestClient;
 import auth.IdcsOidcClient;
 import auth.IdcsProfileAdapter;
 import auth.ProfileFactory;
 import auth.Roles;
-import auth.UatProfileData;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -74,15 +74,15 @@ public class SecurityModule extends AbstractModule {
     // sbt's autoreload, so we have a little workaround here.  configure() gets called on every
     // startup,
     // but the JAVA_SERIALIZER object is only initialized on initial startup.
-    // So, on a second startup, we'll add the UatProfileData a second time.  The
-    // trusted classes set should dedupe UatProfileData against the old UatProfileData,
+    // So, on a second startup, we'll add the CiviFormProfileData a second time.  The
+    // trusted classes set should dedupe CiviFormProfileData against the old CiviFormProfileData,
     // but it's technically a different class with the same name at that point,
     // which triggers the bug.  So, we just clear the classes, which will be empty
     // on first startup and will contain the profile on subsequent startups,
     // so that it's always safe to add the profile.
     // We will need to do this for every class we want to store in the cookie.
     PlayCookieSessionStore.JAVA_SERIALIZER.clearTrustedClasses();
-    PlayCookieSessionStore.JAVA_SERIALIZER.addTrustedClass(UatProfileData.class);
+    PlayCookieSessionStore.JAVA_SERIALIZER.addTrustedClass(CiviFormProfileData.class);
 
     // We need to use the secret key to generate the encrypter / decrypter for the
     // session store, so that cookies from version n of the application can be

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -207,7 +207,7 @@ public class SecurityModule extends AbstractModule {
         new RequireAllRolesAuthorizer(Roles.ROLE_PROGRAM_ADMIN.toString()));
     config.addAuthorizer(
         Authorizers.CIVIFORM_ADMIN.toString(),
-        new RequireAllRolesAuthorizer(Roles.ROLE_UAT_ADMIN.toString()));
+        new RequireAllRolesAuthorizer(Roles.ROLE_CIVIFORM_ADMIN.toString()));
     config.addAuthorizer(
         Authorizers.APPLICANT.toString(),
         new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()));
@@ -216,7 +216,7 @@ public class SecurityModule extends AbstractModule {
     config.addAuthorizer(
         Authorizers.ANY_ADMIN.toString(),
         new RequireAnyRoleAuthorizer(
-            Roles.ROLE_UAT_ADMIN.toString(), Roles.ROLE_PROGRAM_ADMIN.toString()));
+            Roles.ROLE_CIVIFORM_ADMIN.toString(), Roles.ROLE_PROGRAM_ADMIN.toString()));
 
     config.setHttpActionAdapter(PlayHttpActionAdapter.INSTANCE);
     return config;

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -3,7 +3,7 @@ package repository;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -251,8 +251,9 @@ public class UserRepository {
     return ebeanServer.find(Account.class).setId(accountId).findOneOrEmpty();
   }
 
-  public Optional<TrustedIntermediaryGroup> getTrustedIntermediaryGroup(UatProfile uatProfile) {
-    return uatProfile.getAccount().join().getMemberOfGroup();
+  public Optional<TrustedIntermediaryGroup> getTrustedIntermediaryGroup(
+      CiviFormProfile civiformProfile) {
+    return civiformProfile.getAccount().join().getMemberOfGroup();
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -1,6 +1,6 @@
 package services.applicant;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
@@ -59,7 +59,7 @@ public interface ApplicantService {
    *     ApplicationSubmissionException} is thrown and wrapped in a `CompletionException`.
    */
   CompletionStage<Application> submitApplication(
-      long applicantId, long programId, UatProfile submittingProfile);
+      long applicantId, long programId, CiviFormProfile submittingProfile);
 
   /** Create a new {@link Applicant} for a given user. */
   CompletionStage<Applicant> createApplicant(long userId);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -2,7 +2,7 @@ package services.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -200,7 +200,7 @@ public class ApplicantServiceImpl implements ApplicantService {
 
   @Override
   public CompletionStage<Application> submitApplication(
-      long applicantId, long programId, UatProfile submitterProfile) {
+      long applicantId, long programId, CiviFormProfile submitterProfile) {
     if (submitterProfile.isTrustedIntermediary()) {
       return submitterProfile
           .getAccount()

--- a/universal-application-tool-0.0.1/app/services/question/exceptions/UnsupportedQuestionTypeException.java
+++ b/universal-application-tool-0.0.1/app/services/question/exceptions/UnsupportedQuestionTypeException.java
@@ -4,7 +4,7 @@ import services.question.types.QuestionType;
 
 /**
  * This exception should be thrown in the `default` case of all `switch(QuestionType)` to ensure
- * that when new question types are added but not fully supported across the UAT, they fail fast.
+ * that when new question types are added but not fully supported across CiviForm, they fail fast.
  *
  * <p>NOTE: {@link InvalidQuestionTypeException} should be thrown if a question type is not valid.
  */

--- a/universal-application-tool-0.0.1/app/services/role/RoleService.java
+++ b/universal-application-tool-0.0.1/app/services/role/RoleService.java
@@ -27,7 +27,7 @@ public class RoleService {
   }
 
   /**
-   * Get a set of {@link Account}s that have the role {@link auth.Roles#ROLE_UAT_ADMIN}.
+   * Get a set of {@link Account}s that have the role {@link auth.Roles#ROLE_CIVIFORM_ADMIN}.
    *
    * @return an {@link ImmutableSet} of {@link Account}s that are UAT admins.
    */
@@ -38,7 +38,7 @@ public class RoleService {
   /**
    * Promotes the set of accounts (identified by email) to the role of {@link
    * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. If an account is currently a {@link
-   * auth.Roles#ROLE_UAT_ADMIN}, they will not be promoted, since UAT admins cannot be program
+   * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since UAT admins cannot be program
    * admins. Instead, we return a {@link CiviFormError} listing the admin accounts that could not be
    * promoted to program admins.
    *

--- a/universal-application-tool-0.0.1/app/services/role/RoleService.java
+++ b/universal-application-tool-0.0.1/app/services/role/RoleService.java
@@ -29,7 +29,7 @@ public class RoleService {
   /**
    * Get a set of {@link Account}s that have the role {@link auth.Roles#ROLE_CIVIFORM_ADMIN}.
    *
-   * @return an {@link ImmutableSet} of {@link Account}s that are UAT admins.
+   * @return an {@link ImmutableSet} of {@link Account}s that are CiviForm admins.
    */
   public ImmutableSet<Account> getGlobalAdmins() {
     return userRepository.getGlobalAdmins();
@@ -38,9 +38,9 @@ public class RoleService {
   /**
    * Promotes the set of accounts (identified by email) to the role of {@link
    * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. If an account is currently a {@link
-   * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since UAT admins cannot be program
-   * admins. Instead, we return a {@link CiviFormError} listing the admin accounts that could not be
-   * promoted to program admins.
+   * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since CiviForm admins cannot be
+   * program admins. Instead, we return a {@link CiviFormError} listing the admin accounts that
+   * could not be promoted to program admins.
    *
    * @param programId the ID of the {@link models.Program} these accounts administer
    * @param accountEmails a {@link ImmutableSet} of account emails to make program admins
@@ -55,7 +55,8 @@ public class RoleService {
     }
 
     ProgramDefinition program = programService.getProgramDefinition(programId);
-    // Filter out UAT admins from the list of emails - a UAT admin cannot be a program admin.
+    // Filter out CiviForm admins from the list of emails - a CiviForm admin cannot be a program
+    // admin.
     ImmutableSet<String> sysAdminEmails =
         getGlobalAdmins().stream()
             .map(Account::getEmailAddress)

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -71,7 +71,7 @@ public abstract class BaseHtmlView {
 
   /**
    * Generates a hidden HTML input tag containing a signed CSRF token. The token and tag must be
-   * present in all UAT forms.
+   * present in all CiviForm forms.
    */
   protected static Tag makeCsrfTokenInputTag(Http.Request request) {
     return input().isHidden().withValue(getCsrfToken(request)).withName("csrfToken");

--- a/universal-application-tool-0.0.1/app/views/ProfileView.java
+++ b/universal-application-tool-0.0.1/app/views/ProfileView.java
@@ -5,7 +5,7 @@ import static j2html.TagCreator.h1;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import j2html.tags.Tag;
 import javax.inject.Inject;
 import models.Applicant;
@@ -20,7 +20,7 @@ public class ProfileView extends BaseHtmlView {
     this.layout = checkNotNull(layout);
   }
 
-  public Content render(UatProfile profile, Applicant applicant) {
+  public Content render(CiviFormProfile profile, Applicant applicant) {
     Tag applicantIdTag =
         span(String.valueOf(applicant.id))
             .withId("applicant-id")

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -8,7 +8,7 @@ import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.p;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import com.typesafe.config.Config;
 import controllers.admin.routes;
 import j2html.tags.Tag;
@@ -40,8 +40,8 @@ public class ProgramAdministratorProgramListView extends BaseHtmlView {
   public Content render(
       ActiveAndDraftPrograms programs,
       List<String> authorizedPrograms,
-      Optional<UatProfile> uatProfile) {
-    if (uatProfile.isPresent() && uatProfile.get().isProgramAdmin()) {
+      Optional<CiviFormProfile> civiformProfile) {
+    if (civiformProfile.isPresent() && civiformProfile.get().isProgramAdmin()) {
       layout.setProgramAdminType();
     }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -8,7 +8,7 @@ import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.p;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import controllers.admin.routes;
@@ -40,7 +40,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   }
 
   public Content render(
-      ActiveAndDraftPrograms programs, Http.Request request, Optional<UatProfile> profile) {
+      ActiveAndDraftPrograms programs, Http.Request request, Optional<CiviFormProfile> profile) {
     if (profile.isPresent() && profile.get().isProgramAdmin()) {
       layout.setProgramAdminType();
     }
@@ -111,7 +111,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       Optional<ProgramDefinition> activeProgram,
       Optional<ProgramDefinition> draftProgram,
       Http.Request request,
-      Optional<UatProfile> profile) {
+      Optional<CiviFormProfile> profile) {
     String programStatusText = extractProgramStatusText(draftProgram, activeProgram);
     String lastEditText = "Last updated 2 hours ago."; // TODO: Need to generate this.
 
@@ -242,7 +242,7 @@ public final class ProgramIndexView extends BaseHtmlView {
   }
 
   private Tag maybeRenderViewApplicationsLink(
-      Optional<ProgramDefinition> activeProgram, Optional<UatProfile> userProfile) {
+      Optional<ProgramDefinition> activeProgram, Optional<CiviFormProfile> userProfile) {
     if (activeProgram.isPresent() && userProfile.isPresent()) {
       boolean userIsAuthorized = true;
       try {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
@@ -9,9 +9,9 @@ import static j2html.TagCreator.input;
 import static j2html.TagCreator.nav;
 import static j2html.TagCreator.text;
 
+import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import auth.Roles;
-import auth.UatProfile;
 import com.typesafe.config.Config;
 import controllers.routes;
 import j2html.TagCreator;
@@ -95,7 +95,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
   }
 
   private ContainerTag renderNavBar(Http.Request request, String userName, Messages messages) {
-    Optional<UatProfile> profile = profileUtils.currentUserProfile(request);
+    Optional<CiviFormProfile> profile = profileUtils.currentUserProfile(request);
 
     return nav()
         .withClasses(
@@ -112,7 +112,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
                 .withClasses(Styles.JUSTIFY_SELF_END, Styles.FLEX, Styles.FLEX_ROW));
   }
 
-  private ContainerTag getLanguageForm(Http.Request request, Optional<UatProfile> profile) {
+  private ContainerTag getLanguageForm(Http.Request request, Optional<CiviFormProfile> profile) {
     ContainerTag languageForm = div();
     if (profile.isPresent()) { // Show language switcher.
       long userId = profile.get().getApplicant().join().id;
@@ -155,7 +155,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
                 .withText("CiviForm"));
   }
 
-  private ContainerTag maybeRenderTiButton(Optional<UatProfile> profile, String userName) {
+  private ContainerTag maybeRenderTiButton(Optional<CiviFormProfile> profile, String userName) {
     if (profile.isPresent() && profile.get().getRoles().contains(Roles.ROLE_TI.toString())) {
       String tiDashboardText = "Trusted intermediary dashboard";
       String tiDashboardLink =

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -19,7 +19,7 @@ POST    /admin/programs                                         controllers.admi
 POST    /admin/programs/publish                                 controllers.admin.AdminProgramController.publish()
 POST    /admin/programs/:programId                              controllers.admin.AdminProgramController.update(request: Request, programId: Long)
 
-# Routes for a UAT admin to manage program admins for a given program.
+# Routes for a CiviForm admin to manage program admins for a given program.
 GET     /admin/programs/:programId/admins/edit  controllers.admin.ProgramAdminManagementController.edit(request: Request, programId: Long)
 POST    /admin/programs/:programId/admins       controllers.admin.ProgramAdminManagementController.update(request: Request, programId: Long)
 

--- a/universal-application-tool-0.0.1/package.json
+++ b/universal-application-tool-0.0.1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-application-tool-0.0.1",
   "version": "0.0.1",
-  "description": "Universal Application Tool (UAT) that aims to simplify the application process for benefits programs.",
+  "description": "Universal Application Tool (UAT aka CiviForm) that aims to simplify the application process for benefits programs.",
   "directories": {
     "test": "test"
   },

--- a/universal-application-tool-0.0.1/test/app/SecurityBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/SecurityBrowserTest.java
@@ -156,7 +156,7 @@ public class SecurityBrowserTest extends BaseBrowserTest {
 
     goTo(routes.ProfileController.myProfile());
     assertThat(browser.pageSource()).contains("FakeAdminClient");
-    assertThat(browser.pageSource()).contains(Roles.ROLE_UAT_ADMIN.toString());
+    assertThat(browser.pageSource()).contains(Roles.ROLE_CIVIFORM_ADMIN.toString());
 
     goTo(controllers.admin.routes.AdminProgramController.index());
     assertThat(browser.pageSource()).contains("Programs");

--- a/universal-application-tool-0.0.1/test/auth/CiviFormProfileTest.java
+++ b/universal-application-tool-0.0.1/test/auth/CiviFormProfileTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import repository.WithPostgresContainer;
 
-public class UatProfileTest extends WithPostgresContainer {
+public class CiviFormProfileTest extends WithPostgresContainer {
 
   private ProfileFactory profileFactory;
 
@@ -23,7 +23,7 @@ public class UatProfileTest extends WithPostgresContainer {
   @Test
   public void checkAuthorization_admin_failsForApplicantId() {
     CiviFormProfileData data = profileFactory.createNewAdmin();
-    UatProfile profile = profileFactory.wrapProfileData(data);
+    CiviFormProfile profile = profileFactory.wrapProfileData(data);
 
     try {
       profile.checkAuthorization(1234L).join();
@@ -36,7 +36,7 @@ public class UatProfileTest extends WithPostgresContainer {
   @Test
   public void checkAuthorization_applicant_passesForOwnId() throws Exception {
     CiviFormProfileData data = profileFactory.createNewApplicant();
-    UatProfile profile = profileFactory.wrapProfileData(data);
+    CiviFormProfile profile = profileFactory.wrapProfileData(data);
 
     profile.checkAuthorization(profile.getApplicant().get().id).join();
   }
@@ -59,7 +59,7 @@ public class UatProfileTest extends WithPostgresContainer {
     account.setApplicants(ImmutableList.of(one, two, three));
     account.save();
 
-    UatProfile profile = profileFactory.wrap(account);
+    CiviFormProfile profile = profileFactory.wrap(account);
 
     profile.checkAuthorization(two.id).join();
   }
@@ -67,7 +67,7 @@ public class UatProfileTest extends WithPostgresContainer {
   @Test
   public void checkAuthorization_fails() {
     CiviFormProfileData data = profileFactory.createNewApplicant();
-    UatProfile profile = profileFactory.wrapProfileData(data);
+    CiviFormProfile profile = profileFactory.wrapProfileData(data);
 
     assertThatThrownBy(() -> profile.checkAuthorization(1234L).join())
         .hasCauseInstanceOf(SecurityException.class);

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -38,7 +38,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
-    CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    CiviFormProfileData profileData = profileAdapter.civiformProfileFromOidcProfile(oidcProfile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -50,7 +50,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
-    CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    CiviFormProfileData profileData = profileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThat(
             profileAdapter
@@ -66,7 +66,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     OidcProfile conflictingProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "bar@example.com");
 
-    CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    CiviFormProfileData profileData = profileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
             () ->

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -38,7 +38,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
-    UatProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
     UatProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -50,7 +50,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
-    UatProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
 
     assertThat(
             profileAdapter
@@ -66,7 +66,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     OidcProfile conflictingProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "bar@example.com");
 
-    UatProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
             () ->

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -39,7 +39,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
     CiviFormProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
-    UatProfile profile = profileFactory.wrapProfileData(profileData);
+    CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
     assertThat(profile.getEmailAddress().get()).isEqualTo("foo@example.com");

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -54,7 +54,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
 
     assertThat(
             profileAdapter
-                .mergeUatProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
+                .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
                 .getEmail())
         .isEqualTo("foo@example.com");
   }
@@ -70,7 +70,7 @@ public class ProfileMergeTest extends WithPostgresContainer {
 
     assertThatThrownBy(
             () ->
-                profileAdapter.mergeUatProfile(
+                profileAdapter.mergeCiviFormProfile(
                     profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }

--- a/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
+++ b/universal-application-tool-0.0.1/test/auth/UatProfileTest.java
@@ -22,7 +22,7 @@ public class UatProfileTest extends WithPostgresContainer {
 
   @Test
   public void checkAuthorization_admin_failsForApplicantId() {
-    UatProfileData data = profileFactory.createNewAdmin();
+    CiviFormProfileData data = profileFactory.createNewAdmin();
     UatProfile profile = profileFactory.wrapProfileData(data);
 
     try {
@@ -35,7 +35,7 @@ public class UatProfileTest extends WithPostgresContainer {
 
   @Test
   public void checkAuthorization_applicant_passesForOwnId() throws Exception {
-    UatProfileData data = profileFactory.createNewApplicant();
+    CiviFormProfileData data = profileFactory.createNewApplicant();
     UatProfile profile = profileFactory.wrapProfileData(data);
 
     profile.checkAuthorization(profile.getApplicant().get().id).join();
@@ -66,7 +66,7 @@ public class UatProfileTest extends WithPostgresContainer {
 
   @Test
   public void checkAuthorization_fails() {
-    UatProfileData data = profileFactory.createNewApplicant();
+    CiviFormProfileData data = profileFactory.createNewApplicant();
     UatProfile profile = profileFactory.wrapProfileData(data);
 
     assertThatThrownBy(() -> profile.checkAuthorization(1234L).join())

--- a/universal-application-tool-0.0.1/test/controllers/WithMockedProfiles.java
+++ b/universal-application-tool-0.0.1/test/controllers/WithMockedProfiles.java
@@ -4,9 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static play.inject.Bindings.bind;
 
+import auth.CiviFormProfile;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
-import auth.UatProfile;
 import java.util.Optional;
 import models.Account;
 import models.Applicant;
@@ -90,7 +90,7 @@ public class WithMockedProfiles {
 
   protected Applicant createApplicantWithMockedProfile() {
     Applicant applicant = createApplicant();
-    UatProfile profile = profileFactory.wrap(applicant);
+    CiviFormProfile profile = profileFactory.wrap(applicant);
     mockProfile(profile);
     return applicant;
   }
@@ -105,7 +105,7 @@ public class WithMockedProfiles {
     ti.setMemberOfGroup(group);
     ti.save();
 
-    UatProfile profile = profileFactory.wrap(ti);
+    CiviFormProfile profile = profileFactory.wrap(ti);
     mockProfile(profile);
     return ti;
   }
@@ -116,7 +116,7 @@ public class WithMockedProfiles {
     programAdmin.addAdministeredProgram(program.getProgramDefinition());
     programAdmin.save();
 
-    UatProfile profile = profileFactory.wrap(programAdmin);
+    CiviFormProfile profile = profileFactory.wrap(programAdmin);
     mockProfile(profile);
     return programAdmin;
   }
@@ -127,12 +127,12 @@ public class WithMockedProfiles {
     globalAdmin.setGlobalAdmin(true);
     globalAdmin.save();
 
-    UatProfile profile = profileFactory.wrap(globalAdmin);
+    CiviFormProfile profile = profileFactory.wrap(globalAdmin);
     mockProfile(profile);
     return globalAdmin;
   }
 
-  private void mockProfile(UatProfile profile) {
+  private void mockProfile(CiviFormProfile profile) {
     when(MOCK_UTILS.currentUserProfile(any(Http.Request.class))).thenReturn(Optional.of(profile));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import auth.UatProfile;
+import auth.CiviFormProfile;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
@@ -47,7 +47,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
   private ProgramDefinition programDefinition;
   private ApplicationRepository applicationRepository;
   private UserRepository userRepository;
-  private UatProfile trustedIntermediaryProfile;
+  private CiviFormProfile trustedIntermediaryProfile;
 
   @Before
   public void setUp() throws Exception {
@@ -58,7 +58,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     createQuestions();
     createProgram();
 
-    trustedIntermediaryProfile = Mockito.mock(UatProfile.class);
+    trustedIntermediaryProfile = Mockito.mock(CiviFormProfile.class);
     Account account = new Account();
     account.setEmailAddress("test@example.com");
     Mockito.when(trustedIntermediaryProfile.isTrustedIntermediary()).thenReturn(true);


### PR DESCRIPTION
### Description
Rename references of UAT to CiviForm in order to avoid confusion. The references are mostly in auth library.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

