### PR TITLE
Remove admin access for global admins to programs which don't have admins

### DIFF
--- a/browser-test/src/application_previous_version.test.ts
+++ b/browser-test/src/application_previous_version.test.ts
@@ -1,4 +1,4 @@
-import { startSession, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
+import { startSession, loginAsProgramAdmin, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
 
 describe('view an application in an older version', () => {
   it('create an application, and create a new version of the program, and view the application in the old version of the program', async () => {
@@ -28,7 +28,7 @@ describe('view an application in an older version', () => {
     await applicantQuestions.submitFromReviewPage(programName);
 
     await logout(page);
-    await loginAsAdmin(page);
+    await loginAsProgramAdmin(page);
 
     // See the application in admin page
     await adminPrograms.viewApplications(programName);
@@ -41,6 +41,9 @@ describe('view an application in an older version', () => {
     // Create a new version of the question and program
     await adminQuestions.createNewVersion(questionName);
     await adminPrograms.publishProgram(programName);
+
+    await logout(page);
+    await loginAsProgramAdmin(page);
 
     // See the application in admin page in the old version
     await adminPrograms.viewApplications(programName);

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -1,4 +1,4 @@
-import { startSession, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
+import { startSession, loginAsProgramAdmin, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
 
 describe('normal application flow', () => {
   it('all major steps', async () => {
@@ -99,7 +99,7 @@ describe('normal application flow', () => {
     await applicantQuestions.submitFromReviewPage(programName);
 
     await logout(page);
-    await loginAsAdmin(page);
+    await loginAsProgramAdmin(page);
 
     await adminPrograms.viewApplications(programName);
     await adminPrograms.viewApplicationForApplicant(userDisplayName());
@@ -126,6 +126,9 @@ describe('normal application flow', () => {
     await page.click('button:text("Remove"):visible')
     await page.click('text=Update');
     await adminPrograms.publishProgram(programName);
+
+    await logout(page);
+    await loginAsProgramAdmin(page);
 
     await adminPrograms.viewApplicationsForOldVersion(programName);
     await adminPrograms.viewApplicationForApplicant(userDisplayName());

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
@@ -15,7 +15,6 @@ import models.Account;
 import models.Applicant;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.DatabaseExecutionContext;
-import repository.ProgramRepository;
 
 /**
  * This is a "pure" wrapper of CiviFormProfileData. Since CiviFormProfileData is the serialized data

--- a/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/CiviFormProfile.java
@@ -26,18 +26,15 @@ public class CiviFormProfile {
   private DatabaseExecutionContext dbContext;
   private HttpExecutionContext httpContext;
   private CiviFormProfileData profileData;
-  private ProgramRepository programRepository;
 
   @Inject
   public CiviFormProfile(
       DatabaseExecutionContext dbContext,
       HttpExecutionContext httpContext,
-      CiviFormProfileData profileData,
-      ProgramRepository programRepository) {
+      CiviFormProfileData profileData) {
     this.dbContext = Preconditions.checkNotNull(dbContext);
     this.httpContext = Preconditions.checkNotNull(httpContext);
     this.profileData = Preconditions.checkNotNull(profileData);
-    this.programRepository = Preconditions.checkNotNull(programRepository);
   }
 
   public CompletableFuture<Applicant> getApplicant() {
@@ -152,13 +149,6 @@ public class CiviFormProfile {
               if (account.getAdministeredProgramNames().stream()
                   .anyMatch(program -> program.equals(programName))) {
                 return null;
-              }
-              if (account.getGlobalAdmin()) {
-                // If there are no administrators for this program, then all global
-                // admins count as administrators.
-                if (this.programRepository.getProgramAdministrators(programName).isEmpty()) {
-                  return null;
-                }
               }
               throw new SecurityException(
                   String.format(

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -7,7 +7,6 @@ import models.Account;
 import models.Applicant;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.DatabaseExecutionContext;
-import repository.ProgramRepository;
 import repository.VersionRepository;
 
 public class ProfileFactory {

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -14,18 +14,15 @@ public class ProfileFactory {
 
   private DatabaseExecutionContext dbContext;
   private HttpExecutionContext httpContext;
-  private Provider<ProgramRepository> programRepositoryProvider;
   private Provider<VersionRepository> versionRepositoryProvider;
 
   @Inject
   public ProfileFactory(
       DatabaseExecutionContext dbContext,
       HttpExecutionContext httpContext,
-      Provider<ProgramRepository> programRepositoryProvider,
       Provider<VersionRepository> versionRepositoryProvider) {
     this.dbContext = Preconditions.checkNotNull(dbContext);
     this.httpContext = Preconditions.checkNotNull(httpContext);
-    this.programRepositoryProvider = Preconditions.checkNotNull(programRepositoryProvider);
     this.versionRepositoryProvider = Preconditions.checkNotNull(versionRepositoryProvider);
   }
 
@@ -47,7 +44,7 @@ public class ProfileFactory {
   }
 
   public CiviFormProfile wrapProfileData(CiviFormProfileData p) {
-    return new CiviFormProfile(dbContext, httpContext, p, programRepositoryProvider.get());
+    return new CiviFormProfile(dbContext, httpContext, p);
   }
 
   private CiviFormProfileData create(Roles role) {

--- a/universal-application-tool-0.0.1/test/controllers/FileControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/FileControllerTest.java
@@ -106,13 +106,13 @@ public class FileControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void adminShow_globalAdminWhenNoProgramAdmin_redirects() {
+  public void adminShow_globalAdminWhenNoProgramAdmin_returnsUnauthorizedResult() {
     Program program = ProgramBuilder.newDraftProgram().build();
     createGlobalAdminWithMockedProfile();
     String fileKey = fakeFileKey(1L, program.id);
     Request request = fakeRequest().build();
     Result result = controller.adminShow(request, program.id, fileKey);
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test


### PR DESCRIPTION
### Description
Admins should in fact not have access to programs, even if there are no program admins.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1461.
