### PR TITLE
Admin predicate UI: Add help text for entering "comma-separated values" in some cases

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -162,7 +162,7 @@ function attachLineClampListeners() {
   applicationCardDescriptions.forEach(el => el.addEventListener('click', removeLineClamp));
 }
 
-function configurePredicateForm(event: Event) {
+function configurePredicateFormOnScalarChange(event: Event) {
   // Get the type of scalar currently selected.
   const scalarDropdown = event.target as HTMLSelectElement;
   const selectedScalarType = scalarDropdown.options[scalarDropdown.options.selectedIndex].dataset.type;
@@ -220,37 +220,65 @@ function shouldHideOperator(
 function configurePredicateValueInput(
   scalarDropdown: HTMLSelectElement,
   selectedScalarType: string,
-  selectedScalarValue: string) {
+  selectedScalarValue: string
+) {
   // If the scalar is from a multi-option question, there is not an input box for the 'Value'
   // field (there's a set of checkboxes instead), so return immediately.
-  if (selectedScalarValue.toUpperCase() === 'SELECTION') {
+  if (
+    selectedScalarValue.toUpperCase() === "SELECTION" ||
+    selectedScalarValue.toUpperCase() === "SELECTIONS"
+  ) {
     return;
   }
 
-  const valueInput =
-    scalarDropdown
-      .closest('.cf-predicate-options') // div containing all predicate builder form fields
-      .querySelector('.cf-predicate-value-input') // div containing the predicate value input
-      .querySelector('input') as HTMLInputElement;
+  const valueInput = scalarDropdown
+    .closest(".cf-predicate-options") // div containing all predicate builder form fields
+    .querySelector(".cf-predicate-value-input") // div containing the predicate value input
+    .querySelector("input");
 
   switch (selectedScalarType.toUpperCase()) {
-    case 'STRING':
-      if (selectedScalarValue.toUpperCase() === 'EMAIL') {
+    case "STRING":
+      if (selectedScalarValue.toUpperCase() === "EMAIL") {
         // Need to look at the selected scalar *value* for email since the type is just a
         // string, but emails have a special type in HTML inputs.
-        valueInput.setAttribute('type', 'email');
+        valueInput.setAttribute("type", "email");
         break;
       }
-      valueInput.setAttribute('type', 'text');
+      valueInput.setAttribute("type", "text");
       break;
-    case 'LONG':
-      valueInput.setAttribute('type', 'number');
+    case "LONG":
+      valueInput.setAttribute("type", "number");
       break;
-    case 'DATE':
-      valueInput.setAttribute('type', 'date');
+    case "DATE":
+      valueInput.setAttribute("type", "date");
       break;
     default:
-      valueInput.setAttribute('type', 'text');
+      valueInput.setAttribute("type", "text");
+  }
+}
+
+function configurePredicateFormOnOperatorChange(event: Event) {
+  const operatorDropdown = event.target as HTMLSelectElement;
+  const selectedOperatorValue =
+    operatorDropdown.options[operatorDropdown.options.selectedIndex].value;
+
+  const commaSeparatedHelpText = operatorDropdown
+    .closest(".cf-predicate-options")
+    .querySelector(".cf-predicate-value-comma-help-text");
+
+  // This help text div isn't present at all in some cases.
+  if (!commaSeparatedHelpText) {
+    return;
+  }
+
+  // Remove any existing hidden class.
+  commaSeparatedHelpText.classList.remove("hidden");
+
+  if (
+    selectedOperatorValue.toUpperCase() !== "IN" &&
+    selectedOperatorValue.toUpperCase() !== "NOT_IN"
+  ) {
+    commaSeparatedHelpText.classList.add("hidden");
   }
 }
 
@@ -262,7 +290,10 @@ window.addEventListener('load', (event) => {
   // Configure the admin predicate builder to show the appropriate options based on
   // the type of scalar selected.
   Array.from(document.querySelectorAll('.cf-scalar-select')).forEach(
-    el => el.addEventListener('input', configurePredicateForm));
+    el => el.addEventListener('input', configurePredicateFormOnScalarChange));
+
+  Array.from(document.querySelectorAll('.cf-operator-select')).forEach(
+    el => el.addEventListener('input', configurePredicateFormOnOperatorChange));
 
   // Submit button is disabled by default until program block edit form is changed
   const blockEditForm = document.getElementById('block-edit-form');

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -225,35 +225,35 @@ function configurePredicateValueInput(
   // If the scalar is from a multi-option question, there is not an input box for the 'Value'
   // field (there's a set of checkboxes instead), so return immediately.
   if (
-    selectedScalarValue.toUpperCase() === "SELECTION" ||
-    selectedScalarValue.toUpperCase() === "SELECTIONS"
+    selectedScalarValue.toUpperCase() === 'SELECTION' ||
+    selectedScalarValue.toUpperCase() === 'SELECTIONS'
   ) {
     return;
   }
 
   const valueInput = scalarDropdown
-    .closest(".cf-predicate-options") // div containing all predicate builder form fields
-    .querySelector(".cf-predicate-value-input") // div containing the predicate value input
-    .querySelector("input");
+    .closest('.cf-predicate-options') // div containing all predicate builder form fields
+    .querySelector('.cf-predicate-value-input') // div containing the predicate value input
+    .querySelector('input');
 
   switch (selectedScalarType.toUpperCase()) {
-    case "STRING":
-      if (selectedScalarValue.toUpperCase() === "EMAIL") {
+    case 'STRING':
+      if (selectedScalarValue.toUpperCase() === 'EMAIL') {
         // Need to look at the selected scalar *value* for email since the type is just a
         // string, but emails have a special type in HTML inputs.
-        valueInput.setAttribute("type", "email");
+        valueInput.setAttribute('type', 'email');
         break;
       }
-      valueInput.setAttribute("type", "text");
+      valueInput.setAttribute('type', 'text');
       break;
-    case "LONG":
-      valueInput.setAttribute("type", "number");
+    case 'LONG':
+      valueInput.setAttribute('type', 'number');
       break;
-    case "DATE":
-      valueInput.setAttribute("type", "date");
+    case 'DATE':
+      valueInput.setAttribute('type', 'date');
       break;
     default:
-      valueInput.setAttribute("type", "text");
+      valueInput.setAttribute('type', 'text');
   }
 }
 
@@ -263,8 +263,8 @@ function configurePredicateFormOnOperatorChange(event: Event) {
     operatorDropdown.options[operatorDropdown.options.selectedIndex].value;
 
   const commaSeparatedHelpText = operatorDropdown
-    .closest(".cf-predicate-options")
-    .querySelector(".cf-predicate-value-comma-help-text");
+    .closest('.cf-predicate-options')
+    .querySelector('.cf-predicate-value-comma-help-text');
 
   // This help text div isn't present at all in some cases.
   if (!commaSeparatedHelpText) {
@@ -272,13 +272,13 @@ function configurePredicateFormOnOperatorChange(event: Event) {
   }
 
   // Remove any existing hidden class.
-  commaSeparatedHelpText.classList.remove("hidden");
+  commaSeparatedHelpText.classList.remove('hidden');
 
   if (
-    selectedOperatorValue.toUpperCase() !== "IN" &&
-    selectedOperatorValue.toUpperCase() !== "NOT_IN"
+    selectedOperatorValue.toUpperCase() !== 'IN' &&
+    selectedOperatorValue.toUpperCase() !== 'NOT_IN'
   ) {
-    commaSeparatedHelpText.classList.add("hidden");
+    commaSeparatedHelpText.classList.add('hidden');
   }
 }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockPredicatesEditView.java
@@ -353,11 +353,21 @@ public class ProgramBlockPredicatesEditView extends BaseHtmlView {
       }
       return valueOptionsDiv;
     } else {
-      return FieldWithLabel.input()
-          .setFieldName("predicateValue")
-          .setLabelText("Value")
-          .addReferenceClass(ReferenceClasses.PREDICATE_VALUE_INPUT)
-          .getContainer();
+      return div()
+          .with(
+              FieldWithLabel.input()
+                  .setFieldName("predicateValue")
+                  .setLabelText("Value")
+                  .addReferenceClass(ReferenceClasses.PREDICATE_VALUE_INPUT)
+                  .getContainer())
+          .with(
+              div()
+                  .withClasses(
+                      ReferenceClasses.PREDICATE_VALUE_COMMA_HELP_TEXT,
+                      Styles.HIDDEN,
+                      Styles.TEXT_XS,
+                      BaseStyles.FORM_LABEL_TEXT_COLOR)
+                  .withText("Enter a list of comma-separated values. For example, \"v1,v2,v3\"."));
     }
   }
 }

--- a/universal-application-tool-0.0.1/app/views/style/ReferenceClasses.java
+++ b/universal-application-tool-0.0.1/app/views/style/ReferenceClasses.java
@@ -21,6 +21,7 @@ public final class ReferenceClasses {
   public static final String PREDICATE_OPERATOR_SELECT = "cf-operator-select";
   public static final String PREDICATE_OPTIONS = "cf-predicate-options";
   public static final String PREDICATE_VALUE_INPUT = "cf-predicate-value-input";
+  public static final String PREDICATE_VALUE_COMMA_HELP_TEXT = "cf-predicate-value-comma-help-text";
 
   public static final String QUESTION_BANK_ELEMENT = "cf-question-bank-element";
 


### PR DESCRIPTION
Also fixed a small bug in another part of the JavaScript where we should have checked for "SELECTIONS" _in addition to "SELECTION". Before this PR there was a null error being printed in the console in some cases.

<img width="753" alt="Screen Shot 2021-06-28 at 3 00 11 PM" src="https://user-images.githubusercontent.com/5732310/123710315-64b57280-d823-11eb-8ee8-3ce1fab92b7f.png">
<img width="592" alt="Screen Shot 2021-06-28 at 3 00 18 PM" src="https://user-images.githubusercontent.com/5732310/123710319-667f3600-d823-11eb-81ba-ab59b121eec4.png">
<img width="562" alt="Screen Shot 2021-06-28 at 3 09 35 PM" src="https://user-images.githubusercontent.com/5732310/123710327-68e19000-d823-11eb-9614-e923d5964fc4.png">

### Issue(s)
Works toward #322 