### PR TITLE
Use more specific selector in browser tests

### DIFF
--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -48,7 +48,7 @@ describe('normal application flow', () => {
 
     await adminQuestions.createNewVersion('dropdown-csv-download');
     await adminQuestions.gotoQuestionEditPage('dropdown-csv-download');
-    await page.click('button:text("Remove"):visible')
+    await page.click('#question-settings button:text("Remove"):visible')
     await page.click('text=Update');
     await adminPrograms.publishProgram(programName);
 

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -123,7 +123,7 @@ describe('normal application flow', () => {
     await loginAsAdmin(page);
     await adminQuestions.createNewVersion('favorite-trees-q');
     await adminQuestions.gotoQuestionEditPage('favorite-trees-q');
-    await page.click('button:text("Remove"):visible')
+    await page.click('#question-settings button:text("Remove"):visible')
     await page.click('text=Update');
     await adminPrograms.publishProgram(programName);
 

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -85,7 +85,7 @@ export class AdminPrograms {
   }
 
   async expectDraftProgram(programName: string) {
-    expect(await this.page.innerText(`div.border:has(:text("${programName}"), :text("DRAFT"))`)).not.toContain('New Version');
+    expect(await this.page.innerText(this.selectProgramCard(programName, 'DRAFT'))).not.toContain('New Version');
   }
 
   async expectActiveProgram(programName: string) {


### PR DESCRIPTION
### Description
Use more specific selectors to avoid selecting hidden elements, causing browser tests to time out.

