### PR TITLE
Add an aria-label to the Edit link in application review page

### DIFF
--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -18,6 +18,7 @@ public enum MessageKey {
   ADDRESS_VALIDATION_STATE_REQUIRED("validation.stateRequired"),
   ADDRESS_VALIDATION_STREET_REQUIRED("validation.streetRequired"),
   ADDRESS_VALIDATION_ZIPCODE_REQUIRED("validation.zipcodeRequired"),
+  ARIA_LABEL_EDIT("aria-label.edit"),
   BUTTON_APPLY("button.apply"),
   BUTTON_APPLY_SR("button.applySr"),
   BUTTON_CONTINUE("button.continue"),

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -18,7 +18,7 @@ public enum MessageKey {
   ADDRESS_VALIDATION_STATE_REQUIRED("validation.stateRequired"),
   ADDRESS_VALIDATION_STREET_REQUIRED("validation.streetRequired"),
   ADDRESS_VALIDATION_ZIPCODE_REQUIRED("validation.zipcodeRequired"),
-  ARIA_LABEL_EDIT("aria-label.edit"),
+  ARIA_LABEL_EDIT("ariaLabel.edit"),
   BUTTON_APPLY("button.apply"),
   BUTTON_APPLY_SR("button.applySr"),
   BUTTON_CONTINUE("button.continue"),

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
@@ -193,7 +193,10 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
                   Styles.PR_2,
                   Styles.TEXT_BLUE_600,
                   StyleUtils.hover(Styles.TEXT_BLUE_700))
-              .asAnchorText();
+              .asAnchorText()
+              .attr(
+                  "aria-label",
+                  messages.at(MessageKey.ARIA_LABEL_EDIT.getKeyName(), data.questionText()));
       ContainerTag editContent =
           div(editAction)
               .withClasses(

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -152,7 +152,7 @@ link.edit=Edit
 
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
-aria-label.edit=Edit {0}
+ariaLabel.edit=Edit {0}
 
 # Program Preview Title
 title.programPreview=Program application preview

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -150,10 +150,14 @@ link.begin=Start here
 # The text that appears next to an answered question that the applicant can click on to modify the response.
 link.edit=Edit
 
-# Program Prewiew Title
+# An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
+# question, so this might say "Edit What is your name?". The {0} variable is the question text.
+aria-label.edit=Edit {0}
+
+# Program Preview Title
 title.programPreview=Program application preview
 
-# Program Rewiew Title
+# Program Review Title
 title.programReview=Program application review
 
 #---------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Description
The "Edit" link does not provide enough context to know what you are editing. This adds an `aria-label` so screen readers will read out the question you are editing 

Verified with a Chrome screen reader

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1464 
<img width="796" alt="Screen Shot 2021-06-29 at 12 01 47 PM" src="https://user-images.githubusercontent.com/8559046/123853013-cdf3bf00-d8d1-11eb-9132-782424cf4a67.png">
