### PR TITLE
Fix modal header spacing between title and close button

### DIFF
--- a/universal-application-tool-0.0.1/app/views/components/Modal.java
+++ b/universal-application-tool-0.0.1/app/views/components/Modal.java
@@ -57,6 +57,7 @@ public class Modal {
     return div()
         .withClasses(BaseStyles.MODAL_HEADER)
         .with(div(modalTitle).withClasses(Styles.TEXT_LG))
+        .with(div().withClasses(Styles.FLEX_GROW))
         .with(div("x").withId(modalId + "-close").withClasses(BaseStyles.MODAL_CLOSE_BUTTON));
   }
 

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -120,7 +120,14 @@ public final class BaseStyles {
           Styles.OVERFLOW_Y_AUTO);
 
   public static final String MODAL_HEADER =
-      StyleUtils.joinStyles(Styles.STICKY, Styles.TOP_0, Styles.BG_GRAY_200, Styles.P_2);
+      StyleUtils.joinStyles(
+          Styles.STICKY,
+          Styles.TOP_0,
+          Styles.BG_GRAY_200,
+          Styles.P_2,
+          Styles.FLEX,
+          Styles.GAP_4,
+          Styles.PLACE_ITEMS_CENTER);
   /** Generic style for for the button for the modal. */
   public static final String MODAL_BUTTON =
       StyleUtils.joinStyles(
@@ -135,12 +142,10 @@ public final class BaseStyles {
   /** Generic styles for the button to close the modal. This is shared across all modals. */
   public static final String MODAL_CLOSE_BUTTON =
       StyleUtils.joinStyles(
-          Styles.ABSOLUTE,
-          Styles.TOP_2,
-          Styles.RIGHT_4,
           Styles.FONT_BOLD,
           Styles.CURSOR_POINTER,
           Styles.OPACITY_60,
+          Styles.PX_2,
           StyleUtils.hover(Styles.OPACITY_100));
   /**
    * Simple styling for the div that holds the custom modal content. Should just have decent margins


### PR DESCRIPTION
### Description
Use `flex-grow` and `gap-4` to make sure there is space between the modal header and the "x" that closes the modal.

OLD
![image](https://user-images.githubusercontent.com/12072571/123882129-fe038800-d8fa-11eb-844f-db156541eaae.png)

NEW
![image](https://user-images.githubusercontent.com/12072571/123882147-065bc300-d8fb-11eb-9f59-caf2e5801a42.png)
