### PR TITLE
Display the option text rather than ID for single-select questions

### DIFF
--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -195,6 +195,8 @@ public class FieldWithLabel {
       if (this.fieldValueNumber.isPresent()) {
         fieldTag.withValue(String.valueOf(this.fieldValueNumber.getAsLong()));
       }
+      // We only allow integer input.
+      fieldTag.attr("oninput", "n=parseInt(this.value);this.value=Number.isNaN(n)?'':n;");
     } else {
       fieldTag.withValue(this.fieldValue);
     }

--- a/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/predicate/PredicateValueTest.java
@@ -62,6 +62,16 @@ public class PredicateValueTest {
   }
 
   @Test
+  public void toDisplayString_multiOptionSingleValue_convertsIdToString() {
+    QuestionDefinition multiOption =
+        testQuestionBank.applicantKitchenTools().getQuestionDefinition();
+
+    PredicateValue value = PredicateValue.of("1");
+
+    assertThat(value.toDisplayString(Optional.of(multiOption))).isEqualTo("toaster");
+  }
+
+  @Test
   public void toDisplayString_multiOptionList_missingIdDefaultsToObsolete() {
     QuestionDefinition multiOption = testQuestionBank.applicantIceCream().getQuestionDefinition();
 

--- a/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/FieldWithLabelTest.java
@@ -38,7 +38,8 @@ public class FieldWithLabelTest {
   @Test
   public void number_setsNoValueByDefault() {
     FieldWithLabel fieldWithLabel = FieldWithLabel.number();
-    assertThat(fieldWithLabel.getContainer().render()).doesNotContain("value");
+    // No "value"="some-value" attribute. But allow "this.value" in script.
+    assertThat(fieldWithLabel.getContainer().render()).doesNotContain(" value");
   }
 
   @Test


### PR DESCRIPTION
### Description
Fixes a bug introduced in #1430 - we need to convert the option ID to option text for single-select questions, as well as multi-select

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#322