### PR TITLE
Allow a list of values for multi-option question predicates

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -165,14 +165,17 @@ function configurePredicateForm(event: Event) {
   const selectedScalarType = scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type;
   const selectedScalarValue = scalarDropdown.options[scalarDropdown.options.selectedIndex].value;
 
-  filterOperators(scalarDropdown, selectedScalarType);
+  filterOperators(scalarDropdown, selectedScalarType, selectedScalarValue);
   configurePredicateValueInput(scalarDropdown, selectedScalarType, selectedScalarValue);
 }
 
 /**
  * Filter the operators available for each scalar type based on the current scalar selected.
  */
-function filterOperators(scalarDropdown: HTMLSelectElement, selectedScalarType: string) {
+function filterOperators(
+  scalarDropdown: HTMLSelectElement,
+  selectedScalarType: string,
+  selectedScalarValue: string) {
   // Filter the operators available for the given selected scalar type.
   const operatorDropdown =
     scalarDropdown
@@ -180,14 +183,35 @@ function filterOperators(scalarDropdown: HTMLSelectElement, selectedScalarType: 
       .querySelector('.cf-operator-select') // div containing the operator dropdown
       .querySelector('select') as HTMLSelectElement;
 
-  Array.from(operatorDropdown.options).forEach(option => {
+  Array.from(operatorDropdown.options).forEach(operatorOption => {
     // Remove any existing hidden class from previous filtering.
-    option.classList.remove('hidden');
-    // If this operator is not for the currently selected type, hide it.
-    if (!(selectedScalarType in option.dataset)) {
-      option.classList.add('hidden');
+    operatorOption.classList.remove('hidden');
+
+    if (shouldHideOperator(selectedScalarType, selectedScalarValue, operatorOption)) {
+      operatorOption.classList.add('hidden');
     }
   });
+}
+
+function shouldHideOperator(
+  selectedScalarType: string,
+  selectedScalarValue: string,
+  operatorOption: HTMLOptionElement
+): boolean {
+  // If this operator is not for the currently selected type, hide it.
+  return (
+    !(selectedScalarType in operatorOption.dataset) ||
+    // Special case for SELECTION scalars (which are of type STRING):
+    // do not include EQUAL_TO or NOT_EQUAL_TO. This is because we use a set of checkbox
+    // inputs for values for multi-option question predicates, which works well for list
+    // operators such as ANY_OF and NONE_OF. Because you can achieve the same functionality
+    // of EQUAL_TO with ANY_OF and NOT_EQUAL_TO with NONE_OF, we made a technical choice to
+    // exclude these operators from single-select predicates to simplify the code on the
+    // form processing side.
+    (selectedScalarValue.toUpperCase() === 'SELECTION' &&
+      (operatorOption.value === 'EQUAL_TO' ||
+        operatorOption.value === 'NOT_EQUAL_TO'))
+  );
 }
 
 function configurePredicateValueInput(

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -206,8 +206,8 @@ function shouldHideOperator(
     // inputs for values for multi-option question predicates, which works well for list
     // operators such as ANY_OF and NONE_OF. Because you can achieve the same functionality
     // of EQUAL_TO with ANY_OF and NOT_EQUAL_TO with NONE_OF, we made a technical choice to
-    // exclude these operators from single-select predicates to simplify the code on the
-    // form processing side.
+    // exclude these operators from single-select predicates to simplify the code on both
+    // the form processing side and on the admin user side.
     (selectedScalarValue.toUpperCase() === 'SELECTION' &&
       (operatorOption.value === 'EQUAL_TO' ||
         operatorOption.value === 'NOT_EQUAL_TO'))

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -146,9 +146,18 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
    * Parses the given value based on the given scalar type and operator. For example, if the scalar
    * is of type LONG and the operator is of type ANY_OF, the value will be parsed as a list of
    * comma-separated longs.
+   *
+   * <p>If value is the empty string, then parses the list of values instead.
    */
   private PredicateValue parsePredicateValue(
       Scalar scalar, Operator operator, String value, List<String> values) {
+
+    // If no value, then parse the list of values.
+    if (value.isEmpty()) {
+      ImmutableList.Builder<String> builder = ImmutableList.builder();
+      return PredicateValue.listOfStrings(builder.addAll(values).build());
+    }
+
     switch (scalar.toScalarType()) {
       case DATE:
         LocalDate localDate = LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
@@ -169,11 +178,8 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
             return PredicateValue.of(Long.parseLong(value));
         }
 
-      case LIST_OF_STRINGS:
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
-        return PredicateValue.listOfStrings(builder.addAll(values).build());
-
-      default: // STRING
+      default: // STRING, should not include LIST_OF_STRINGS since that should be covered at the top
+        // of the method with `values`.
         switch (operator) {
           case ANY_OF:
           case NONE_OF:

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -152,8 +152,9 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
   private PredicateValue parsePredicateValue(
       Scalar scalar, Operator operator, String value, List<String> values) {
 
-    // If no value, then parse the list of values.
-    if (value.isEmpty()) {
+    // If the scalar is SELECTION or SELECTIONS then this is a multi-option question predicate, and
+    // the right hand side values are in the `values` list rather than the `value` string.
+    if (scalar == Scalar.SELECTION || scalar == Scalar.SELECTIONS) {
       ImmutableList.Builder<String> builder = ImmutableList.builder();
       return PredicateValue.listOfStrings(builder.addAll(values).build());
     }

--- a/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
+++ b/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
@@ -5,11 +5,12 @@ import java.util.List;
 import play.data.validation.Constraints;
 import play.data.validation.Constraints.Validatable;
 import play.data.validation.Constraints.Validate;
+import play.data.validation.ValidationError;
 import services.applicant.question.Scalar;
 import services.program.predicate.Operator;
 
 @Validate
-public class BlockVisibilityPredicateForm implements Validatable<String> {
+public class BlockVisibilityPredicateForm implements Validatable<List<ValidationError>> {
   @Constraints.Required(message = "Must select 'hidden if' or 'shown if'.")
   private String predicateAction;
 
@@ -22,16 +23,20 @@ public class BlockVisibilityPredicateForm implements Validatable<String> {
   @Constraints.Required(message = "Operator is required.")
   private String operator;
 
-  // TODO(natsid): probably need to add this to our custom validate method
-  //  since it's not as straightforward "required" anymore.
-  //  Specifically: need ONE OF value or values.
-  @Constraints.Required(message = "Value is required.")
+  /**
+   * Either predicateValue OR predicateValues must be present. But because this validation logic is
+   * more complex than can be described by {@link @Constraints.Required}, we add it to the validate
+   * method below.
+   */
   private String predicateValue;
 
-  // This value is used when the question ID is for a multi-option question.
-  // Caution: This must be a mutable list type, or else Play's form binding cannot add elements to
-  // the list. This means the constructors MUST set this field to a mutable List type, NOT
-  // ImmutableList.
+  /**
+   * This value is used when the question ID is for a multi-option question.
+   *
+   * <p>Caution: This must be a mutable list type, or else Play's form binding cannot add elements
+   * to the list. This means the constructors MUST set this field to a mutable List type, NOT
+   * ImmutableList.
+   */
   private List<String> predicateValues;
 
   public BlockVisibilityPredicateForm(
@@ -60,20 +65,37 @@ public class BlockVisibilityPredicateForm implements Validatable<String> {
   }
 
   @Override
-  public String validate() {
-    // Don't attempt to run this validate method if missing required values.
-    if (operator.isEmpty() || scalar.isEmpty()) return null;
+  public List<ValidationError> validate() {
+    ArrayList<ValidationError> errors = new ArrayList<>();
 
-    Operator operator = Operator.valueOf(getOperator());
-    Scalar scalar = Scalar.valueOf(getScalar());
+    // The rest of this validate method depends on scalar being present.
+    if (scalar.isEmpty()) return errors;
 
-    // This should never happen since we only expose the usable operators for the given scalar.
-    if (!operator.getOperableTypes().contains(scalar.toScalarType())) {
-      return String.format(
-          "Cannot use operator \"%s\" on scalar \"%s\".",
-          operator.toDisplayString(), scalar.toDisplayString());
+    Scalar scalarEnum = Scalar.valueOf(getScalar());
+
+    // Only attempt to run the scalar-operator compatibility validation if both values are present.
+    if (!operator.isEmpty()) {
+      Operator operatorEnum = Operator.valueOf(getOperator());
+
+      // This should never happen since we only expose the usable operators for the given scalar.
+      if (!operatorEnum.getOperableTypes().contains(scalarEnum.toScalarType())) {
+        errors.add(
+            new ValidationError(
+                "operator",
+                String.format(
+                    "Cannot use operator \"%s\" on scalar \"%s\".",
+                    operatorEnum.toDisplayString(), scalarEnum.toDisplayString())));
+      }
     }
-    return null;
+
+    if ((scalarEnum == Scalar.SELECTION || scalarEnum == Scalar.SELECTIONS)
+        && predicateValues.isEmpty()) {
+      errors.add(new ValidationError("predicateValues", "Must select at least one value."));
+    } else if (predicateValue.isEmpty()) {
+      errors.add(new ValidationError("predicateValue", "Value is required."));
+    }
+
+    return errors;
   }
 
   public String getPredicateAction() {

--- a/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
+++ b/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
@@ -88,9 +88,10 @@ public class BlockVisibilityPredicateForm implements Validatable<List<Validation
       }
     }
 
-    if ((scalarEnum == Scalar.SELECTION || scalarEnum == Scalar.SELECTIONS)
-        && predicateValues.isEmpty()) {
-      errors.add(new ValidationError("predicateValues", "Must select at least one value."));
+    if ((scalarEnum == Scalar.SELECTION || scalarEnum == Scalar.SELECTIONS)) {
+      if (predicateValues.isEmpty()) {
+        errors.add(new ValidationError("predicateValues", "Must select at least one value."));
+      }
     } else if (predicateValue.isEmpty()) {
       errors.add(new ValidationError("predicateValue", "Value is required."));
     }

--- a/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
+++ b/universal-application-tool-0.0.1/app/forms/BlockVisibilityPredicateForm.java
@@ -1,5 +1,7 @@
 package forms;
 
+import java.util.ArrayList;
+import java.util.List;
 import play.data.validation.Constraints;
 import play.data.validation.Constraints.Validatable;
 import play.data.validation.Constraints.Validate;
@@ -20,20 +22,31 @@ public class BlockVisibilityPredicateForm implements Validatable<String> {
   @Constraints.Required(message = "Operator is required.")
   private String operator;
 
+  // TODO(natsid): probably need to add this to our custom validate method
+  //  since it's not as straightforward "required" anymore.
+  //  Specifically: need ONE OF value or values.
   @Constraints.Required(message = "Value is required.")
   private String predicateValue;
+
+  // This value is used when the question ID is for a multi-option question.
+  // Caution: This must be a mutable list type, or else Play's form binding cannot add elements to
+  // the list. This means the constructors MUST set this field to a mutable List type, NOT
+  // ImmutableList.
+  private List<String> predicateValues;
 
   public BlockVisibilityPredicateForm(
       String predicateAction,
       long questionId,
       String scalar,
       String operator,
-      String predicateValue) {
+      String predicateValue,
+      List<String> predicateValues) {
     this.predicateAction = predicateAction;
     this.questionId = questionId;
     this.scalar = scalar;
     this.operator = operator;
     this.predicateValue = predicateValue;
+    this.predicateValues = predicateValues;
   }
 
   public BlockVisibilityPredicateForm() {
@@ -43,6 +56,7 @@ public class BlockVisibilityPredicateForm implements Validatable<String> {
     scalar = "";
     operator = "";
     predicateValue = "";
+    predicateValues = new ArrayList<>();
   }
 
   @Override
@@ -100,5 +114,13 @@ public class BlockVisibilityPredicateForm implements Validatable<String> {
 
   public void setPredicateValue(String predicateValue) {
     this.predicateValue = predicateValue;
+  }
+
+  public List<String> getPredicateValues() {
+    return predicateValues;
+  }
+
+  public void setPredicateValues(List<String> predicateValues) {
+    this.predicateValues = predicateValues;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -44,6 +44,7 @@ import views.components.Modal;
 import views.components.SelectWithLabel;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
+import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.Styles;
 
@@ -244,6 +245,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
             Styles.GAP_4,
             Styles.PX_4,
             Styles.PY_2,
+            Styles.MY_2,
             Styles.BORDER,
             Styles.BORDER_GRAY_200)
         .with(
@@ -337,13 +339,14 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
       // localized.
       ImmutableList<QuestionOption> options =
           ((MultiOptionQuestionDefinition) questionDefinition).getOptions();
-      ContainerTag valueOptionsDiv = div();
+      ContainerTag valueOptionsDiv =
+          div().with(div("Values").withClasses(BaseStyles.CHECKBOX_GROUP_LABEL));
       for (QuestionOption option : options) {
         // TODO(natsid): Figure out how to do multi-option checkboxes! Probably need to update field
         //  name to something else for an array.
         ContainerTag optionCheckbox =
             FieldWithLabel.checkbox()
-                .setFieldName("predicateValue")
+                .setFieldName("predicateValues[]")
                 .setLabelText(option.optionText().getDefault())
                 .getContainer();
         valueOptionsDiv.with(optionCheckbox);

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -342,8 +342,6 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
       ContainerTag valueOptionsDiv =
           div().with(div("Values").withClasses(BaseStyles.CHECKBOX_GROUP_LABEL));
       for (QuestionOption option : options) {
-        // TODO(natsid): Figure out how to do multi-option checkboxes! Probably need to update field
-        //  name to something else for an array.
         ContainerTag optionCheckbox =
             FieldWithLabel.checkbox()
                 .setFieldName("predicateValues[]")

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -345,6 +345,7 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
         ContainerTag optionCheckbox =
             FieldWithLabel.checkbox()
                 .setFieldName("predicateValues[]")
+                .setValue(String.valueOf(option.id()))
                 .setLabelText(option.optionText().getDefault())
                 .getContainer();
         valueOptionsDiv.with(optionCheckbox);

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -29,6 +29,7 @@ import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.program.predicate.Operator;
 import services.program.predicate.PredicateAction;
+import services.question.QuestionOption;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.MultiOptionQuestionDefinition;
@@ -334,19 +335,20 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
       // choose from instead of a freeform text field. Not only is it a better UX, but we store the
       // ID of the options rather than the display strings since the option display strings are
       // localized.
-      ImmutableMap<String, String> valueOptions =
-          ((MultiOptionQuestionDefinition) questionDefinition)
-              .getOptions().stream()
-                  .collect(
-                      toImmutableMap(
-                          option -> option.optionText().getDefault(),
-                          option -> String.valueOf(option.id())));
-
-      return new SelectWithLabel()
-          .setFieldName("predicateValue")
-          .setLabelText("Value")
-          .setOptions(valueOptions)
-          .getContainer();
+      ImmutableList<QuestionOption> options =
+          ((MultiOptionQuestionDefinition) questionDefinition).getOptions();
+      ContainerTag valueOptionsDiv = div();
+      for (QuestionOption option : options) {
+        // TODO(natsid): Figure out how to do multi-option checkboxes! Probably need to update field
+        //  name to something else for an array.
+        ContainerTag optionCheckbox =
+            FieldWithLabel.checkbox()
+                .setFieldName("predicateValue")
+                .setLabelText(option.optionText().getDefault())
+                .getContainer();
+        valueOptionsDiv.with(optionCheckbox);
+      }
+      return valueOptionsDiv;
     } else {
       return FieldWithLabel.input()
           .setFieldName("predicateValue")

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -81,6 +81,10 @@ public final class BaseStyles {
   /** Same as the above but for radio buttons. */
   public static final String RADIO_LABEL = CHECKBOX_LABEL;
 
+  /** For labelling a *group* of checkboxes that are related to the same thing. */
+  public static final String CHECKBOX_GROUP_LABEL =
+      StyleUtils.joinStyles(BaseStyles.FORM_LABEL_TEXT_COLOR, Styles.TEXT_BASE);
+
   /** For use on an `input` of type "checkbox". */
   public static final String CHECKBOX =
       StyleUtils.joinStyles(Styles.H_4, Styles.W_4, Styles.MR_4, Styles.ALIGN_MIDDLE);

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -153,7 +153,7 @@ public class AdminProgramBlockPredicatesControllerTest extends WithPostgresConta
         .hasValue(
             routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
     assertThat(result.flash().get("error")).isEmpty();
-    assertThat(result.flash().get("success").get()).contains("Saved visibility condition blah");
+    assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
   }
 
   @Test
@@ -170,7 +170,7 @@ public class AdminProgramBlockPredicatesControllerTest extends WithPostgresConta
                     "SELECTIONS",
                     "operator",
                     "ANY_OF",
-                    "predicateValue[]",
+                    "predicateValues[]",
                     "1"))
             .build();
 

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -32,6 +32,7 @@ public class AdminProgramBlockPredicatesControllerTest extends WithPostgresConta
             .withBlock("Block 2")
             .withQuestion(testQuestionBank.applicantAddress())
             .withQuestion(testQuestionBank.applicantIceCream())
+            .withQuestion(testQuestionBank.applicantKitchenTools())
             .withBlock("Block 3")
             .withQuestion(testQuestionBank.applicantFavoriteColor())
             .build();
@@ -108,6 +109,69 @@ public class AdminProgramBlockPredicatesControllerTest extends WithPostgresConta
                     "EQUAL_TO",
                     "predicateValue",
                     "Hello"))
+            .build();
+
+    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+    assertThat(result.flash().get("error")).isEmpty();
+    assertThat(result.flash().get("success").get()).contains("Saved visibility condition");
+
+    // For some reason the above result has an empty contents. So we test the new content of the
+    // edit page manually.
+    Result redirectResult =
+        controller.edit(addCSRFToken(fakeRequest()).build(), programWithThreeBlocks.id, 3L);
+    assertThat(Helpers.contentAsString(redirectResult))
+        .doesNotContain("This block is always shown.");
+  }
+
+  @Test
+  public void update_withSingleSelectQuestion() {
+    Http.Request request =
+        fakeRequest()
+            .bodyForm(
+                ImmutableMap.of(
+                    "predicateAction",
+                    "HIDE_BLOCK",
+                    "questionId",
+                    String.valueOf(testQuestionBank.applicantIceCream().id),
+                    "scalar",
+                    "SELECTION",
+                    "operator",
+                    "IN",
+                    "predicateValues[]",
+                    "1"))
+            .build();
+
+    Result result = controller.update(request, programWithThreeBlocks.id, 3L);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramBlockPredicatesController.edit(programWithThreeBlocks.id, 3L).url());
+    assertThat(result.flash().get("error")).isEmpty();
+    assertThat(result.flash().get("success").get()).contains("Saved visibility condition blah");
+  }
+
+  @Test
+  public void update_withMultiSelectQuestion() {
+    Http.Request request =
+        fakeRequest()
+            .bodyForm(
+                ImmutableMap.of(
+                    "predicateAction",
+                    "SHOW_BLOCK",
+                    "questionId",
+                    String.valueOf(testQuestionBank.applicantKitchenTools().id),
+                    "scalar",
+                    "SELECTIONS",
+                    "operator",
+                    "ANY_OF",
+                    "predicateValue[]",
+                    "1"))
             .build();
 
     Result result = controller.update(request, programWithThreeBlocks.id, 3L);


### PR DESCRIPTION
### Description
Now predicates based on multi-options questions can actually have lists as the `values` field on the right hand side! Works for both single select (radios, dropdowns) and multi select questions.

* Use a set of checkbox inputs for the `value` field when the left hand side of the predicate operator is a selection or selections from a multi-option question.
* Parse these checkbox values differently than if we were getting one string value.
* Removed  "is equal to" and "is not equal to" operator options from single-select predicates. This is because then we'd need to limit the number of checkboxes selected in that case. We could have added extra validation to enforce selecting only a single option in that case. But, since "is one of" with just one value is equivalent to "is equal to" and likewise for "is none of" and "is not equal to", we think this strategy actually _helps_ the user by not getting in their way. If they select multiple options on the right side, they probably mean "is one of" anyway.  A validation error when a user uses "is equal to" and multiple options on the right hand side seems not very helpful.
* Note that `string` scalars can already have "lists" on the right-hand side prior to this PR, but the value is just entered as a comma-separated list in that case.

<img width="566" alt="Screen Shot 2021-06-24 at 2 01 35 PM" src="https://user-images.githubusercontent.com/5732310/123341832-82bd6300-d503-11eb-92fc-d2a507e08cc7.png">

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Manually tested this flow with both single select and multi select question predicates
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #322
