### PR TITLE
Stop storing blank values in applicant data.

### DIFF
--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -90,9 +90,9 @@ describe('normal application flow', () => {
     await applicantQuestions.answerFileUploadQuestion('file key');
     await applicantQuestions.clickUpload();
 
-    // fill 4th application block. 
-    // skip one checkbox question.
+    // fill 4th application block.
     await applicantQuestions.answerCheckboxQuestion(['clowns']);
+    await applicantQuestions.answerCheckboxQuestion(['sewage']);
     await applicantQuestions.clickNext();
 
     // submit

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -136,7 +136,9 @@ describe('End to end enumerator test', () => {
     await page.click('.cf-applicant-summary-row:has(div:has-text("Household members")) a:has-text("Edit")');
     await applicantQuestions.deleteEnumeratorEntity("Bugs");
     await applicantQuestions.deleteEnumeratorEntity("Daffy");
+    // Submit the answers by clicking next, and then go to review page.
     await applicantQuestions.clickNext();
+    await applicantQuestions.clickReview();
 
     // Make sure there are no enumerators or repeated things in the review page
     expect(await page.innerText("#application-summary")).toContain("Porky Pig");
@@ -155,7 +157,7 @@ describe('End to end enumerator test', () => {
     await applicantQuestions.clickNext();
     await applicantQuestions.answerNameQuestion("Tweety", "Bird");
     await applicantQuestions.clickNext();
-    await applicantQuestions.clickNext();
+    await applicantQuestions.clickReview();
 
     // Make sure there are no enumerators or repeated things in the review page
     expect(await page.innerText("#application-summary")).toContain("Porky Pig");

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -76,6 +76,10 @@ export class ApplicantQuestions {
     await this.page.click('text="Next"');
   }
 
+  async clickReview() {
+    await this.page.click('text="Review"');
+  }
+
   async clickUpload() {
     await this.page.click('text="Upload"');
   }

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -326,7 +326,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     Block thisBlockUpdated = thisBlockUpdatedMaybe.get();
 
     // Validation errors: re-render this block with errors and previously entered data.
-    if (thisBlockUpdated.hasErrors()) {
+    if (thisBlockUpdated.hasErrors()
+        || thisBlockUpdated.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()) {
       return supplyAsync(
           () ->
               ok(

--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -298,16 +298,15 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             },
             httpExecutionContext.current())
         .thenComposeAsync(
-            (roApplicantProgramService) -> {
-              return renderErrorOrRedirectToNextBlock(
-                  request,
-                  applicantId,
-                  programId,
-                  blockId,
-                  applicantStage.toCompletableFuture().join(),
-                  inReview,
-                  roApplicantProgramService);
-            },
+            roApplicantProgramService ->
+                renderErrorOrRedirectToNextBlock(
+                    request,
+                    applicantId,
+                    programId,
+                    blockId,
+                    applicantStage.toCompletableFuture().join(),
+                    inReview,
+                    roApplicantProgramService),
             httpExecutionContext.current())
         .exceptionally(ex -> handleUpdateExceptions(ex));
   }

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -80,7 +80,8 @@ public enum MessageKey {
   TOAST_APPLICATION_SAVED("toast.applicationSaved"),
   TOAST_LOCALE_NOT_SUPPORTED("toast.localeNotSupported"),
   TOAST_PROGRAM_COMPLETED("toast.programCompleted"),
-  USER_NAME("header.userName");
+  USER_NAME("header.userName"),
+  VALIDATION_REQUIRED("validation.isRequired");
 
   private final String keyName;
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -236,11 +236,15 @@ public class ApplicantData {
     }
   }
 
-  /** Clears an array in preparation of updates. */
+  /**
+   * Clears an array in preparation of updates, regardless of whether there are anything values
+   * present.
+   */
   public void maybeClearArray(Path path) {
+    checkLocked();
     if (path.isArrayElement()) {
       putParentIfMissing(path);
-      putAt(path.withoutArrayReference(), new ArrayList<>());
+      jsonData.delete(path.withoutArrayReference().toString());
     }
   }
 
@@ -364,6 +368,14 @@ public class ApplicantData {
       index++;
     }
     return listBuilder.build();
+  }
+
+  /** If there are no repeated entities at the path, remove the array entirely. */
+  public void maybeClearRepeatedEntities(Path path) {
+    checkLocked();
+    if (readRepeatedEntities(path).isEmpty()) {
+      jsonData.delete(path.withoutArrayReference().toString());
+    }
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -248,10 +248,14 @@ public class ApplicantData {
     }
   }
 
-  /** Delete whatever is there. */
-  public void delete(Path path) {
+  /** Delete whatever is there if it exists. Returns whether a delete actually happened. */
+  public boolean maybeDelete(Path path) {
     checkLocked();
-    jsonData.delete(path.toString());
+    if (hasPath(path)) {
+      jsonData.delete(path.toString());
+      return true;
+    }
+    return false;
   }
 
   private void putAt(Path path, Object value) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -249,7 +249,7 @@ public class ApplicantData {
   }
 
   /** Delete whatever is there. */
-  public boolean delete(Path path) {
+  public void delete(Path path) {
     checkLocked();
     jsonData.delete(path.toString());
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -370,12 +370,17 @@ public class ApplicantData {
     return listBuilder.build();
   }
 
-  /** If there are no repeated entities at the path, remove the array entirely. */
-  public void maybeClearRepeatedEntities(Path path) {
+  /**
+   * If there are no repeated entities at the path, remove the array entirely. Returns true if it
+   * was deleted.
+   */
+  public boolean maybeClearRepeatedEntities(Path path) {
     checkLocked();
     if (readRepeatedEntities(path).isEmpty()) {
       jsonData.delete(path.withoutArrayReference().toString());
+      return true;
     }
+    return false;
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -237,8 +237,8 @@ public class ApplicantData {
   }
 
   /**
-   * Clears an array in preparation of updates, regardless of whether there are anything values
-   * present.
+   * Clears an array in preparation of updates if the path is pointing to an array element,
+   * regardless of whether there are any values present.
    */
   public void maybeClearArray(Path path) {
     checkLocked();
@@ -246,6 +246,12 @@ public class ApplicantData {
       putParentIfMissing(path);
       jsonData.delete(path.withoutArrayReference().toString());
     }
+  }
+
+  /** Delete whatever is there. */
+  public boolean delete(Path path) {
+    checkLocked();
+    jsonData.delete(path.toString());
   }
 
   private void putAt(Path path, Object value) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -244,18 +244,16 @@ public class ApplicantData {
     checkLocked();
     if (path.isArrayElement()) {
       putParentIfMissing(path);
-      jsonData.delete(path.withoutArrayReference().toString());
+      maybeDelete(path.withoutArrayReference());
     }
   }
 
   /** Delete whatever is there if it exists. Returns whether a delete actually happened. */
-  public boolean maybeDelete(Path path) {
+  public void maybeDelete(Path path) {
     checkLocked();
     if (hasPath(path)) {
       jsonData.delete(path.toString());
-      return true;
     }
-    return false;
   }
 
   private void putAt(Path path, Object value) {
@@ -381,8 +379,8 @@ public class ApplicantData {
   }
 
   /**
-   * If there are no repeated entities at the path, remove the array entirely. Returns true if it
-   * was deleted.
+   * If there are no repeated entities at the path, remove the array entirely. Returns true if there
+   * are no repeated entities anymore.
    *
    * <p>This method needs to check that there are no repeated entity data stored before deleting
    * because we do not want to delete repeated entity data via this method. To delete data for
@@ -391,7 +389,7 @@ public class ApplicantData {
   public boolean maybeClearRepeatedEntities(Path path) {
     checkLocked();
     if (readRepeatedEntities(path).isEmpty()) {
-      jsonData.delete(path.withoutArrayReference().toString());
+      maybeDelete(path.withoutArrayReference());
       return true;
     }
     return false;

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -383,6 +383,10 @@ public class ApplicantData {
   /**
    * If there are no repeated entities at the path, remove the array entirely. Returns true if it
    * was deleted.
+   *
+   * <p>This method needs to check that there are no repeated entity data stored before deleting
+   * because we do not want to delete repeated entity data via this method. To delete data for
+   * repeated entities, use {@link #deleteRepeatedEntities(Path, ImmutableList)};
    */
   public boolean maybeClearRepeatedEntities(Path path) {
     checkLocked();

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -485,7 +485,7 @@ public class ApplicantServiceImpl implements ApplicantService {
               .getScalarType(currentPath)
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
       // An empty update means the applicant doesn't want to store anything.
-      if (update.value().isBlank()) {
+      if (!update.path().isArrayElement() && update.value().isBlank()) {
         applicantData.maybeDelete(update.path());
       } else {
         switch (type) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -484,7 +484,10 @@ public class ApplicantServiceImpl implements ApplicantService {
           block
               .getScalarType(currentPath)
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
-      if (!update.value().isBlank()) {
+      // An empty update means the applicant doesn't want to store anything.
+      if (update.value().isBlank()) {
+        applicantData.delete(update.path());
+      } else {
         switch (type) {
           case DATE:
             applicantData.putDate(currentPath, update.value());

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -393,8 +393,8 @@ public class ApplicantServiceImpl implements ApplicantService {
     }
 
     // Before adding anything, if only metadata is being stored then delete it
-    if (applicantData.hasPath(enumeratorPath.withoutArrayReference())) {
-      applicantData.delete(enumeratorPath.withoutArrayReference());
+    if (applicantData.readRepeatedEntities(enumeratorPath).isEmpty()) {
+      applicantData.maybeDelete(enumeratorPath.withoutArrayReference());
     }
 
     // Add and change entity names BEFORE deleting, because if deletes happened first, then changed
@@ -486,7 +486,7 @@ public class ApplicantServiceImpl implements ApplicantService {
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
       // An empty update means the applicant doesn't want to store anything.
       if (update.value().isBlank()) {
-        applicantData.delete(update.path());
+        applicantData.maybeDelete(update.path());
       } else {
         switch (type) {
           case DATE:

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -413,8 +413,7 @@ public class ApplicantServiceImpl implements ApplicantService {
 
     // If there are no repeated entities at this point, we still need to save metadata for this
     // question.
-    if (applicantData.readRepeatedEntities(enumeratorPath).isEmpty()) {
-      applicantData.maybeClearRepeatedEntities(enumeratorPath);
+    if (applicantData.maybeClearRepeatedEntities(enumeratorPath)) {
       writeMetadataForPath(enumeratorPath.withoutArrayReference(), applicantData, updateMetadata);
     }
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -392,7 +392,9 @@ public class ApplicantServiceImpl implements ApplicantService {
       throw new PathNotInBlockException(block.getId(), unknownUpdates.iterator().next().path());
     }
 
-    // Before adding anything, if only metadata is being stored then delete it
+    // Before adding anything, if only metadata is being stored then delete it. We cannot put an
+    // array of entities at the question path if a JSON object with metadata is already at that
+    // path.
     if (applicantData.readRepeatedEntities(enumeratorPath).isEmpty()) {
       applicantData.maybeDelete(enumeratorPath.withoutArrayReference());
     }
@@ -484,7 +486,8 @@ public class ApplicantServiceImpl implements ApplicantService {
           block
               .getScalarType(currentPath)
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
-      // An empty update means the applicant doesn't want to store anything. We already cleared the multi-select array above in preparation for updates, so do not remove the path.
+      // An empty update means the applicant doesn't want to store anything. We already cleared the
+      // multi-select array above in preparation for updates, so do not remove the path.
       if (!update.path().isArrayElement() && update.value().isBlank()) {
         applicantData.maybeDelete(update.path());
       } else {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -484,7 +484,7 @@ public class ApplicantServiceImpl implements ApplicantService {
           block
               .getScalarType(currentPath)
               .orElseThrow(() -> new PathNotInBlockException(block.getId(), currentPath));
-      // An empty update means the applicant doesn't want to store anything.
+      // An empty update means the applicant doesn't want to store anything. We already cleared the multi-select array above in preparation for updates, so do not remove the path.
       if (!update.path().isArrayElement() && update.value().isBlank()) {
         applicantData.maybeDelete(update.path());
       } else {

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -152,6 +152,15 @@ public final class Block {
   }
 
   /**
+   * Return true if any of this blocks questions are required but were left unanswered while filling
+   * out the current program.
+   */
+  public boolean hasRequiredQuestionsThatAreUnansweredInCurrentProgram() {
+    return getQuestions().stream()
+        .anyMatch(ApplicantQuestion::isRequiredButWasUnansweredInCurrentProgram);
+  }
+
+  /**
    * Checks whether the block is complete - that is, {@link ApplicantData} has values at all the
    * paths for all required questions in this block and there are no errors. Note: this cannot be
    * memoized, since we need to reflect internal changes to ApplicantData.

--- a/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
@@ -78,7 +78,7 @@ public class AddressQuestion implements PresentsErrors {
   }
 
   public ImmutableSet<ValidationErrorMessage> getStreetErrors() {
-    if (isStreetAnswered() && getStreetValue().isEmpty()) {
+    if (isAnswered() && getStreetValue().isEmpty()) {
       return getStreetErrorMessage();
     }
 
@@ -91,7 +91,7 @@ public class AddressQuestion implements PresentsErrors {
   }
 
   public ImmutableSet<ValidationErrorMessage> getCityErrors() {
-    if (isCityAnswered() && getCityValue().isEmpty()) {
+    if (isAnswered() && getCityValue().isEmpty()) {
       return getCityErrorMessage();
     }
 
@@ -105,7 +105,7 @@ public class AddressQuestion implements PresentsErrors {
 
   public ImmutableSet<ValidationErrorMessage> getStateErrors() {
     // TODO: Validate state further.
-    if (isStateAnswered() && getStateValue().isEmpty()) {
+    if (isAnswered() && getStateValue().isEmpty()) {
       return getStateErrorMessage();
     }
 
@@ -118,7 +118,7 @@ public class AddressQuestion implements PresentsErrors {
   }
 
   public ImmutableSet<ValidationErrorMessage> getZipErrors() {
-    if (isZipAnswered()) {
+    if (isAnswered()) {
       Optional<String> zipValue = getZipValue();
       if (zipValue.isEmpty()) {
         return ImmutableSet.of(
@@ -240,10 +240,7 @@ public class AddressQuestion implements PresentsErrors {
     return applicantQuestion.getApplicantData().hasPath(getZipPath());
   }
 
-  /**
-   * Returns true if any one of the address fields is answered. Returns false if all are not
-   * answered.
-   */
+  /** Returns true if any field is answered. Returns false if all are not. */
   @Override
   public boolean isAnswered() {
     return isStreetAnswered()

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -77,6 +77,20 @@ public class ApplicantQuestion {
   }
 
   /**
+   * Return true this question is required but was left unanswered while filling out the current
+   * program.
+   */
+  public boolean isRequiredButWasUnansweredInCurrentProgram() {
+    return !isOptional() && !errorsPresenter().isAnswered() && wasRecentlyUpdated();
+  }
+
+  /** Returns true if this question was most recently updated in this program. */
+  private boolean wasRecentlyUpdated() {
+    return getUpdatedInProgramMetadata().stream()
+        .anyMatch(pid -> pid.equals(programQuestionDefinition.getProgramDefinitionId()));
+  }
+
+  /**
    * Get the question text localized to the applicant's preferred locale, contextualized with {@link
    * RepeatedEntity}.
    */

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -81,11 +81,11 @@ public class ApplicantQuestion {
    * program.
    */
   public boolean isRequiredButWasUnansweredInCurrentProgram() {
-    return !isOptional() && !errorsPresenter().isAnswered() && wasRecentlyUpdated();
+    return !isOptional() && !errorsPresenter().isAnswered() && wasRecentlyUpdatedInThisProgram();
   }
 
   /** Returns true if this question was most recently updated in this program. */
-  private boolean wasRecentlyUpdated() {
+  private boolean wasRecentlyUpdatedInThisProgram() {
     return getUpdatedInProgramMetadata().stream()
         .anyMatch(pid -> pid.equals(programQuestionDefinition.getProgramDefinitionId()));
   }
@@ -166,19 +166,15 @@ public class ApplicantQuestion {
   }
 
   private Path getMetadataPath(Scalar metadataScalar) {
-    Path contextualizedMetadataPath = getContextualizedPath().join(metadataScalar);
-
     // For enumerator questions, rely on the metadata at the first repeated entity if it exists.
     // If it doesn't exist, check for metadata stored when there are no repeated entities.
     if (getQuestionDefinition().isEnumerator()) {
       Path firstEntity = getContextualizedPath().atIndex(0);
-      contextualizedMetadataPath =
-          applicantData.hasPath(firstEntity)
-              ? firstEntity.join(metadataScalar)
-              : getContextualizedPath().withoutArrayReference().join(metadataScalar);
+      return applicantData.hasPath(firstEntity)
+          ? firstEntity.join(metadataScalar)
+          : getContextualizedPath().withoutArrayReference().join(metadataScalar);
     }
-
-    return contextualizedMetadataPath;
+    return getContextualizedPath().join(metadataScalar);
   }
 
   public AddressQuestion createAddressQuestion() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -77,7 +77,7 @@ public class ApplicantQuestion {
   }
 
   /**
-   * Return true this question is required but was left unanswered while filling out the current
+   * Return true if this question is required but was left unanswered while filling out the current
    * program.
    */
   public boolean isRequiredButWasUnansweredInCurrentProgram() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -84,7 +84,7 @@ public class EnumeratorQuestion implements PresentsErrors {
   public boolean isAnswered() {
     return applicantQuestion
         .getApplicantData()
-        .hasPath(applicantQuestion.getContextualizedPath().withoutArrayReference());
+        .hasPath(applicantQuestion.getContextualizedPath().atIndex(0));
   }
 
   /** Return the repeated entity names associated with this enumerator question. */

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NameQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NameQuestion.java
@@ -53,7 +53,7 @@ public class NameQuestion implements PresentsErrors {
   }
 
   public ImmutableSet<ValidationErrorMessage> getFirstNameErrors() {
-    if (isFirstNameAnswered() && getFirstNameValue().isEmpty()) {
+    if (isAnswered() && getFirstNameValue().isEmpty()) {
       return getFirstNameErrorMessage();
     }
 
@@ -66,7 +66,7 @@ public class NameQuestion implements PresentsErrors {
   }
 
   public ImmutableSet<ValidationErrorMessage> getLastNameErrors() {
-    if (isLastNameAnswered() && getLastNameValue().isEmpty()) {
+    if (isAnswered() && getLastNameValue().isEmpty()) {
       return getLastNameErrorMessage();
     }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/PresentsErrors.java
@@ -26,8 +26,8 @@ public interface PresentsErrors {
   ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors();
 
   /**
-   * Returns true if the question has been answered by the applicant, even if that answer was blank.
-   * In general, if a question is not answered, it cannot have errors associated with it.
+   * Returns true any part of the question has been answered by the applicant. Blank answers should
+   * not count. In general, if a question is not answered, it cannot have errors associated with it.
    */
   boolean isAnswered();
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
@@ -41,6 +41,11 @@ public abstract class ProgramQuestionDefinition {
   abstract Optional<QuestionDefinition> questionDefinition();
 
   @JsonIgnore
+  public long getProgramDefinitionId() {
+    return programDefinitionId().get();
+  }
+
+  @JsonIgnore
   public QuestionDefinition getQuestionDefinition() {
     return questionDefinition().get();
   }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -406,11 +406,13 @@ public class ProgramBlockEditView extends BaseHtmlView {
         optionalToggle(
             csrfTag, programDefinitionId, blockDefinitionId, questionDefinition, isOptional);
 
-    return ret.with(icon, content)
-        .condWith(maybeOptionalToggle.isPresent(), maybeOptionalToggle.get())
-        .with(
-            deleteQuestionForm(
-                csrfTag, programDefinitionId, blockDefinitionId, questionDefinition, canRemove));
+    ret.with(icon, content);
+    if (maybeOptionalToggle.isPresent()) {
+      ret.with(maybeOptionalToggle.get());
+    }
+    return ret.with(
+        deleteQuestionForm(
+            csrfTag, programDefinitionId, blockDefinitionId, questionDefinition, canRemove));
   }
 
   private Optional<Tag> optionalToggle(

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -195,6 +195,10 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
   }
 
   private Tag renderSkipFileUploadButton(Params params) {
+    // Cannot skip required file questions.
+    if (!params.block().getQuestions().get(0).isOptional()) {
+      return null;
+    }
     String skipUrl =
         routes.ApplicantProgramBlocksController.skipFile(
                 params.applicantId(), params.programId(), params.block().getId(), params.inReview())

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -13,6 +13,7 @@ import com.google.inject.Inject;
 import controllers.applicant.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Optional;
 import play.i18n.Messages;
 import play.mvc.Http;
 import play.mvc.Http.HttpVerbs;
@@ -175,12 +176,13 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
   }
 
   private Tag renderFileUploadBottomNavButtons(Params params) {
+    Optional<Tag> maybeSkipFileUploadButton = renderSkipFileUploadButton(params);
     return div()
         .withClasses(ApplicantStyles.APPLICATION_NAV_BAR)
         // An empty div to take up the space to the left of the buttons.
         .with(div().withClasses(Styles.FLEX_GROW))
         .with(renderReviewButton(params))
-        .with(renderSkipFileUploadButton(params))
+        .condWith(maybeSkipFileUploadButton.isPresent(), maybeSkipFileUploadButton.get())
         .with(renderUploadButton(params));
   }
 
@@ -194,19 +196,20 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
         .withClasses(ApplicantStyles.BUTTON_REVIEW);
   }
 
-  private Tag renderSkipFileUploadButton(Params params) {
+  private Optional<Tag> renderSkipFileUploadButton(Params params) {
     // Cannot skip required file questions.
     if (!params.block().getQuestions().get(0).isOptional()) {
-      return null;
+      return Optional.empty();
     }
     String skipUrl =
         routes.ApplicantProgramBlocksController.skipFile(
                 params.applicantId(), params.programId(), params.block().getId(), params.inReview())
             .url();
-    return a().attr(HREF, skipUrl)
-        .withText(params.messages().at(MessageKey.BUTTON_SKIP_FILEUPLOAD.getKeyName()))
-        .withId("skip-fileupload-button")
-        .withClasses(ApplicantStyles.BUTTON_REVIEW);
+    return Optional.of(
+        a().attr(HREF, skipUrl)
+            .withText(params.messages().at(MessageKey.BUTTON_SKIP_FILEUPLOAD.getKeyName()))
+            .withId("skip-fileupload-button")
+            .withClasses(ApplicantStyles.BUTTON_REVIEW));
   }
 
   private Tag renderNextButton(Params params) {

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -177,13 +177,16 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
   private Tag renderFileUploadBottomNavButtons(Params params) {
     Optional<Tag> maybeSkipFileUploadButton = renderSkipFileUploadButton(params);
-    return div()
-        .withClasses(ApplicantStyles.APPLICATION_NAV_BAR)
-        // An empty div to take up the space to the left of the buttons.
-        .with(div().withClasses(Styles.FLEX_GROW))
-        .with(renderReviewButton(params))
-        .condWith(maybeSkipFileUploadButton.isPresent(), maybeSkipFileUploadButton.get())
-        .with(renderUploadButton(params));
+    ContainerTag ret =
+        div()
+            .withClasses(ApplicantStyles.APPLICATION_NAV_BAR)
+            // An empty div to take up the space to the left of the buttons.
+            .with(div().withClasses(Styles.FLEX_GROW))
+            .with(renderReviewButton(params));
+    if (maybeSkipFileUploadButton.isPresent()) {
+      ret.with(maybeSkipFileUploadButton.get());
+    }
+    return ret.with(renderUploadButton(params));
   }
 
   private Tag renderReviewButton(Params params) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.div;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import play.i18n.Messages;
+import services.MessageKey;
 import services.applicant.question.ApplicantQuestion;
 import views.BaseHtmlView;
 import views.components.TextFormatter;
@@ -65,9 +66,17 @@ public abstract class ApplicantQuestionRenderer {
       questionTextDiv.with(BaseHtmlView.fieldErrors(messages, question.getQuestionErrors()));
     }
 
+    if (question.isRequiredButWasUnansweredInCurrentProgram()) {
+      String requiredQuestionMessage = messages.at(MessageKey.VALIDATION_REQUIRED.getKeyName());
+      questionTextDiv.with(
+          div()
+              .withClasses(Styles.P_1, Styles.TEXT_RED_600)
+              .withText("*" + requiredQuestionMessage));
+    }
+
     return div()
         .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.MB_8, this.getReferenceClass(), this.getRequiredClass())
+        .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
         .with(questionTextDiv)
         .with(questionFormContent);
   }

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -28,6 +28,9 @@ footer.supportLinkDescription=For technical support, contact
 # Message with user's name to show who you are logged in as.
 header.userName=Logged in as {0}
 
+# Error message to answer a required question
+validation.isRequired=This question is required.
+
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #
 #-------------------------------------------------------------#

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -60,6 +60,7 @@ placeholder.lastName=Last name
 placeholder.entityName=Nickname for {0}
 button.addEntity=Add {0}
 button.removeEntity=Remove {0}
+validation.isRequired=This question is required.
 validation.duplicateEntityName=Please enter a unique value for each line.
 validation.firstNameRequired=Please enter your first name.
 validation.lastNameRequired=Please enter your last name.

--- a/universal-application-tool-0.0.1/conf/messages.es-US
+++ b/universal-application-tool-0.0.1/conf/messages.es-US
@@ -59,4 +59,5 @@ placeholder.entityName=Apodo para {0}
 button.addEntity=Agrega otro {0}
 button.removeEntity=Eliminar {0}
 
+validation.isRequired=Esta pregunta es requerida.
 validation.entityNameRequired=Ingrese un valor para cada línea.

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -562,7 +562,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newDraftProgram()
             .withBlock("block 1")
-            .withQuestion(testQuestionBank().applicantFile())
+            .withQuestion(testQuestionBank().applicantFile(), true)
             .withBlock("block 2")
             .withQuestion(testQuestionBank().applicantAddress())
             .build();
@@ -594,7 +594,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     program =
         ProgramBuilder.newDraftProgram()
             .withBlock("block 1")
-            .withQuestion(testQuestionBank().applicantFile())
+            .withQuestion(testQuestionBank().applicantFile(), true)
             .build();
 
     RequestBuilder request =

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantDataTest.java
@@ -489,7 +489,7 @@ public class ApplicantDataTest {
 
     data.maybeClearArray(Path.create("applicant.things[0]"));
 
-    String nextExpected = "{\"applicant\":{\"things\":[],\"stuff\":\"cars\"}}";
+    String nextExpected = "{\"applicant\":{\"stuff\":\"cars\"}}";
     assertThat(data.asJsonString()).isEqualTo(nextExpected);
   }
 

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -196,7 +196,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
 
     assertThat(
             applicantDataAfter.readList(Path.create("applicant.checkbox").join(Scalar.SELECTIONS)))
-        .hasValue(ImmutableList.of());
+        .isEmpty();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -368,6 +368,116 @@ public class BlockTest {
     assertThat(block.isFileUpload()).isFalse();
   }
 
+  @Test
+  public void hasRequiredQuestionsThatAreUnansweredInCurrentProgram_returnsTrue() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    block.getQuestions().stream()
+        .map(ApplicantQuestion::getContextualizedPath)
+        .forEach(path -> QuestionAnswerer.addMetadata(applicantData, path, programId, 1L));
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isTrue();
+  }
+
+  @Test
+  public void
+      hasRequiredQuestionsThatAreUnansweredInCurrentProgram_questionsAnsweredInAnotherProgram_returnsFalse() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    block.getQuestions().stream()
+        .map(ApplicantQuestion::getContextualizedPath)
+        .forEach(path -> QuestionAnswerer.addMetadata(applicantData, path, programId + 1, 1L));
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void
+      hasRequiredQuestionsThatAreUnansweredInCurrentProgram_withOptionalQuestions_returnsFalse() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                        testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                        Optional.of(programId))
+                    .setOptional(true))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                        testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                        Optional.of(programId))
+                    .setOptional(true))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void
+      hasRequiredQuestionsThatAreUnansweredInCurrentProgram_withAnsweredQuestions_returnsFalse() {
+    long programId = 5L;
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    testQuestionBank.applicantFavoriteColor().getQuestionDefinition(),
+                    Optional.of(programId)))
+            .build();
+    ApplicantData applicantData = new ApplicantData();
+    Block block = new Block("id", blockDefinition, applicantData, Optional.empty());
+
+    QuestionAnswerer.answerNumberQuestion(
+        applicantData, block.getQuestions().get(0).getContextualizedPath(), "5");
+    QuestionAnswerer.answerTextQuestion(
+        applicantData, block.getQuestions().get(1).getContextualizedPath(), "brown");
+
+    assertThat(block.hasRequiredQuestionsThatAreUnansweredInCurrentProgram()).isFalse();
+  }
+
   private static BlockDefinition setUpBlockWithQuestions() {
     return BlockDefinition.builder()
         .setId(20L)

--- a/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
+import services.program.ProgramQuestionDefinition;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -285,5 +286,73 @@ public class ApplicantQuestionTest {
 
     assertThat(applicantQuestion.getUpdatedInProgramMetadata()).contains(1L);
     assertThat(applicantQuestion.getLastUpdatedTimeMetadata()).contains(2L);
+  }
+
+  @Test
+  public void isRequiredButWasUnansweredInCurrentProgram_returnsTrue() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            Optional.of(programId));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isTrue();
+  }
+
+  @Test
+  public void
+      isRequiredButWasUnansweredInCurrentProgram_leftUnansweredInDifferentProgram_returnsFalse() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            Optional.of(programId));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId + 1, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void isRequiredButWasUnansweredInCurrentProgram_isAnswered_returnsFalse() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+            testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+            Optional.of(programId));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.answerNumberQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "5");
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isFalse();
+  }
+
+  @Test
+  public void isRequiredButWasUnansweredInCurrentProgram_isOptional_returnsFalse() {
+    ApplicantData applicantData = new ApplicantData();
+    long programId = 5L;
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(
+                testQuestionBank.applicantJugglingNumber().getQuestionDefinition(),
+                Optional.of(programId))
+            .setOptional(true);
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(pqd, applicantData, Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath(), programId, 1L);
+
+    assertThat(applicantQuestion.isRequiredButWasUnansweredInCurrentProgram()).isFalse();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
@@ -271,4 +271,19 @@ public class ApplicantQuestionTest {
     assertThat(applicantQuestion.getQuestionHelpText())
         .isEqualTo("What is the monthly income of Jonathan at JonCo?");
   }
+
+  @Test
+  public void getMetadata_forEnumerator_withNoRepeatedEntities() {
+    ApplicantData applicantData = new ApplicantData();
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+            applicantData,
+            Optional.empty());
+    QuestionAnswerer.addMetadata(
+        applicantData, applicantQuestion.getContextualizedPath().withoutArrayReference(), 1L, 2L);
+
+    assertThat(applicantQuestion.getUpdatedInProgramMetadata()).contains(1L);
+    assertThat(applicantQuestion.getLastUpdatedTimeMetadata()).contains(2L);
+  }
 }

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -202,10 +202,19 @@ public class ProgramBuilder {
       return this;
     }
 
+    /** Add a required question to the block. */
     public BlockBuilder withQuestion(Question question) {
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
               question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId)));
+      return this;
+    }
+
+    public BlockBuilder withQuestion(Question question, boolean optional) {
+      blockDefBuilder.addQuestion(
+          ProgramQuestionDefinition.create(
+                  question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId))
+              .setOptional(optional));
       return this;
     }
 


### PR DESCRIPTION
## Description

Before, updates with empty values ("") would be stored in applicant data json. Now we don't store empty values, and updates with empty values delete the value that was stored.

Metadata is updated for every question, which we can use to mark whether a question has been visited even though it is unanswered. 

Arrays (enumerator and multi select questions) with empty updates get deleted, but the metadata is still updated.

Questions are "answered" if any of their scalars have a value in applicant data. There might be weird behavior with old applicant data that is storing blank values, but blank values shouldn't exist in the future.

Scalar specific errors for multi-field questions (address and name) for each of their fields are present if the question is answered, not just if the field is answered.

All questions are required. This includes:
* enumerator questions need at least one repeated entity
* multi select questions must have at least one selection

### Validation
Questions that are required, are not answered, and have been visited in the current program will prevent application progress the same way validation errors on questions do. 

Adds `ApplicantQuestion#isRequiredButWasUnansweredInCurrentProgram`, and `ApplicantQuestionRenderer` uses that method to show an "question is required" error message.

A similar method is added to `Block`, which is used by `ApplicantProgramBlocksController` to hold up application progression the same way `Block#hasErrors()` blocks progress.

Had to implement `empty updates -> deleting json data` to make things work well. Also had to implement `delete enumerator metadata if its the only thing at that path` for similar reasons.

## Issue(s)
Fixes #1417 