### PR TITLE
Leave export options out of the enumerator question edit view

### DIFF
--- a/universal-application-tool-0.0.1/app/forms/QuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/QuestionForm.java
@@ -9,6 +9,7 @@ import models.Question;
 import models.QuestionTag;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
+import services.export.ExporterService;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
@@ -130,6 +131,10 @@ public abstract class QuestionForm {
   }
 
   public String getQuestionExportState() {
+    if (ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(this.getQuestionType())) {
+      return QuestionTag.NON_DEMOGRAPHIC.getValue();
+    }
+
     if (this.questionExportState == null) {
       Question q = new Question(this.qd);
       q.refresh();

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -36,6 +37,7 @@ import services.program.ProgramQuestionDefinition;
 import services.program.ProgramService;
 import services.question.QuestionService;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionType;
 
 public class ExporterService {
   private final ExporterFactory exporterFactory;
@@ -45,6 +47,9 @@ public class ExporterService {
 
   private static final String HEADER_SPACER_ENUM = " - ";
   private static final String HEADER_SPACER_SCALAR = " ";
+
+  public static final ImmutableSet<QuestionType> NON_EXPORTED_QUESTION_TYPES =
+      ImmutableSet.of(QuestionType.ENUMERATOR, QuestionType.STATIC);
 
   @Inject
   public ExporterService(
@@ -259,7 +264,7 @@ public class ExporterService {
         ImmutableList.of(QuestionTag.DEMOGRAPHIC, QuestionTag.DEMOGRAPHIC_PII)) {
       for (QuestionDefinition questionDefinition :
           this.questionService.getQuestionsForTag(tagType)) {
-        if (questionDefinition.isEnumerator()) {
+        if (NON_EXPORTED_QUESTION_TYPES.contains(questionDefinition.getQuestionType())) {
           continue; // Do not include Enumerator answers in CSVs.
         }
         // Use a program question definition that doesn't have a program associated with it,

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -16,6 +16,7 @@ import repository.QuestionRepository;
 import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
+import services.export.ExporterService;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
@@ -146,6 +147,11 @@ public final class QuestionServiceImpl implements QuestionService {
   @Override
   public void setExportState(QuestionDefinition questionDefinition, QuestionTag questionExportState)
       throws QuestionNotFoundException, InvalidUpdateException {
+    if (ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(
+        questionDefinition.getQuestionType())) {
+      return;
+    }
+
     Optional<Question> questionMaybe =
         questionRepository.lookupQuestion(questionDefinition.getId()).toCompletableFuture().join();
     if (questionMaybe.isEmpty()) {

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -22,6 +22,7 @@ import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http.Request;
 import play.twirl.api.Content;
+import services.export.ExporterService;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.EnumeratorQuestionDefinition;
@@ -287,7 +288,6 @@ public final class QuestionEditView extends BaseHtmlView {
                       .map(String::valueOf)
                       .orElse(NO_ENUMERATOR_ID_STRING)));
     }
-    boolean isStaticQuestionType = questionForm.getQuestionType() == QuestionType.STATIC;
 
     ContainerTag questionHelpTextField =
         FieldWithLabel.textArea()
@@ -298,7 +298,7 @@ public final class QuestionEditView extends BaseHtmlView {
             .setDisabled(!submittable)
             .setValue(questionForm.getQuestionHelpText())
             .getContainer();
-    if (isStaticQuestionType) { // Hide help text for static questions.
+    if (questionType.equals(QuestionType.STATIC)) { // Hide help text for static questions.
       questionHelpTextField.withClasses(Styles.HIDDEN);
     }
 
@@ -325,7 +325,7 @@ public final class QuestionEditView extends BaseHtmlView {
 
     formTag.with(QuestionConfig.buildQuestionConfig(questionForm));
 
-    if (!isStaticQuestionType) {
+    if (!ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(questionType)) {
       formTag.with(
           div().withId("demographic-field-content").with(buildDemographicFields(questionForm)));
     }


### PR DESCRIPTION
Enumerators are not exported, so the admin shouldn't have to see options for configuring their export.

![image](https://user-images.githubusercontent.com/12072571/123857219-e5817680-d8d6-11eb-81dd-a743cd800ac3.png)

Fixes #1533. Static questions also do not have export options in the question edit view, but when updating it checks for export state which is problematic because it doesn't exist in the form. The changes should fix the bug for both enumerators and static questions.