### PR TITLE
Make base style for link text darker.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -9,7 +9,7 @@ package views.style;
  */
 public final class BaseStyles {
 
-  public static final String LINK_TEXT = Styles.TEXT_BLUE_400;
+  public static final String LINK_TEXT = Styles.TEXT_BLUE_600;
   public static final String LINK_HOVER_TEXT = StyleUtils.hover(Styles.TEXT_BLUE_500);
 
   public static final String TABLE_CELL_STYLES = StyleUtils.joinStyles(Styles.PX_4, Styles.PY_2);


### PR DESCRIPTION
### Description
Made base style for link text `text-blue-600`. Tested with Lighthouse in chrome developer tools.

<img width="1039" alt="Screen Shot 2021-06-29 at 9 58 57 AM" src="https://user-images.githubusercontent.com/12072571/123838481-e60f1280-d8c0-11eb-9e4e-b0ff3c8e05b1.png">

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1472
