### PR TITLE
Admin predicate UI: Fix toast message for multi-option questions

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -31,19 +31,24 @@ import services.program.predicate.PredicateAction;
 import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
+import services.question.QuestionService;
+import services.question.ReadOnlyQuestionService;
 import views.admin.programs.ProgramBlockPredicatesEditView;
 
 public class AdminProgramBlockPredicatesController extends CiviFormController {
   private final ProgramService programService;
+  private final QuestionService questionService;
   private final ProgramBlockPredicatesEditView predicatesEditView;
   private final FormFactory formFactory;
 
   @Inject
   public AdminProgramBlockPredicatesController(
       ProgramService programService,
+      QuestionService questionService,
       ProgramBlockPredicatesEditView predicatesEditView,
       FormFactory formFactory) {
     this.programService = checkNotNull(programService);
+    this.questionService = checkNotNull(questionService);
     this.predicatesEditView = checkNotNull(predicatesEditView);
     this.formFactory = checkNotNull(formFactory);
   }
@@ -117,13 +122,17 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
             .flashing("error", e.getLocalizedMessage());
       }
 
+      ReadOnlyQuestionService roQuestionService =
+          questionService.getReadOnlyQuestionService().toCompletableFuture().join();
+
       return redirect(
               routes.AdminProgramBlockPredicatesController.edit(programId, blockDefinitionId))
           .flashing(
               "success",
               String.format(
                   "Saved visibility condition: %s %s",
-                  action.toDisplayString(), leafExpression.toDisplayString(ImmutableList.of())));
+                  action.toDisplayString(),
+                  leafExpression.toDisplayString(roQuestionService.getUpToDateQuestions())));
     }
   }
 


### PR DESCRIPTION
### After
<img width="457" alt="Screen Shot 2021-06-29 at 11 10 52 AM" src="https://user-images.githubusercontent.com/5732310/123849813-17daa600-d8ce-11eb-999e-d9a1dd171041.png">

### Before
<img width="456" alt="Screen Shot 2021-06-29 at 11 10 28 AM" src="https://user-images.githubusercontent.com/5732310/123849785-0f826b00-d8ce-11eb-82b4-ad4dab02070e.png">

### Issue(s)
Works toward #322
