### PR TITLE
Remove redundant '- CiviForm' in main page title.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -63,7 +63,7 @@ public class ProgramIndexView extends BaseHtmlView {
       ImmutableList<ProgramDefinition> activePrograms,
       Optional<String> banner) {
     HtmlBundle bundle = layout.getBundle();
-    bundle.setTitle(messages.at(MessageKey.CONTENT_GET_BENEFITS.getKeyName()) + " - CiviForm");
+    bundle.setTitle(messages.at(MessageKey.CONTENT_GET_BENEFITS.getKeyName()));
     if (banner.isPresent()) {
       bundle.addToastMessages(ToastMessage.alert(banner.get()));
     }


### PR DESCRIPTION
### Description
Fixes https://github.com/seattle-uat/civiform/issues/1465.

From

<img width="238" alt="Screen Shot 2021-06-29 at 9 35 14 PM" src="https://user-images.githubusercontent.com/605324/123902566-eab7e300-d921-11eb-86f7-c6cb71f8c657.png">


To

<img width="236" alt="Screen Shot 2021-06-29 at 9 31 16 PM" src="https://user-images.githubusercontent.com/605324/123902530-daa00380-d921-11eb-87ce-b5473deb8b00.png">


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
