### PR TITLE
Record and show uploaded filename

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
@@ -85,11 +85,18 @@ public class FileUploadQuestion implements PresentsErrors {
     return applicantQuestion.getContextualizedPath().join(Scalar.FILE_KEY);
   }
 
+  public Optional<String> getFilename() {
+    if (!isAnswered() || getFileKeyValue().isEmpty()) {
+      return Optional.empty();
+    }
+    return getFileKeyValue().map(key -> key.split("/")).map(arr -> arr[arr.length - 1]);
+  }
+
   @Override
   public String getAnswerString() {
-    if (!isAnswered() || getFileKeyValue().isEmpty()) {
+    if (getFilename().isEmpty()) {
       return "-- NO FILE SELECTED --";
     }
-    return "-- FILE UPLOADED (click to download) --";
+    return String.format("-- %s UPLOADED (click to download) --", getFilename().get());
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
@@ -89,7 +89,7 @@ public class FileUploadQuestion implements PresentsErrors {
     if (!isAnswered() || getFileKeyValue().isEmpty()) {
       return Optional.empty();
     }
-    return getFileKeyValue().map(key -> key.split("/")).map(arr -> arr[arr.length - 1]);
+    return getFileKeyValue().map(key -> key.split("/", 4)).map(arr -> arr[arr.length - 1]);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -131,7 +131,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
     // cautious if you want to change the format.
     String key =
         String.format(
-            "applicant-%d/program-%d/block-%s",
+            "applicant-%d/program-%d/block-%s/${filename}",
             params.applicantId(), params.programId(), params.block().getId());
     String onSuccessRedirectUrl =
         params.baseUrl()

--- a/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -16,6 +16,7 @@ import views.style.ReferenceClasses;
 import views.style.Styles;
 
 public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
+  private static final String IMAGES_AND_PDF = "image/*,.pdf";
 
   private final FileUploadQuestion fileuploadQuestion;
 
@@ -43,7 +44,7 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
 
   private ContainerTag fileUploadFieldsPreview() {
     return div()
-        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, acceptFileType()));
+        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, acceptFileTypes()));
   }
 
   private ContainerTag signedFileUploadFields(ApplicantQuestionRendererParams params) {
@@ -76,12 +77,12 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
         .with(input().withType("hidden").withName("X-Amz-Date").withValue(request.date()))
         .with(input().withType("hidden").withName("Policy").withValue(request.policy()))
         .with(input().withType("hidden").withName("X-Amz-Signature").withValue(request.signature()))
-        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, acceptFileType()))
+        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, acceptFileTypes()))
         .with(errorDiv(params.messages()));
   }
 
-  private String acceptFileType() {
-    return "image/*,.pdf";
+  private String acceptFileTypes() {
+    return IMAGES_AND_PDF;
   }
 
   private ContainerTag errorDiv(Messages messages) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.input;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Optional;
 import play.i18n.Messages;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.FileUploadQuestion;
@@ -16,8 +17,11 @@ import views.style.Styles;
 
 public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
 
+  private final FileUploadQuestion fileuploadQuestion;
+
   public FileUploadQuestionRenderer(ApplicantQuestion question) {
     super(question);
+    this.fileuploadQuestion = question.createFileUploadQuestion();
   }
 
   @Override
@@ -38,13 +42,17 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   private ContainerTag fileUploadFieldsPreview() {
-    return div().with(input().withType("file").withName("file"));
+    return div()
+        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, acceptFileType()));
   }
 
   private ContainerTag signedFileUploadFields(ApplicantQuestionRendererParams params) {
     SignedS3UploadRequest request = params.signedFileUploadRequest().get();
+    Optional<String> uploaded =
+        fileuploadQuestion.getFilename().map(f -> String.format("File uploaded: %s", f));
     ContainerTag fieldsTag =
         div()
+            .with(div().withText(uploaded.orElse("")))
             .with(input().withType("hidden").withName("key").withValue(request.key()))
             .with(
                 input()
@@ -68,12 +76,15 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
         .with(input().withType("hidden").withName("X-Amz-Date").withValue(request.date()))
         .with(input().withType("hidden").withName("Policy").withValue(request.policy()))
         .with(input().withType("hidden").withName("X-Amz-Signature").withValue(request.signature()))
-        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, "image/*,.pdf"))
+        .with(input().withType("file").withName("file").attr(Attr.ACCEPT, acceptFileType()))
         .with(errorDiv(params.messages()));
   }
 
+  private String acceptFileType() {
+    return "image/*,.pdf";
+  }
+
   private ContainerTag errorDiv(Messages messages) {
-    FileUploadQuestion fileuploadQuestion = question.createFileUploadQuestion();
     return div(fileuploadQuestion.fileRequiredMessage().getMessage(messages))
         .withClasses(
             ReferenceClasses.FILEUPLOAD_ERROR, BaseStyles.FORM_ERROR_TEXT_BASE, Styles.HIDDEN);

--- a/universal-application-tool-0.0.1/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/FileUploadQuestionTest.java
@@ -59,4 +59,53 @@ public class FileUploadQuestionTest {
     assertThat(fileUploadQuestion.hasTypeSpecificErrors()).isFalse();
     assertThat(fileUploadQuestion.hasQuestionErrors()).isFalse();
   }
+
+  @Test
+  public void getFilename_notAnswered_returnsEmpty() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(fileUploadQuestionDefinition, applicantData, Optional.empty());
+
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+
+    assertThat(fileUploadQuestion.getFilename()).isEmpty();
+  }
+
+  @Test
+  public void getFilename_emptyAnswer_returnsEmpty() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(fileUploadQuestionDefinition, applicantData, Optional.empty());
+    QuestionAnswerer.answerFileQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "");
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+
+    assertThat(fileUploadQuestion.getFilename()).isEmpty();
+  }
+
+  @Test
+  public void getFilename() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(fileUploadQuestionDefinition, applicantData, Optional.empty());
+    QuestionAnswerer.answerFileQuestion(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        "applicant-123/program-456/block-789/filename");
+
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+
+    assertThat(fileUploadQuestion.getFilename().get()).isEqualTo("filename");
+  }
+
+  @Test
+  public void getFilename_specialCharacters() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(fileUploadQuestionDefinition, applicantData, Optional.empty());
+    QuestionAnswerer.answerFileQuestion(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        "applicant-123/program-456/block-789/file%?\\/^&!@");
+
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+
+    assertThat(fileUploadQuestion.getFilename().get()).isEqualTo("file%?\\/^&!@");
+  }
 }


### PR DESCRIPTION
### Description
Record the filename and show user the file they have uploaded.
In file upload question block:
![Screen Shot 2021-06-24 at 11 17 21 AM](https://user-images.githubusercontent.com/2597580/123314883-f6e60f80-d4df-11eb-84ce-a0e3473123e4.png)
In review page:
![Screen Shot 2021-06-24 at 11 17 13 AM](https://user-images.githubusercontent.com/2597580/123314873-f483b580-d4df-11eb-872e-5ab091f6f0d0.png)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1312 
#1428