### PR TITLE
Add confirmation dialog to enumerator deletion.

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -111,7 +111,7 @@ describe('End to end enumerator test', () => {
 
     // Remove one of the 'Banker' entries and add 'Painter'.
     // the value attribute of the inputs isn't set, so we're clicking the second one.
-    await page.click(':nth-match(:text("Remove Entity"), 2)');
+    await applicantQuestions.deleteEnumeratorEntityByIndex(2);
     await applicantQuestions.addEnumeratorAnswer("Painter");
     await applicantQuestions.clickNext();
 

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -85,7 +85,17 @@ export class ApplicantQuestions {
   }
 
   async deleteEnumeratorEntity(entityName: string) {
+    this.page.once('dialog', async dialog => {
+      await dialog.accept();
+    });
     await this.page.click(`.cf-enumerator-field:has(input[value="${entityName}"]) button`);
+  }
+
+  async deleteEnumeratorEntityByIndex(entityIndex: number) {
+    this.page.once('dialog', async dialog => {
+      await dialog.accept();
+    });
+    await this.page.click(`:nth-match(:text("Remove Entity"), ${entityIndex})`);
   }
 
   async submitFromReviewPage(programName: string) {

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -46,6 +46,7 @@ public enum MessageKey {
   DROPDOWN_PLACEHOLDER("placeholder.noDropdownSelection"),
   ENUMERATOR_BUTTON_ADD_ENTITY("button.addEntity"),
   ENUMERATOR_BUTTON_REMOVE_ENTITY("button.removeEntity"),
+  ENUMERATOR_DIALOG_CONFIRM_DELETE("dialog.confirmDelete"),
   ENUMERATOR_PLACEHOLDER_ENTITY_NAME("placeholder.entityName"),
   ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME("validation.duplicateEntityName"),
   ENUMERATOR_VALIDATION_ENTITY_REQUIRED("validation.entityNameRequired"),

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -118,10 +118,18 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
                     localizedEntityType))
             .addReferenceClass(ReferenceClasses.ENTITY_NAME_INPUT)
             .getContainer();
+    String confirmationMessage =
+        messages.at(MessageKey.ENUMERATOR_DIALOG_CONFIRM_DELETE.getKeyName(), localizedEntityType);
     Tag removeEntityButton =
         TagCreator.button()
             .withType("button")
             .withCondId(existingIndex.isPresent(), existingIndex.map(String::valueOf).orElse(""))
+            .attr(
+                "onclick",
+                String.format(
+                    "if(confirm('%s')){ return true; } else { var e = arguments[0] ||"
+                        + " window.event; e.stopImmediatePropagation(); return false; }",
+                    confirmationMessage))
             .withClasses(
                 existingEntity.isPresent()
                     ? StyleUtils.joinStyles(ReferenceClasses.ENUMERATOR_EXISTING_DELETE_BUTTON)

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -215,6 +215,9 @@ button.addEntity=Add {0}
 # Text on a button an applicant would click to delete an entity
 button.removeEntity=Remove {0}
 
+# The confirmation dialog when an applicant deletes an enumerator entry.
+dialog.confirmDelete=Are you sure you want to remove this {0}? This change will be saved after you click "Next" and all data associated with this {0} will be lost.
+
 # Validation error that shows when an applicant does not enter a value.
 validation.entityNameRequired=Please enter a value for each line.
 


### PR DESCRIPTION
### Description
I added a browser confirmation that shows when a user deletes an enumerator entity.  If the user clicks "cancel", the click event is not propagated to the normal entity-deleting listener.

The styling of the dialog isn't very pretty, because it's the default browser confirm dialog that we don't have control over.
<img width="549" alt="enumerator_confirmation" src="https://user-images.githubusercontent.com/1851626/123588397-8c152c80-d79c-11eb-8b74-022852abda12.PNG">

Tested locally.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1117
