### PR TITLE
Hide optional question toggle behind feature flag

### DIFF
--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -49,5 +49,6 @@ services:
       - ADFS_SECRET
       - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
       - BASE_URL=http://civiform:9000
+      - CF_OPTIONAL_QUESTIONS
 
     command: ~run -Dconfig.file=conf/application.dev.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,5 +40,6 @@ services:
       - IDCS_SECRET
       - ADFS_CLIENT_ID
       - ADFS_SECRET
+      - CF_OPTIONAL_QUESTIONS
 
     command: -jvm-debug "*:8457" ~run -Dconfig.file=conf/application.dev.conf

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -42,7 +42,7 @@ import views.style.Styles;
 public class ProgramBlockEditView extends BaseHtmlView {
 
   private final AdminLayout layout;
-  private final Config config;
+  private final boolean featureFlagOptionalQuestions;
 
   public static final String ENUMERATOR_ID_FORM_FIELD = "enumeratorId";
   private static final String CREATE_BLOCK_FORM_ID = "block-create-form";
@@ -52,7 +52,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
   @Inject
   public ProgramBlockEditView(AdminLayout layout, Config config) {
     this.layout = checkNotNull(layout);
-    this.config = checkNotNull(config);
+    this.featureFlagOptionalQuestions = checkNotNull(config).hasPath("cf.optional_questions");
   }
 
   public Content render(
@@ -392,51 +392,51 @@ public class ProgramBlockEditView extends BaseHtmlView {
       long blockDefinitionId,
       QuestionDefinition questionDefinition,
       boolean isOptional) {
-    if (config.hasPath("cf.optional_questions")) {
-      ContainerTag optionalButton =
-          TagCreator.button()
-              .withClasses(
-                  Styles.FLEX,
-                  Styles.GAP_2,
-                  Styles.ITEMS_CENTER,
-                  isOptional ? Styles.TEXT_BLACK : Styles.TEXT_GRAY_400,
-                  Styles.FONT_MEDIUM,
-                  Styles.BG_TRANSPARENT,
-                  Styles.ROUNDED_FULL,
-                  StyleUtils.hover(Styles.BG_GRAY_400, Styles.TEXT_GRAY_300))
-              .withType("submit")
-              .with(p("optional").withClasses("hover-group:text-white"))
-              .with(
-                  div()
-                      .withClasses(Styles.RELATIVE)
-                      .with(
-                          div()
-                              .withClasses(
-                                  isOptional ? Styles.BG_BLUE_600 : Styles.BG_GRAY_600,
-                                  Styles.W_14,
-                                  Styles.H_8,
-                                  Styles.ROUNDED_FULL))
-                      .with(
-                          div()
-                              .withClasses(
-                                  Styles.ABSOLUTE,
-                                  Styles.BG_WHITE,
-                                  isOptional ? Styles.RIGHT_1 : Styles.LEFT_1,
-                                  Styles.TOP_1,
-                                  Styles.W_6,
-                                  Styles.H_6,
-                                  Styles.ROUNDED_FULL)));
-      String toggleOptionalAction =
-          controllers.admin.routes.AdminProgramBlockQuestionsController.setOptional(
-                  programDefinitionId, blockDefinitionId, questionDefinition.getId())
-              .url();
-      return form(csrfTag)
-          .withMethod(HttpVerbs.POST)
-          .withAction(toggleOptionalAction)
-          .with(input().isHidden().withName("optional").withValue(isOptional ? "false" : "true"))
-          .with(optionalButton);
+    if (!featureFlagOptionalQuestions) {
+      return null;
     }
-    return null;
+    ContainerTag optionalButton =
+        TagCreator.button()
+            .withClasses(
+                Styles.FLEX,
+                Styles.GAP_2,
+                Styles.ITEMS_CENTER,
+                isOptional ? Styles.TEXT_BLACK : Styles.TEXT_GRAY_400,
+                Styles.FONT_MEDIUM,
+                Styles.BG_TRANSPARENT,
+                Styles.ROUNDED_FULL,
+                StyleUtils.hover(Styles.BG_GRAY_400, Styles.TEXT_GRAY_300))
+            .withType("submit")
+            .with(p("optional").withClasses("hover-group:text-white"))
+            .with(
+                div()
+                    .withClasses(Styles.RELATIVE)
+                    .with(
+                        div()
+                            .withClasses(
+                                isOptional ? Styles.BG_BLUE_600 : Styles.BG_GRAY_600,
+                                Styles.W_14,
+                                Styles.H_8,
+                                Styles.ROUNDED_FULL))
+                    .with(
+                        div()
+                            .withClasses(
+                                Styles.ABSOLUTE,
+                                Styles.BG_WHITE,
+                                isOptional ? Styles.RIGHT_1 : Styles.LEFT_1,
+                                Styles.TOP_1,
+                                Styles.W_6,
+                                Styles.H_6,
+                                Styles.ROUNDED_FULL)));
+    String toggleOptionalAction =
+        controllers.admin.routes.AdminProgramBlockQuestionsController.setOptional(
+                programDefinitionId, blockDefinitionId, questionDefinition.getId())
+            .url();
+    return form(csrfTag)
+        .withMethod(HttpVerbs.POST)
+        .withAction(toggleOptionalAction)
+        .with(input().isHidden().withName("optional").withValue(isOptional ? "false" : "true"))
+        .with(optionalButton);
   }
 
   private Tag deleteQuestionForm(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -377,7 +377,21 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .with(p(questionDefinition.getName()))
             .with(p(questionDefinition.getDescription()).withClasses(Styles.MT_1, Styles.TEXT_SM));
 
-    Tag optionalToggle;
+    return ret.with(
+        icon,
+        content,
+        optionalToggle(
+            csrfTag, programDefinitionId, blockDefinitionId, questionDefinition, isOptional),
+        deleteQuestionForm(
+            csrfTag, programDefinitionId, blockDefinitionId, questionDefinition, canRemove));
+  }
+
+  private Tag optionalToggle(
+      Tag csrfTag,
+      long programDefinitionId,
+      long blockDefinitionId,
+      QuestionDefinition questionDefinition,
+      boolean isOptional) {
     if (config.hasPath("cf.optional_questions")) {
       ContainerTag optionalButton =
           TagCreator.button()
@@ -416,17 +430,21 @@ public class ProgramBlockEditView extends BaseHtmlView {
           controllers.admin.routes.AdminProgramBlockQuestionsController.setOptional(
                   programDefinitionId, blockDefinitionId, questionDefinition.getId())
               .url();
-      optionalToggle =
-          form(csrfTag)
-              .withMethod(HttpVerbs.POST)
-              .withAction(toggleOptionalAction)
-              .with(
-                  input().isHidden().withName("optional").withValue(isOptional ? "false" : "true"))
-              .with(optionalButton);
-    } else {
-      optionalToggle = div();
+      return form(csrfTag)
+          .withMethod(HttpVerbs.POST)
+          .withAction(toggleOptionalAction)
+          .with(input().isHidden().withName("optional").withValue(isOptional ? "false" : "true"))
+          .with(optionalButton);
     }
+    return null;
+  }
 
+  private Tag deleteQuestionForm(
+      Tag csrfTag,
+      long programDefinitionId,
+      long blockDefinitionId,
+      QuestionDefinition questionDefinition,
+      boolean canRemove) {
     Tag removeButton =
         TagCreator.button(text("DELETE"))
             .withType("submit")
@@ -445,14 +463,11 @@ public class ProgramBlockEditView extends BaseHtmlView {
         controllers.admin.routes.AdminProgramBlockQuestionsController.destroy(
                 programDefinitionId, blockDefinitionId, questionDefinition.getId())
             .url();
-    ContainerTag questionDeleteForm =
-        form(csrfTag)
-            .withId("block-questions-form")
-            .withMethod(HttpVerbs.POST)
-            .withAction(deleteQuestionAction)
-            .with(removeButton);
-
-    return ret.with(icon, content, optionalToggle, questionDeleteForm);
+    return form(csrfTag)
+        .withId("block-questions-form")
+        .withMethod(HttpVerbs.POST)
+        .withAction(deleteQuestionAction)
+        .with(removeButton);
   }
 
   private ContainerTag questionBankPanel(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -10,6 +10,7 @@ import static j2html.TagCreator.text;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import com.typesafe.config.Config;
 import controllers.admin.routes;
 import forms.BlockForm;
 import j2html.TagCreator;
@@ -41,6 +42,7 @@ import views.style.Styles;
 public class ProgramBlockEditView extends BaseHtmlView {
 
   private final AdminLayout layout;
+  private final Config config;
 
   public static final String ENUMERATOR_ID_FORM_FIELD = "enumeratorId";
   private static final String CREATE_BLOCK_FORM_ID = "block-create-form";
@@ -48,8 +50,9 @@ public class ProgramBlockEditView extends BaseHtmlView {
   private static final String DELETE_BLOCK_FORM_ID = "block-delete-form";
 
   @Inject
-  public ProgramBlockEditView(AdminLayout layout) {
+  public ProgramBlockEditView(AdminLayout layout, Config config) {
     this.layout = checkNotNull(layout);
+    this.config = checkNotNull(config);
   }
 
   public Content render(
@@ -374,49 +377,55 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .with(p(questionDefinition.getName()))
             .with(p(questionDefinition.getDescription()).withClasses(Styles.MT_1, Styles.TEXT_SM));
 
-    ContainerTag optionalButton =
-        TagCreator.button()
-            .withClasses(
-                Styles.FLEX,
-                Styles.GAP_2,
-                Styles.ITEMS_CENTER,
-                isOptional ? Styles.TEXT_BLACK : Styles.TEXT_GRAY_400,
-                Styles.FONT_MEDIUM,
-                Styles.BG_TRANSPARENT,
-                Styles.ROUNDED_FULL,
-                StyleUtils.hover(Styles.BG_GRAY_400, Styles.TEXT_GRAY_300))
-            .withType("submit")
-            .with(p("optional").withClasses("hover-group:text-white"))
-            .with(
-                div()
-                    .withClasses(Styles.RELATIVE)
-                    .with(
-                        div()
-                            .withClasses(
-                                isOptional ? Styles.BG_BLUE_600 : Styles.BG_GRAY_600,
-                                Styles.W_14,
-                                Styles.H_8,
-                                Styles.ROUNDED_FULL))
-                    .with(
-                        div()
-                            .withClasses(
-                                Styles.ABSOLUTE,
-                                Styles.BG_WHITE,
-                                isOptional ? Styles.RIGHT_1 : Styles.LEFT_1,
-                                Styles.TOP_1,
-                                Styles.W_6,
-                                Styles.H_6,
-                                Styles.ROUNDED_FULL)));
-    String toggleOptionalAction =
-        controllers.admin.routes.AdminProgramBlockQuestionsController.setOptional(
-                programDefinitionId, blockDefinitionId, questionDefinition.getId())
-            .url();
-    ContainerTag optionalToggle =
-        form(csrfTag)
-            .withMethod(HttpVerbs.POST)
-            .withAction(toggleOptionalAction)
-            .with(input().isHidden().withName("optional").withValue(isOptional ? "false" : "true"))
-            .with(optionalButton);
+    Tag optionalToggle;
+    if (config.hasPath("cf.optional_questions")) {
+      ContainerTag optionalButton =
+          TagCreator.button()
+              .withClasses(
+                  Styles.FLEX,
+                  Styles.GAP_2,
+                  Styles.ITEMS_CENTER,
+                  isOptional ? Styles.TEXT_BLACK : Styles.TEXT_GRAY_400,
+                  Styles.FONT_MEDIUM,
+                  Styles.BG_TRANSPARENT,
+                  Styles.ROUNDED_FULL,
+                  StyleUtils.hover(Styles.BG_GRAY_400, Styles.TEXT_GRAY_300))
+              .withType("submit")
+              .with(p("optional").withClasses("hover-group:text-white"))
+              .with(
+                  div()
+                      .withClasses(Styles.RELATIVE)
+                      .with(
+                          div()
+                              .withClasses(
+                                  isOptional ? Styles.BG_BLUE_600 : Styles.BG_GRAY_600,
+                                  Styles.W_14,
+                                  Styles.H_8,
+                                  Styles.ROUNDED_FULL))
+                      .with(
+                          div()
+                              .withClasses(
+                                  Styles.ABSOLUTE,
+                                  Styles.BG_WHITE,
+                                  isOptional ? Styles.RIGHT_1 : Styles.LEFT_1,
+                                  Styles.TOP_1,
+                                  Styles.W_6,
+                                  Styles.H_6,
+                                  Styles.ROUNDED_FULL)));
+      String toggleOptionalAction =
+          controllers.admin.routes.AdminProgramBlockQuestionsController.setOptional(
+                  programDefinitionId, blockDefinitionId, questionDefinition.getId())
+              .url();
+      optionalToggle =
+          form(csrfTag)
+              .withMethod(HttpVerbs.POST)
+              .withAction(toggleOptionalAction)
+              .with(
+                  input().isHidden().withName("optional").withValue(isOptional ? "false" : "true"))
+              .with(optionalButton);
+    } else {
+      optionalToggle = div();
+    }
 
     Tag removeButton =
         TagCreator.button(text("DELETE"))

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -409,3 +409,6 @@ aws.ses.sender=${?AWS_SES_SENDER}
 aws.s3.bucket=civiform-local-s3
 aws.s3.bucket=${?AWS_S3_BUCKET_NAME}
 aws.local.endpoint="http://localstack:4566"
+
+## Feature flags
+cf.optional_questions = ${?CF_OPTIONAL_QUESTIONS}


### PR DESCRIPTION
### Description
Hide optional question toggle behind feature flag.

Feature is enabled by setting `CF_OPTIONAL_QUESTIONS` environment variable to any value.

turned on:
![turned on](https://user-images.githubusercontent.com/12072571/123046656-3530e100-d3b1-11eb-89e1-c99238ae047b.PNG)

turned off:
![turned off](https://user-images.githubusercontent.com/12072571/123046659-36620e00-d3b1-11eb-9fa5-39754c064389.PNG)
