### PR TITLE
Add program id to program question definition

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -219,8 +219,10 @@ public class DatabaseSeedController extends DevController {
           programId,
           blockId,
           ImmutableList.of(
-              ProgramQuestionDefinition.create(insertNameQuestionDefinition(), programId),
-              ProgramQuestionDefinition.create(insertColorQuestionDefinition(), programId)));
+              ProgramQuestionDefinition.create(
+                  insertNameQuestionDefinition(), Optional.of(programId)),
+              ProgramQuestionDefinition.create(
+                  insertColorQuestionDefinition(), Optional.of(programId))));
 
       blockId =
           programService.addBlockToProgram(programId).getResult().getLastBlockDefinition().id();

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -219,8 +219,8 @@ public class DatabaseSeedController extends DevController {
           programId,
           blockId,
           ImmutableList.of(
-              ProgramQuestionDefinition.create(insertNameQuestionDefinition()),
-              ProgramQuestionDefinition.create(insertColorQuestionDefinition())));
+              ProgramQuestionDefinition.create(insertNameQuestionDefinition(), programId),
+              ProgramQuestionDefinition.create(insertColorQuestionDefinition(), programId)));
 
       blockId =
           programService.addBlockToProgram(programId).getResult().getLastBlockDefinition().id();

--- a/universal-application-tool-0.0.1/app/repository/VersionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/VersionRepository.java
@@ -195,7 +195,7 @@ public class VersionRepository {
         draftProgram.getProgramDefinition().toBuilder().setBlockDefinitions(ImmutableList.of());
     for (BlockDefinition block : draftProgram.getProgramDefinition().blockDefinitions()) {
       LOG.trace("Updating block {}.", block.id());
-      updatedDefinition.addBlockDefinition(updateQuestionVersions(block));
+      updatedDefinition.addBlockDefinition(updateQuestionVersions(draftProgram.id, block));
     }
     draftProgram = new Program(updatedDefinition.build());
     LOG.trace("Submitting update.");
@@ -223,7 +223,7 @@ public class VersionRepository {
         .anyMatch(draftProgram -> draftProgram.id.equals(program.id));
   }
 
-  private BlockDefinition updateQuestionVersions(BlockDefinition block) {
+  private BlockDefinition updateQuestionVersions(long programDefinitionId, BlockDefinition block) {
     BlockDefinition.Builder updatedBlock =
         block.toBuilder().setProgramQuestionDefinitions(ImmutableList.of());
     // Update questions contained in this block.
@@ -232,7 +232,8 @@ public class VersionRepository {
       LOG.trace(
           "Updating question ID {} to new ID {}.", question.id(), updatedQuestion.orElseThrow().id);
       updatedBlock.addQuestion(
-          question.setQuestionDefinition(updatedQuestion.orElseThrow().getQuestionDefinition()));
+          question.loadCompletely(
+              programDefinitionId, updatedQuestion.orElseThrow().getQuestionDefinition()));
     }
     // Update questions referenced in this block's predicate(s)
     if (block.visibilityPredicate().isPresent()) {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -55,7 +55,7 @@ public class ApplicantQuestion {
       ApplicantData applicantData,
       Optional<RepeatedEntity> repeatedEntity) {
     this.programQuestionDefinition =
-        ProgramQuestionDefinition.create(checkNotNull(questionDefinition), 0L);
+        ProgramQuestionDefinition.create(checkNotNull(questionDefinition), Optional.empty());
     this.applicantData = checkNotNull(applicantData);
     this.repeatedEntity = checkNotNull(repeatedEntity);
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -36,25 +36,26 @@ public class ApplicantQuestion {
    * Optional.empty()} repeated entity.
    */
   public ApplicantQuestion(
-      QuestionDefinition questionDefinition,
+      ProgramQuestionDefinition programQuestionDefinition,
       ApplicantData applicantData,
       Optional<RepeatedEntity> repeatedEntity) {
-    this.programQuestionDefinition =
-        ProgramQuestionDefinition.create(checkNotNull(questionDefinition));
+    this.programQuestionDefinition = checkNotNull(programQuestionDefinition);
     this.applicantData = checkNotNull(applicantData);
     this.repeatedEntity = checkNotNull(repeatedEntity);
   }
 
   /**
-   * If this is a repeated question, it should be created with the repeated entity associated with
-   * this question. If this is not a repeated question, then it should be created with an {@code
-   * Optional.empty()} repeated entity.
+   * DEPRECATED.
+   *
+   * <p>This constructor is only used in tests, which should eventually be converted to use the
+   * constructor that uses {@link ProgramQuestionDefinition}.
    */
   public ApplicantQuestion(
-      ProgramQuestionDefinition programQuestionDefinition,
+      QuestionDefinition questionDefinition,
       ApplicantData applicantData,
       Optional<RepeatedEntity> repeatedEntity) {
-    this.programQuestionDefinition = checkNotNull(programQuestionDefinition);
+    this.programQuestionDefinition =
+        ProgramQuestionDefinition.create(checkNotNull(questionDefinition), 0L);
     this.applicantData = checkNotNull(applicantData);
     this.repeatedEntity = checkNotNull(repeatedEntity);
   }

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -264,7 +264,8 @@ public class ExporterService {
         }
         // Use a program question definition that doesn't have a program associated with it,
         // which is okay because this should be program agnostic.
-        ProgramQuestionDefinition pqd = ProgramQuestionDefinition.create(questionDefinition, 0L);
+        ProgramQuestionDefinition pqd =
+            ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
         PresentsErrors applicantQuestion =
             new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty()).errorsPresenter();
         for (Path path : applicantQuestion.getAllPaths()) {

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -32,6 +32,7 @@ import services.program.ColumnType;
 import services.program.CsvExportConfig;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
+import services.program.ProgramQuestionDefinition;
 import services.program.ProgramService;
 import services.question.QuestionService;
 import services.question.types.QuestionDefinition;
@@ -261,9 +262,11 @@ public class ExporterService {
         if (questionDefinition.isEnumerator()) {
           continue; // Do not include Enumerator answers in CSVs.
         }
+        // Use a program question definition that doesn't have a program associated with it,
+        // which is okay because this should be program agnostic.
+        ProgramQuestionDefinition pqd = ProgramQuestionDefinition.create(questionDefinition, 0L);
         PresentsErrors applicantQuestion =
-            new ApplicantQuestion(questionDefinition, new ApplicantData(), Optional.empty())
-                .errorsPresenter();
+            new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty()).errorsPresenter();
         for (Path path : applicantQuestion.getAllPaths()) {
           columnsBuilder.add(
               Column.builder()

--- a/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
@@ -19,6 +19,12 @@ public abstract class ProgramQuestionDefinition {
   public abstract long id();
 
   /**
+   * A reference to the program this is a question of. Program question definitions are not stored
+   * with this reference and this should be set upon load.
+   */
+  abstract long programDefinitionId();
+
+  /**
    * True if this program question definition is optional. Otherwise it is required.
    *
    * <p>This field was added in June 2021. Program question definitions created before this field
@@ -27,6 +33,11 @@ public abstract class ProgramQuestionDefinition {
   @JsonProperty("optional")
   public abstract boolean optional();
 
+  /**
+   * The actual question with same id as this program question definition. Program question
+   * definitions are not stored with this value, so it may not be present unless it is explicitly
+   * loaded in.
+   */
   abstract Optional<QuestionDefinition> questionDefinition();
 
   @JsonIgnore
@@ -42,29 +53,37 @@ public abstract class ProgramQuestionDefinition {
   @JsonCreator
   static ProgramQuestionDefinition create(
       @JsonProperty("id") long id, @JsonProperty("optional") boolean optional) {
-    return new AutoValue_ProgramQuestionDefinition(id, optional, Optional.empty());
+    return new AutoValue_ProgramQuestionDefinition(id, 0L, optional, Optional.empty());
   }
 
   /** Create a required program question definition. */
-  public static ProgramQuestionDefinition create(QuestionDefinition questionDefinition) {
-    return create(questionDefinition, false);
+  public static ProgramQuestionDefinition create(
+      QuestionDefinition questionDefinition, long programDefinitionId) {
+    return create(questionDefinition, programDefinitionId, false);
   }
 
   /** Create a program question definition. */
-  public static ProgramQuestionDefinition create(
-      QuestionDefinition questionDefinition, boolean optional) {
+  private static ProgramQuestionDefinition create(
+      QuestionDefinition questionDefinition, long programDefinitionId, boolean optional) {
     return new AutoValue_ProgramQuestionDefinition(
-        questionDefinition.getId(), optional, Optional.of(questionDefinition));
+        questionDefinition.getId(), programDefinitionId, optional, Optional.of(questionDefinition));
   }
 
-  /** Return a program question definition with the {@link QuestionDefinition} set. */
-  public ProgramQuestionDefinition setQuestionDefinition(QuestionDefinition questionDefinition) {
+  /**
+   * Return a program question definition that is completely loaded with a program definition id and
+   * {@link QuestionDefinition} set.
+   */
+  public ProgramQuestionDefinition loadCompletely(
+      long programDefinitionId, QuestionDefinition questionDefinition) {
     return new AutoValue_ProgramQuestionDefinition(
-        questionDefinition.getId(), optional(), Optional.of(questionDefinition));
+        questionDefinition.getId(),
+        programDefinitionId,
+        optional(),
+        Optional.of(questionDefinition));
   }
 
   /** Return a program question definition with a new optional setting. */
   public ProgramQuestionDefinition setOptional(boolean optional) {
-    return create(getQuestionDefinition(), optional);
+    return create(getQuestionDefinition(), programDefinitionId(), optional);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramQuestionDefinition.java
@@ -22,7 +22,7 @@ public abstract class ProgramQuestionDefinition {
    * A reference to the program this is a question of. Program question definitions are not stored
    * with this reference and this should be set upon load.
    */
-  abstract long programDefinitionId();
+  abstract Optional<Long> programDefinitionId();
 
   /**
    * True if this program question definition is optional. Otherwise it is required.
@@ -53,18 +53,19 @@ public abstract class ProgramQuestionDefinition {
   @JsonCreator
   static ProgramQuestionDefinition create(
       @JsonProperty("id") long id, @JsonProperty("optional") boolean optional) {
-    return new AutoValue_ProgramQuestionDefinition(id, 0L, optional, Optional.empty());
+    return new AutoValue_ProgramQuestionDefinition(
+        id, Optional.empty(), optional, Optional.empty());
   }
 
   /** Create a required program question definition. */
   public static ProgramQuestionDefinition create(
-      QuestionDefinition questionDefinition, long programDefinitionId) {
+      QuestionDefinition questionDefinition, Optional<Long> programDefinitionId) {
     return create(questionDefinition, programDefinitionId, false);
   }
 
   /** Create a program question definition. */
   private static ProgramQuestionDefinition create(
-      QuestionDefinition questionDefinition, long programDefinitionId, boolean optional) {
+      QuestionDefinition questionDefinition, Optional<Long> programDefinitionId, boolean optional) {
     return new AutoValue_ProgramQuestionDefinition(
         questionDefinition.getId(), programDefinitionId, optional, Optional.of(questionDefinition));
   }
@@ -77,7 +78,7 @@ public abstract class ProgramQuestionDefinition {
       long programDefinitionId, QuestionDefinition questionDefinition) {
     return new AutoValue_ProgramQuestionDefinition(
         questionDefinition.getId(),
-        programDefinitionId,
+        Optional.of(programDefinitionId),
         optional(),
         Optional.of(questionDefinition));
   }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -371,7 +371,7 @@ public class ProgramServiceImpl implements ProgramService {
     for (long qid : questionIds) {
       newQuestionListBuilder.add(
           ProgramQuestionDefinition.create(
-              roQuestionService.getQuestionDefinition(qid), programId));
+              roQuestionService.getQuestionDefinition(qid), Optional.of(programId)));
     }
 
     ImmutableList<ProgramQuestionDefinition> newProgramQuestionDefinitions =

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -370,7 +370,8 @@ public class ProgramServiceImpl implements ProgramService {
 
     for (long qid : questionIds) {
       newQuestionListBuilder.add(
-          ProgramQuestionDefinition.create(roQuestionService.getQuestionDefinition(qid)));
+          ProgramQuestionDefinition.create(
+              roQuestionService.getQuestionDefinition(qid), programId));
     }
 
     ImmutableList<ProgramQuestionDefinition> newProgramQuestionDefinitions =
@@ -619,7 +620,8 @@ public class ProgramServiceImpl implements ProgramService {
 
     ImmutableList.Builder<BlockDefinition> blockListBuilder = ImmutableList.builder();
     for (BlockDefinition block : programDefinition.blockDefinitions()) {
-      BlockDefinition syncedBlock = syncBlockDefinitionQuestions(block, roQuestionService);
+      BlockDefinition syncedBlock =
+          syncBlockDefinitionQuestions(programDefinition.id(), block, roQuestionService);
       blockListBuilder.add(syncedBlock);
     }
 
@@ -628,12 +630,15 @@ public class ProgramServiceImpl implements ProgramService {
   }
 
   private BlockDefinition syncBlockDefinitionQuestions(
-      BlockDefinition blockDefinition, ReadOnlyQuestionService roQuestionService) {
+      long programDefinitionId,
+      BlockDefinition blockDefinition,
+      ReadOnlyQuestionService roQuestionService) {
     BlockDefinition.Builder blockBuilder = blockDefinition.toBuilder();
 
     ImmutableList.Builder<ProgramQuestionDefinition> pqdListBuilder = ImmutableList.builder();
     for (ProgramQuestionDefinition pqd : blockDefinition.programQuestionDefinitions()) {
-      ProgramQuestionDefinition syncedPqd = syncProgramQuestionDefinition(pqd, roQuestionService);
+      ProgramQuestionDefinition syncedPqd =
+          syncProgramQuestionDefinition(programDefinitionId, pqd, roQuestionService);
       pqdListBuilder.add(syncedPqd);
     }
 
@@ -642,10 +647,12 @@ public class ProgramServiceImpl implements ProgramService {
   }
 
   private ProgramQuestionDefinition syncProgramQuestionDefinition(
-      ProgramQuestionDefinition pqd, ReadOnlyQuestionService roQuestionService) {
+      long programDefinitionId,
+      ProgramQuestionDefinition pqd,
+      ReadOnlyQuestionService roQuestionService) {
     try {
       QuestionDefinition questionDefinition = roQuestionService.getQuestionDefinition(pqd.id());
-      return pqd.setQuestionDefinition(questionDefinition);
+      return pqd.loadCompletely(programDefinitionId, questionDefinition);
     } catch (QuestionNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.program.ProgramQuestionDefinition;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
@@ -17,8 +18,9 @@ public class ApplicantQuestionRendererFactory {
   public ApplicantQuestionRenderer getSampleRenderer(QuestionType questionType)
       throws UnsupportedQuestionTypeException {
     QuestionDefinition questionDefinition = questionDefinitionSample(questionType);
+    ProgramQuestionDefinition pqd = ProgramQuestionDefinition.create(questionDefinition, 0L);
     ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(questionDefinition, new ApplicantData(), Optional.empty());
+        new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty());
     return getRenderer(applicantQuestion);
   }
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -18,7 +18,8 @@ public class ApplicantQuestionRendererFactory {
   public ApplicantQuestionRenderer getSampleRenderer(QuestionType questionType)
       throws UnsupportedQuestionTypeException {
     QuestionDefinition questionDefinition = questionDefinitionSample(questionType);
-    ProgramQuestionDefinition pqd = ProgramQuestionDefinition.create(questionDefinition, 0L);
+    ProgramQuestionDefinition pqd =
+        ProgramQuestionDefinition.create(questionDefinition, Optional.empty());
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(pqd, new ApplicantData(), Optional.empty());
     return getRenderer(applicantQuestion);

--- a/universal-application-tool-0.0.1/test/models/ProgramTest.java
+++ b/universal-application-tool-0.0.1/test/models/ProgramTest.java
@@ -54,7 +54,8 @@ public class ProgramTest extends WithPostgresContainer {
             .setDescription("basic info")
             .setProgramQuestionDefinitions(
                 ImmutableList.of(
-                    ProgramQuestionDefinition.create(questionDefinition, programDefinitionId)))
+                    ProgramQuestionDefinition.create(
+                        questionDefinition, Optional.of(programDefinitionId))))
             .build();
 
     ProgramDefinition definition =
@@ -120,8 +121,9 @@ public class ProgramTest extends WithPostgresContainer {
             .setProgramQuestionDefinitions(
                 ImmutableList.of(
                     ProgramQuestionDefinition.create(
-                        addressQuestionDefinition, programDefinitionId),
-                    ProgramQuestionDefinition.create(nameQuestionDefinition, programDefinitionId)))
+                        addressQuestionDefinition, Optional.of(programDefinitionId)),
+                    ProgramQuestionDefinition.create(
+                        nameQuestionDefinition, Optional.of(programDefinitionId))))
             .build();
 
     ProgramDefinition definition =
@@ -199,7 +201,7 @@ public class ProgramTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
-                            programDefinitionId))
+                            Optional.of(programDefinitionId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -209,7 +211,7 @@ public class ProgramTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantEmail().getQuestionDefinition(),
-                            programDefinitionId))
+                            Optional.of(programDefinitionId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -220,7 +222,7 @@ public class ProgramTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
-                            programDefinitionId))
+                            Optional.of(programDefinitionId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -231,7 +233,7 @@ public class ProgramTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition(),
-                            programDefinitionId))
+                            Optional.of(programDefinitionId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -244,7 +246,7 @@ public class ProgramTest extends WithPostgresContainer {
                             testQuestionBank
                                 .applicantHouseholdMemberJobIncome()
                                 .getQuestionDefinition(),
-                            programDefinitionId))
+                            Optional.of(programDefinitionId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -254,7 +256,7 @@ public class ProgramTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantName().getQuestionDefinition(),
-                            programDefinitionId))
+                            Optional.of(programDefinitionId)))
                     .build())
             .build();
 

--- a/universal-application-tool-0.0.1/test/models/ProgramTest.java
+++ b/universal-application-tool-0.0.1/test/models/ProgramTest.java
@@ -46,19 +46,20 @@ public class ProgramTest extends WithPostgresContainer {
             .setDescription("applicant's name")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
             .build();
-
+    long programDefinitionId = 1L;
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
             .setId(1L)
             .setName("First Block")
             .setDescription("basic info")
             .setProgramQuestionDefinitions(
-                ImmutableList.of(ProgramQuestionDefinition.create(questionDefinition)))
+                ImmutableList.of(
+                    ProgramQuestionDefinition.create(questionDefinition, programDefinitionId)))
             .build();
 
     ProgramDefinition definition =
         ProgramDefinition.builder()
-            .setId(1L)
+            .setId(programDefinitionId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(LocalizedStrings.of(Locale.US, "ProgramTest"))
@@ -110,6 +111,7 @@ public class ProgramTest extends WithPostgresContainer {
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
                 .build();
 
+    long programDefinitionId = 1L;
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
             .setId(1L)
@@ -117,13 +119,14 @@ public class ProgramTest extends WithPostgresContainer {
             .setDescription("basic info")
             .setProgramQuestionDefinitions(
                 ImmutableList.of(
-                    ProgramQuestionDefinition.create(addressQuestionDefinition),
-                    ProgramQuestionDefinition.create(nameQuestionDefinition)))
+                    ProgramQuestionDefinition.create(
+                        addressQuestionDefinition, programDefinitionId),
+                    ProgramQuestionDefinition.create(nameQuestionDefinition, programDefinitionId)))
             .build();
 
     ProgramDefinition definition =
         ProgramDefinition.builder()
-            .setId(1L)
+            .setId(programDefinitionId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(LocalizedStrings.of(Locale.US, "ProgramTest"))
@@ -185,6 +188,7 @@ public class ProgramTest extends WithPostgresContainer {
 
   @Test
   public void unorderedBlockDefinitions_getOrderedBlockDefinitionsOnSave() {
+    long programDefinitionId = 45832L;
     ImmutableList<BlockDefinition> unorderedBlocks =
         ImmutableList.<BlockDefinition>builder()
             .add(
@@ -194,7 +198,8 @@ public class ProgramTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
+                            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                            programDefinitionId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -203,7 +208,8 @@ public class ProgramTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantEmail().getQuestionDefinition()))
+                            testQuestionBank.applicantEmail().getQuestionDefinition(),
+                            programDefinitionId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -213,9 +219,8 @@ public class ProgramTest extends WithPostgresContainer {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank
-                                .applicantHouseholdMemberJobs()
-                                .getQuestionDefinition()))
+                            testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                            programDefinitionId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -225,9 +230,8 @@ public class ProgramTest extends WithPostgresContainer {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank
-                                .applicantHouseholdMemberName()
-                                .getQuestionDefinition()))
+                            testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition(),
+                            programDefinitionId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -239,7 +243,8 @@ public class ProgramTest extends WithPostgresContainer {
                         ProgramQuestionDefinition.create(
                             testQuestionBank
                                 .applicantHouseholdMemberJobIncome()
-                                .getQuestionDefinition()))
+                                .getQuestionDefinition(),
+                            programDefinitionId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -248,13 +253,14 @@ public class ProgramTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantName().getQuestionDefinition()))
+                            testQuestionBank.applicantName().getQuestionDefinition(),
+                            programDefinitionId))
                     .build())
             .build();
 
     ProgramDefinition programDefinition =
         ProgramDefinition.builder()
-            .setId(45832L)
+            .setId(programDefinitionId)
             .setAdminName("test program")
             .setAdminDescription("test description")
             .setExternalLink("")

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -49,6 +49,7 @@ public class BlockTest {
     QuestionDefinition question = NAME_QUESTION;
     ApplicantData applicant = new ApplicantData();
     applicant.putString(Path.create("applicant.hello"), "world");
+    long programDefinitionId = 1L;
 
     new EqualsTester()
         .addEqualityGroup(
@@ -61,14 +62,14 @@ public class BlockTest {
             new Block(
                 "1",
                 definition.toBuilder()
-                    .addQuestion(ProgramQuestionDefinition.create(question))
+                    .addQuestion(ProgramQuestionDefinition.create(question, programDefinitionId))
                     .build(),
                 new ApplicantData(),
                 Optional.empty()),
             new Block(
                 "1",
                 definition.toBuilder()
-                    .addQuestion(ProgramQuestionDefinition.create(question))
+                    .addQuestion(ProgramQuestionDefinition.create(question, programDefinitionId))
                     .build(),
                 new ApplicantData(),
                 Optional.empty()))
@@ -296,7 +297,7 @@ public class BlockTest {
             .setDescription("")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
+                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(), 1L))
             .build();
 
     Block block = new Block("1", definition, applicantData, Optional.empty());
@@ -324,7 +325,7 @@ public class BlockTest {
             .setId(1L)
             .setName("")
             .setDescription("")
-            .addQuestion(ProgramQuestionDefinition.create(enumeratorQuestionDefinition))
+            .addQuestion(ProgramQuestionDefinition.create(enumeratorQuestionDefinition, 1L))
             .build();
     Block block = new Block("1", definition, applicantData, Optional.empty());
 
@@ -343,7 +344,7 @@ public class BlockTest {
             .setDescription("")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFile().getQuestionDefinition()))
+                    testQuestionBank.applicantFile().getQuestionDefinition(), 1L))
             .build();
 
     Block block = new Block("1", definition, applicantData, Optional.empty());
@@ -366,8 +367,8 @@ public class BlockTest {
         .setId(20L)
         .setName("")
         .setDescription("")
-        .addQuestion(ProgramQuestionDefinition.create(NAME_QUESTION))
-        .addQuestion(ProgramQuestionDefinition.create(COLOR_QUESTION))
+        .addQuestion(ProgramQuestionDefinition.create(NAME_QUESTION, 1L))
+        .addQuestion(ProgramQuestionDefinition.create(COLOR_QUESTION, 1L))
         .build();
   }
 

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -62,14 +62,18 @@ public class BlockTest {
             new Block(
                 "1",
                 definition.toBuilder()
-                    .addQuestion(ProgramQuestionDefinition.create(question, programDefinitionId))
+                    .addQuestion(
+                        ProgramQuestionDefinition.create(
+                            question, Optional.of(programDefinitionId)))
                     .build(),
                 new ApplicantData(),
                 Optional.empty()),
             new Block(
                 "1",
                 definition.toBuilder()
-                    .addQuestion(ProgramQuestionDefinition.create(question, programDefinitionId))
+                    .addQuestion(
+                        ProgramQuestionDefinition.create(
+                            question, Optional.of(programDefinitionId)))
                     .build(),
                 new ApplicantData(),
                 Optional.empty()))
@@ -297,7 +301,8 @@ public class BlockTest {
             .setDescription("")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(), 1L))
+                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                    Optional.empty()))
             .build();
 
     Block block = new Block("1", definition, applicantData, Optional.empty());
@@ -325,7 +330,8 @@ public class BlockTest {
             .setId(1L)
             .setName("")
             .setDescription("")
-            .addQuestion(ProgramQuestionDefinition.create(enumeratorQuestionDefinition, 1L))
+            .addQuestion(
+                ProgramQuestionDefinition.create(enumeratorQuestionDefinition, Optional.empty()))
             .build();
     Block block = new Block("1", definition, applicantData, Optional.empty());
 
@@ -344,7 +350,7 @@ public class BlockTest {
             .setDescription("")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFile().getQuestionDefinition(), 1L))
+                    testQuestionBank.applicantFile().getQuestionDefinition(), Optional.empty()))
             .build();
 
     Block block = new Block("1", definition, applicantData, Optional.empty());
@@ -367,8 +373,8 @@ public class BlockTest {
         .setId(20L)
         .setName("")
         .setDescription("")
-        .addQuestion(ProgramQuestionDefinition.create(NAME_QUESTION, 1L))
-        .addQuestion(ProgramQuestionDefinition.create(COLOR_QUESTION, 1L))
+        .addQuestion(ProgramQuestionDefinition.create(NAME_QUESTION, Optional.empty()))
+        .addQuestion(ProgramQuestionDefinition.create(COLOR_QUESTION, Optional.empty()))
         .build();
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -53,7 +53,8 @@ public class BlockDefinitionTest {
             .setDescription("Block Description")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(), 0L))
+                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                    Optional.empty()))
             .build();
 
     assertThat(blockDefinition.isEnumerator()).isTrue();
@@ -76,7 +77,7 @@ public class BlockDefinitionTest {
             .setDescription("Block Description")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFile().getQuestionDefinition(), 0L))
+                    testQuestionBank.applicantFile().getQuestionDefinition(), Optional.empty()))
             .build();
 
     assertThat(blockDefinition.isFileUpload()).isTrue();
@@ -94,9 +95,9 @@ public class BlockDefinitionTest {
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(nameQuestion, 0L))
-            .addQuestion(ProgramQuestionDefinition.create(addressQuestion, 0L))
-            .addQuestion(ProgramQuestionDefinition.create(colorQuestion, 0L))
+            .addQuestion(ProgramQuestionDefinition.create(nameQuestion, Optional.empty()))
+            .addQuestion(ProgramQuestionDefinition.create(addressQuestion, Optional.empty()))
+            .addQuestion(ProgramQuestionDefinition.create(colorQuestion, Optional.empty()))
             .build();
     return block;
   }

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -53,7 +53,7 @@ public class BlockDefinitionTest {
             .setDescription("Block Description")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
+                    testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(), 0L))
             .build();
 
     assertThat(blockDefinition.isEnumerator()).isTrue();
@@ -76,7 +76,7 @@ public class BlockDefinitionTest {
             .setDescription("Block Description")
             .addQuestion(
                 ProgramQuestionDefinition.create(
-                    testQuestionBank.applicantFile().getQuestionDefinition()))
+                    testQuestionBank.applicantFile().getQuestionDefinition(), 0L))
             .build();
 
     assertThat(blockDefinition.isFileUpload()).isTrue();
@@ -94,9 +94,9 @@ public class BlockDefinitionTest {
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(nameQuestion))
-            .addQuestion(ProgramQuestionDefinition.create(addressQuestion))
-            .addQuestion(ProgramQuestionDefinition.create(colorQuestion))
+            .addQuestion(ProgramQuestionDefinition.create(nameQuestion, 0L))
+            .addQuestion(ProgramQuestionDefinition.create(addressQuestion, 0L))
+            .addQuestion(ProgramQuestionDefinition.create(colorQuestion, 0L))
             .build();
     return block;
   }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -89,12 +89,13 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
     QuestionDefinition questionC =
         testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
 
+    long programDefinitionId = 123L;
     BlockDefinition blockA =
         BlockDefinition.builder()
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA))
+            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
             .build();
 
     BlockDefinition blockB =
@@ -102,12 +103,12 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(321L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB))
+            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
             .build();
 
     ProgramDefinition program =
         ProgramDefinition.builder()
-            .setId(123L)
+            .setId(programDefinitionId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
@@ -200,24 +201,25 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
     QuestionDefinition questionC =
         testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
 
+    long programDefinitionId = 123L;
     BlockDefinition blockA =
         BlockDefinition.builder()
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA))
+            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
             .build();
     BlockDefinition blockB =
         BlockDefinition.builder()
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB))
-            .addQuestion(ProgramQuestionDefinition.create(questionC))
+            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
+            .addQuestion(ProgramQuestionDefinition.create(questionC, programDefinitionId))
             .build();
     ProgramDefinition definition =
         ProgramDefinition.builder()
-            .setId(123L)
+            .setId(programDefinitionId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(
@@ -242,31 +244,32 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
         testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
     QuestionDefinition questionD = testQuestionBank.applicantSeason().getQuestionDefinition();
 
+    long programDefinitionId = 123L;
     BlockDefinition blockA =
         BlockDefinition.builder()
             .setId(1L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA))
+            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
             .build();
     BlockDefinition blockB =
         BlockDefinition.builder()
             .setId(2L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB))
-            .addQuestion(ProgramQuestionDefinition.create(questionC))
+            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
+            .addQuestion(ProgramQuestionDefinition.create(questionC, programDefinitionId))
             .build();
     BlockDefinition blockC =
         BlockDefinition.builder()
             .setId(3L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionD))
+            .addQuestion(ProgramQuestionDefinition.create(questionD, programDefinitionId))
             .build();
     ProgramDefinition programDefinition =
         ProgramDefinition.builder()
-            .setId(123L)
+            .setId(programDefinitionId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(
@@ -304,26 +307,27 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
     QuestionDefinition questionE =
         testQuestionBank.applicantHouseholdMemberJobIncome().getQuestionDefinition();
 
+    long programDefinitionId = 123L;
     BlockDefinition blockA =
         BlockDefinition.builder()
             .setId(1L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA))
+            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
             .build();
     BlockDefinition blockB =
         BlockDefinition.builder()
             .setId(2L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB))
+            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
             .build();
     BlockDefinition blockC =
         BlockDefinition.builder()
             .setId(3L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionC))
+            .addQuestion(ProgramQuestionDefinition.create(questionC, programDefinitionId))
             .setEnumeratorId(Optional.of(2L))
             .build();
     BlockDefinition blockD =
@@ -331,7 +335,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(4L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionD))
+            .addQuestion(ProgramQuestionDefinition.create(questionD, programDefinitionId))
             .setEnumeratorId(Optional.of(2L))
             .build();
     BlockDefinition blockE =
@@ -339,12 +343,12 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(5L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionE))
+            .addQuestion(ProgramQuestionDefinition.create(questionE, programDefinitionId))
             .setEnumeratorId(Optional.of(4L))
             .build();
     ProgramDefinition programDefinition =
         ProgramDefinition.builder()
-            .setId(123L)
+            .setId(programDefinitionId)
             .setAdminName("Admin name")
             .setAdminDescription("Admin description")
             .setLocalizedName(

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -95,7 +95,8 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionA, Optional.of(programDefinitionId)))
             .build();
 
     BlockDefinition blockB =
@@ -103,7 +104,8 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(321L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionB, Optional.of(programDefinitionId)))
             .build();
 
     ProgramDefinition program =
@@ -207,15 +209,18 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionA, Optional.of(programDefinitionId)))
             .build();
     BlockDefinition blockB =
         BlockDefinition.builder()
             .setId(123L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
-            .addQuestion(ProgramQuestionDefinition.create(questionC, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionB, Optional.of(programDefinitionId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionC, Optional.of(programDefinitionId)))
             .build();
     ProgramDefinition definition =
         ProgramDefinition.builder()
@@ -250,22 +255,26 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(1L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionA, Optional.of(programDefinitionId)))
             .build();
     BlockDefinition blockB =
         BlockDefinition.builder()
             .setId(2L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
-            .addQuestion(ProgramQuestionDefinition.create(questionC, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionB, Optional.of(programDefinitionId)))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionC, Optional.of(programDefinitionId)))
             .build();
     BlockDefinition blockC =
         BlockDefinition.builder()
             .setId(3L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionD, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionD, Optional.of(programDefinitionId)))
             .build();
     ProgramDefinition programDefinition =
         ProgramDefinition.builder()
@@ -313,21 +322,24 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(1L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionA, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionA, Optional.of(programDefinitionId)))
             .build();
     BlockDefinition blockB =
         BlockDefinition.builder()
             .setId(2L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionB, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionB, Optional.of(programDefinitionId)))
             .build();
     BlockDefinition blockC =
         BlockDefinition.builder()
             .setId(3L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionC, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionC, Optional.of(programDefinitionId)))
             .setEnumeratorId(Optional.of(2L))
             .build();
     BlockDefinition blockD =
@@ -335,7 +347,8 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(4L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionD, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionD, Optional.of(programDefinitionId)))
             .setEnumeratorId(Optional.of(2L))
             .build();
     BlockDefinition blockE =
@@ -343,7 +356,8 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setId(5L)
             .setName("Block Name")
             .setDescription("Block Description")
-            .addQuestion(ProgramQuestionDefinition.create(questionE, programDefinitionId))
+            .addQuestion(
+                ProgramQuestionDefinition.create(questionE, Optional.of(programDefinitionId)))
             .setEnumeratorId(Optional.of(4L))
             .build();
     ProgramDefinition programDefinition =

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -464,7 +464,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     Long programId = programDefinition.id();
 
     ps.setBlockQuestions(
-        programId, 1L, ImmutableList.of(ProgramQuestionDefinition.create(question)));
+        programId, 1L, ImmutableList.of(ProgramQuestionDefinition.create(question, programId)));
     ProgramDefinition found = ps.getProgramDefinition(programId);
 
     assertThat(found.blockDefinitions()).hasSize(1);
@@ -498,7 +498,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     ProgramDefinition found =
         ps.setBlockQuestions(
-            programId, 1L, ImmutableList.of(ProgramQuestionDefinition.create(question)));
+            programId, 1L, ImmutableList.of(ProgramQuestionDefinition.create(question, programId)));
     QuestionDefinition foundQuestion =
         found.blockDefinitions().get(0).programQuestionDefinitions().get(0).getQuestionDefinition();
     assertThat(foundQuestion).isInstanceOf(NameQuestionDefinition.class);
@@ -528,7 +528,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                 ps.setBlockQuestions(
                     program.id(),
                     1L,
-                    ImmutableList.of(ProgramQuestionDefinition.create(addressQuestion))))
+                    ImmutableList.of(
+                        ProgramQuestionDefinition.create(addressQuestion, program.id()))))
         .withMessage("This action would invalidate a block condition");
   }
 
@@ -957,7 +958,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition()))
+                            testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                            programId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -966,7 +968,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantEmail().getQuestionDefinition()))
+                            testQuestionBank.applicantEmail().getQuestionDefinition(), programId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -976,9 +978,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank
-                                .applicantHouseholdMemberJobs()
-                                .getQuestionDefinition()))
+                            testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                            programId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -988,9 +989,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setEnumeratorId(Optional.of(1L))
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank
-                                .applicantHouseholdMemberName()
-                                .getQuestionDefinition()))
+                            testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition(),
+                            programId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -1002,7 +1002,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                         ProgramQuestionDefinition.create(
                             testQuestionBank
                                 .applicantHouseholdMemberJobIncome()
-                                .getQuestionDefinition()))
+                                .getQuestionDefinition(),
+                            programId))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -1011,7 +1012,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantName().getQuestionDefinition()))
+                            testQuestionBank.applicantName().getQuestionDefinition(), programId))
                     .build())
             .build();
     ObjectMapper mapper =

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -464,7 +464,9 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     Long programId = programDefinition.id();
 
     ps.setBlockQuestions(
-        programId, 1L, ImmutableList.of(ProgramQuestionDefinition.create(question, programId)));
+        programId,
+        1L,
+        ImmutableList.of(ProgramQuestionDefinition.create(question, Optional.of(programId))));
     ProgramDefinition found = ps.getProgramDefinition(programId);
 
     assertThat(found.blockDefinitions()).hasSize(1);
@@ -498,7 +500,9 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     ProgramDefinition found =
         ps.setBlockQuestions(
-            programId, 1L, ImmutableList.of(ProgramQuestionDefinition.create(question, programId)));
+            programId,
+            1L,
+            ImmutableList.of(ProgramQuestionDefinition.create(question, Optional.of(programId))));
     QuestionDefinition foundQuestion =
         found.blockDefinitions().get(0).programQuestionDefinitions().get(0).getQuestionDefinition();
     assertThat(foundQuestion).isInstanceOf(NameQuestionDefinition.class);
@@ -529,7 +533,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     program.id(),
                     1L,
                     ImmutableList.of(
-                        ProgramQuestionDefinition.create(addressQuestion, program.id()))))
+                        ProgramQuestionDefinition.create(
+                            addressQuestion, Optional.of(program.id())))))
         .withMessage("This action would invalidate a block condition");
   }
 
@@ -959,7 +964,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
-                            programId))
+                            Optional.of(programId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -968,7 +973,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantEmail().getQuestionDefinition(), programId))
+                            testQuestionBank.applicantEmail().getQuestionDefinition(),
+                            Optional.of(programId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -979,7 +985,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
-                            programId))
+                            Optional.of(programId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -990,7 +996,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .addQuestion(
                         ProgramQuestionDefinition.create(
                             testQuestionBank.applicantHouseholdMemberName().getQuestionDefinition(),
-                            programId))
+                            Optional.of(programId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -1003,7 +1009,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                             testQuestionBank
                                 .applicantHouseholdMemberJobIncome()
                                 .getQuestionDefinition(),
-                            programId))
+                            Optional.of(programId)))
                     .build())
             .add(
                 BlockDefinition.builder()
@@ -1012,7 +1018,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     .setDescription("description")
                     .addQuestion(
                         ProgramQuestionDefinition.create(
-                            testQuestionBank.applicantName().getQuestionDefinition(), programId))
+                            testQuestionBank.applicantName().getQuestionDefinition(),
+                            Optional.of(programId)))
                     .build())
             .build();
     ObjectMapper mapper =

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -205,13 +205,14 @@ public class ProgramBuilder {
     public BlockBuilder withQuestion(Question question) {
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
-              question.getQuestionDefinition(), programBuilder.programDefinitionId));
+              question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId)));
       return this;
     }
 
     public BlockBuilder withQuestionDefinition(QuestionDefinition question) {
       blockDefBuilder.addQuestion(
-          ProgramQuestionDefinition.create(question, programBuilder.programDefinitionId));
+          ProgramQuestionDefinition.create(
+              question, Optional.of(programBuilder.programDefinitionId)));
       return this;
     }
 
@@ -226,7 +227,7 @@ public class ProgramBuilder {
               .map(
                   questionDefinition ->
                       ProgramQuestionDefinition.create(
-                          questionDefinition, programBuilder.programDefinitionId))
+                          questionDefinition, Optional.of(programBuilder.programDefinitionId)))
               .collect(ImmutableList.toImmutableList());
       blockDefBuilder.setProgramQuestionDefinitions(pqds);
       return this;
@@ -238,7 +239,7 @@ public class ProgramBuilder {
               .map(
                   questionDefinition ->
                       ProgramQuestionDefinition.create(
-                          questionDefinition, programBuilder.programDefinitionId))
+                          questionDefinition, Optional.of(programBuilder.programDefinitionId)))
               .collect(ImmutableList.toImmutableList());
       blockDefBuilder.setProgramQuestionDefinitions(pqds);
       return this;

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -27,10 +27,12 @@ public class ProgramBuilder {
 
   private static Injector injector;
 
+  long programDefinitionId;
   ProgramDefinition.Builder builder;
   AtomicInteger numBlocks = new AtomicInteger(0);
 
-  private ProgramBuilder(ProgramDefinition.Builder builder) {
+  private ProgramBuilder(long programDefinitionId, ProgramDefinition.Builder builder) {
+    this.programDefinitionId = programDefinitionId;
     this.builder = builder;
   }
 
@@ -64,7 +66,7 @@ public class ProgramBuilder {
         program.getProgramDefinition().toBuilder()
             .setBlockDefinitions(ImmutableList.of())
             .setExportDefinitions(ImmutableList.of());
-    return new ProgramBuilder(builder);
+    return new ProgramBuilder(program.id, builder);
   }
 
   /**
@@ -93,7 +95,7 @@ public class ProgramBuilder {
         program.getProgramDefinition().toBuilder()
             .setBlockDefinitions(ImmutableList.of())
             .setExportDefinitions(ImmutableList.of());
-    return new ProgramBuilder(builder);
+    return new ProgramBuilder(program.id, builder);
   }
 
   public ProgramBuilder withName(String name) {
@@ -202,12 +204,14 @@ public class ProgramBuilder {
 
     public BlockBuilder withQuestion(Question question) {
       blockDefBuilder.addQuestion(
-          ProgramQuestionDefinition.create(question.getQuestionDefinition()));
+          ProgramQuestionDefinition.create(
+              question.getQuestionDefinition(), programBuilder.programDefinitionId));
       return this;
     }
 
     public BlockBuilder withQuestionDefinition(QuestionDefinition question) {
-      blockDefBuilder.addQuestion(ProgramQuestionDefinition.create(question));
+      blockDefBuilder.addQuestion(
+          ProgramQuestionDefinition.create(question, programBuilder.programDefinitionId));
       return this;
     }
 
@@ -219,7 +223,10 @@ public class ProgramBuilder {
       ImmutableList<ProgramQuestionDefinition> pqds =
           questions.stream()
               .map(Question::getQuestionDefinition)
-              .map(ProgramQuestionDefinition::create)
+              .map(
+                  questionDefinition ->
+                      ProgramQuestionDefinition.create(
+                          questionDefinition, programBuilder.programDefinitionId))
               .collect(ImmutableList.toImmutableList());
       blockDefBuilder.setProgramQuestionDefinitions(pqds);
       return this;
@@ -228,7 +235,10 @@ public class ProgramBuilder {
     public BlockBuilder withQuestionDefinitions(ImmutableList<QuestionDefinition> questions) {
       ImmutableList<ProgramQuestionDefinition> pqds =
           questions.stream()
-              .map(ProgramQuestionDefinition::create)
+              .map(
+                  questionDefinition ->
+                      ProgramQuestionDefinition.create(
+                          questionDefinition, programBuilder.programDefinitionId))
               .collect(ImmutableList.toImmutableList());
       blockDefBuilder.setProgramQuestionDefinitions(pqds);
       return this;


### PR DESCRIPTION
Larger than I had hoped... but this gets a `program id` reference into a `ProgramQuestionDefinition`. The main change is `ProgramQuestionDefinition#setQuestionDefinition` turned into `ProgramQuestionDefinition#loadCompletely`.

Most other changes change how objects are constructed in tests.


### Issue(s)
Progress towards #1417 