### PR TITLE
Add an aria-label for the language select in applicant header

### DIFF
--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -53,7 +53,7 @@ public enum MessageKey {
   EXTERNAL_LINK("link.externalLink"),
   FILEUPLOAD_VALIDATION_FILE_REQUIRED("validation.fileRequired"),
   FOOTER_SUPPORT_LINK_DESCRIPTION("footer.supportLinkDescription"),
-  LANGUAGE_LABEL("label.language"),
+  LANGUAGE_LABEL_SR("label.languageSr"),
   LINK_ADMIN_LOGIN("link.adminLogin"),
   LINK_ALL_DONE("link.allDone"),
   LINK_APPLY_TO_ANOTHER_PROGRAM("link.applyToAnotherProgram"),

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -53,6 +53,7 @@ public enum MessageKey {
   EXTERNAL_LINK("link.externalLink"),
   FILEUPLOAD_VALIDATION_FILE_REQUIRED("validation.fileRequired"),
   FOOTER_SUPPORT_LINK_DESCRIPTION("footer.supportLinkDescription"),
+  LANGUAGE_LABEL("label.language"),
   LINK_ADMIN_LOGIN("link.adminLogin"),
   LINK_ALL_DONE("link.allDone"),
   LINK_APPLY_TO_ANOTHER_PROGRAM("link.applyToAnotherProgram"),

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
@@ -134,7 +134,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
             languageSelector
                 .renderDropdown(preferredLanguage)
                 .attr("onchange", "this.form.submit()")
-                .attr("aria-label", messages.at(MessageKey.LANGUAGE_LABEL.getKeyName()));
+                .attr("aria-label", messages.at(MessageKey.LANGUAGE_LABEL_SR.getKeyName()));
         languageForm =
             form()
                 .withAction(updateLanguageAction)

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantLayout.java
@@ -108,11 +108,12 @@ public class ApplicantLayout extends BaseHtmlLayout {
         .with(branding())
         .with(maybeRenderTiButton(profile, userName))
         .with(
-            div(getLanguageForm(request, profile), logoutButton(userName, messages))
+            div(getLanguageForm(request, profile, messages), logoutButton(userName, messages))
                 .withClasses(Styles.JUSTIFY_SELF_END, Styles.FLEX, Styles.FLEX_ROW));
   }
 
-  private ContainerTag getLanguageForm(Http.Request request, Optional<CiviFormProfile> profile) {
+  private ContainerTag getLanguageForm(
+      Http.Request request, Optional<CiviFormProfile> profile, Messages messages) {
     ContainerTag languageForm = div();
     if (profile.isPresent()) { // Show language switcher.
       long userId = profile.get().getApplicant().join().id;
@@ -132,7 +133,8 @@ public class ApplicantLayout extends BaseHtmlLayout {
         ContainerTag languageDropdown =
             languageSelector
                 .renderDropdown(preferredLanguage)
-                .attr("onchange", "this.form.submit()");
+                .attr("onchange", "this.form.submit()")
+                .attr("aria-label", messages.at(MessageKey.LANGUAGE_LABEL.getKeyName()));
         languageForm =
             form()
                 .withAction(updateLanguageAction)

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -26,7 +26,7 @@ button.untranslatedSubmit=Submit
 footer.supportLinkDescription=For technical support, contact
 
 # Label read by screen readers for the language dropdown shown in the page header.
-label.language=Choose a language
+label.languageSr=Choose a language
 
 # Message with user's name to show who you are logged in as.
 header.userName=Logged in as {0}

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -25,6 +25,9 @@ button.untranslatedSubmit=Submit
 # Message displayed before the support email address in the page footer for applicants.
 footer.supportLinkDescription=For technical support, contact
 
+# Label read by screen readers for the language dropdown shown in the page header.
+label.language=Choose a language
+
 # Message with user's name to show who you are logged in as.
 header.userName=Logged in as {0}
 


### PR DESCRIPTION
### Description
Adds an aria-label to the language select in applicant header

The screen reader reads "Tagalog, Choose a language, menu pop up collapsed, button"

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1471 
<img width="818" alt="Screen Shot 2021-06-29 at 2 22 07 PM" src="https://user-images.githubusercontent.com/8559046/123869895-727ffc00-d8e6-11eb-8fa7-8bb15420c9e9.png">
