### PR TITLE
Add labels to every field so that screen readers can interact with them.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ManageProgramAdminsView.java
@@ -94,6 +94,7 @@ public class ManageProgramAdminsView extends BaseHtmlView {
         FieldWithLabel.email()
             .setFieldName(inputFieldName)
             .setPlaceholderText(INPUT_PLACEHOLDER)
+            .setScreenReaderText(INPUT_PLACEHOLDER)
             .setValue(existing)
             // If there is an existing value, do not allow changes in the input field.
             .setDisabled(existing.isPresent())

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -147,6 +147,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .with(
                 FieldWithLabel.number()
                     .setFieldName(ENUMERATOR_ID_FORM_FIELD)
+                    .setScreenReaderText(ENUMERATOR_ID_FORM_FIELD)
                     .setValue(OptionalLong.of(blockId))
                     .getContainer());
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramTranslationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramTranslationView.java
@@ -83,11 +83,13 @@ public class ProgramTranslationView extends TranslationFormView {
             .setId("localize-display-name")
             .setFieldName("displayName")
             .setPlaceholderText("Program display name")
+            .setScreenReaderText("Program display name")
             .setValue(localizedName),
         FieldWithLabel.input()
             .setId("localize-display-description")
             .setFieldName("displayDescription")
             .setPlaceholderText("Program description")
+            .setScreenReaderText("Program description")
             .setValue(localizedDescription));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -171,6 +171,7 @@ public class QuestionConfig {
             ? FieldWithLabel.input()
                 .setFieldName("optionIds[]")
                 .setValue(String.valueOf(existingOption.get().id()))
+                .setScreenReaderText("option ids")
                 .getContainer()
                 .withClasses(Styles.HIDDEN)
             : div();

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -210,6 +210,7 @@ public final class QuestionEditView extends BaseHtmlView {
           FieldWithLabel.number()
               .setFieldName("nextAvailableId")
               .setValue(((MultiOptionQuestionForm) questionForm).getNextAvailableId())
+              .setScreenReaderText("next id, hidden")
               .getContainer()
               .withClasses(Styles.HIDDEN));
     }

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -210,7 +210,6 @@ public final class QuestionEditView extends BaseHtmlView {
           FieldWithLabel.number()
               .setFieldName("nextAvailableId")
               .setValue(((MultiOptionQuestionForm) questionForm).getNextAvailableId())
-              .setScreenReaderText("next id, hidden")
               .getContainer()
               .withClasses(Styles.HIDDEN));
     }

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -6,7 +6,6 @@ import static j2html.TagCreator.each;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.textarea;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -236,9 +235,7 @@ public class FieldWithLabel {
             // If the text is screen-reader text, then we want the label to be screen-reader
             // only.
             .withCondClass(labelText.isEmpty(), Styles.SR_ONLY)
-            .withText(
-                Preconditions.checkNotNull(
-                    Strings.emptyToNull(labelText.isEmpty() ? screenReaderText : labelText)));
+            .withText(labelText.isEmpty() ? screenReaderText : labelText);
 
     return div(labelTag, fieldTag, buildFieldErrorsTag())
         .withClasses(

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -231,10 +231,9 @@ public class FieldWithLabel {
     ContainerTag labelTag =
         label()
             .attr(Attr.FOR, this.id)
-            .withCondClass(!labelText.isEmpty(), BaseStyles.INPUT_LABEL)
             // If the text is screen-reader text, then we want the label to be screen-reader
             // only.
-            .withCondClass(labelText.isEmpty(), Styles.SR_ONLY)
+            .withClass(labelText.isEmpty() ? Styles.SR_ONLY : BaseStyles.INPUT_LABEL)
             .withText(labelText.isEmpty() ? screenReaderText : labelText);
 
     return div(labelTag, fieldTag, buildFieldErrorsTag())

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
@@ -24,7 +24,9 @@ public class DateQuestionRenderer extends ApplicantQuestionRenderer {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =
-        FieldWithLabel.date().setFieldName(dateQuestion.getDatePath().toString());
+        FieldWithLabel.date()
+            .setFieldName(dateQuestion.getDatePath().toString())
+            .setScreenReaderText(question.getQuestionText());
     if (dateQuestion.getDateValue().isPresent()) {
       Optional<String> value = dateQuestion.getDateValue().map(LocalDate::toString);
       dateField.setValue(value);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -40,6 +40,7 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
                         toImmutableMap(
                             LocalizedQuestionOption::optionText,
                             option -> String.valueOf(option.id()))));
+    select.setScreenReaderText(question.getQuestionText());
 
     if (singleSelectQuestion.getSelectedOptionId().isPresent()) {
       select.setValue(String.valueOf(singleSelectQuestion.getSelectedOptionId().get()));

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
@@ -26,6 +26,7 @@ public class EmailQuestionRenderer extends ApplicantQuestionRenderer {
             .setFieldName(emailQuestion.getEmailPath().toString())
             .setValue(emailQuestion.getEmailValue().orElse(""))
             .setFieldErrors(params.messages(), emailQuestion.getQuestionErrors())
+            .setScreenReaderText(question.getQuestionText())
             .getContainer();
 
     return renderInternal(params.messages(), questionFormContent, false);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -108,6 +108,10 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
         FieldWithLabel.input()
             .setFieldName(contextualizedPath.toString())
             .setValue(existingEntity)
+            .setScreenReaderText(
+                messages.at(
+                    MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),
+                    localizedEntityType))
             .setPlaceholderText(
                 messages.at(
                     MessageKey.ENUMERATOR_PLACEHOLDER_ENTITY_NAME.getKeyName(),

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
@@ -26,6 +26,7 @@ public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
     FieldWithLabel numberField =
         FieldWithLabel.number()
             .setFieldName(numberQuestion.getNumberPath().toString())
+            .setScreenReaderText(question.getQuestionText())
             .setFieldErrors(params.messages(), numberQuestion.getQuestionErrors());
     if (numberQuestion.getNumberValue().isPresent()) {
       // TODO: [Refactor] Oof! Converting Optional<Long> to OptionalLong.

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -25,6 +25,7 @@ public class TextQuestionRenderer extends ApplicantQuestionRenderer {
             .setFieldName(textQuestion.getTextPath().toString())
             .setValue(textQuestion.getTextValue().orElse(""))
             .setFieldErrors(params.messages(), textQuestion.getQuestionErrors())
+            .setScreenReaderText(question.getQuestionText())
             .getContainer();
 
     return renderInternal(params.messages(), questionFormContent, false);


### PR DESCRIPTION
### Description
Multi-part questions are rendered with their labels adjacent and content-ful - but for the single-part questions where we don't, this PR adds the content.  It also associates all the labels with the inputs.  for the ones where the associated label would be duplicative, apply `sr-only` class.

Tested by adding an assert - browser tests all pass - removed the assert because a ton of unit tests would have needed to be updated to no real benefit.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Addresses #1456.