### PR TITLE
Enable confirmation for link elements, and add confirmation to the bu…

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -182,6 +182,10 @@ export class AdminPrograms {
   }
 
   async publishAllPrograms() {
+    this.page.once("dialog", async dialog => {
+      expect(await dialog.type()).toEqual("confirm");
+      await dialog.accept();
+    });
     await this.page.click(`#publish-programs-button > button`);
   }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -84,6 +84,7 @@ public final class ProgramIndexView extends BaseHtmlView {
           .setId("publish-programs-button")
           .setHref(link)
           .setText("Publish all drafts")
+          .enableConfirmation("Are you sure you want to publish all program drafts?")
           .asHiddenForm(request);
     } else {
       return div();

--- a/universal-application-tool-0.0.1/app/views/components/LinkElement.java
+++ b/universal-application-tool-0.0.1/app/views/components/LinkElement.java
@@ -53,6 +53,7 @@ public class LinkElement {
   private String text = "";
   private String href = "";
   private String styles = "";
+  private String confirmationMessage = "";
 
   public LinkElement setId(String id) {
     this.id = id;
@@ -71,6 +72,16 @@ public class LinkElement {
 
   public LinkElement setStyles(String... styles) {
     this.styles = StyleUtils.joinStyles(styles);
+    return this;
+  }
+
+  public LinkElement enableConfirmation(String confirmationMessage) {
+    this.confirmationMessage = confirmationMessage;
+    return this;
+  }
+
+  public LinkElement disableConfirmation() {
+    this.confirmationMessage = "";
     return this;
   }
 
@@ -105,6 +116,10 @@ public class LinkElement {
                 input().isHidden().withValue(csrfToken).withName("csrfToken"),
                 button(TagCreator.text(text))
                     .withClasses(DEFAULT_LINK_BUTTON_STYLES)
+                    .condAttr(
+                        !confirmationMessage.isBlank(),
+                        "onclick",
+                        confirmationScript(confirmationMessage))
                     .withType("submit"))
             .withMethod("POST")
             .withAction(href)
@@ -128,11 +143,22 @@ public class LinkElement {
                 input().isHidden().withValue(csrfToken).withName("csrfToken"),
                 button(TagCreator.text(text))
                     .withClasses(BUTTON_LOOKS_LIKE_LINK_STYLES)
+                    .condAttr(
+                        !confirmationMessage.isBlank(),
+                        "onclick",
+                        confirmationScript(confirmationMessage))
                     .withType("submit"))
             .withClasses(Styles.INLINE)
             .withMethod("POST")
             .withAction(href)
             .withCondId(!Strings.isNullOrEmpty(id), id);
     return form;
+  }
+
+  private String confirmationScript(String message) {
+    return String.format(
+        "if(confirm('%s')){ return true; } else { var e = arguments[0] || window.event;"
+            + " e.stopImmediatePropagation(); return false; }",
+        message);
   }
 }


### PR DESCRIPTION
…tton that publishes all programs.

### Description
The "publish all programs" button has too many consequences that it should have a confirmation dialog to protect it. This PR adds a confirmation dialog, and updates the browser tests to click OK on that dialog.

![image](https://user-images.githubusercontent.com/12072571/123494392-840a9080-d5d4-11eb-9bb1-2ded182c63ed.png)
