### PR TITLE
Add option to set modal width

### DIFF
--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -565,6 +565,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
     return Modal.builder("block-description-modal", blockDescriptionForm)
         .setModalTitle(modalTitle)
         .setTriggerButtonText(modalButtonText)
+        .setWidth(Styles.W_1_3)
         .build();
   }
 

--- a/universal-application-tool-0.0.1/app/views/components/Modal.java
+++ b/universal-application-tool-0.0.1/app/views/components/Modal.java
@@ -18,6 +18,7 @@ public class Modal {
   private String triggerButtonText;
   private Optional<Tag> triggerButtonContent;
   private String buttonStyles;
+  private Optional<String> width;
 
   private Modal(ModalBuilder builder) {
     this.modalId = builder.modalId;
@@ -26,12 +27,13 @@ public class Modal {
     this.triggerButtonText = builder.triggerButtonText;
     this.triggerButtonContent = builder.triggerButtonContent;
     this.buttonStyles = builder.buttonStyles;
+    this.width = builder.width;
   }
 
   public Tag getContainerTag() {
     return div()
         .withId(modalId)
-        .withClasses(ReferenceClasses.MODAL, BaseStyles.MODAL)
+        .withClasses(ReferenceClasses.MODAL, BaseStyles.MODAL, width.orElse(""))
         .with(getModalHeader())
         .with(getContent());
   }
@@ -76,6 +78,7 @@ public class Modal {
     private String triggerButtonText;
 
     private Optional<Tag> triggerButtonContent = Optional.empty();
+    private Optional<String> width = Optional.empty();
 
     public ModalBuilder(String modalId, Tag content) {
       this.modalId = modalId;
@@ -99,6 +102,11 @@ public class Modal {
 
     public ModalBuilder setTriggerButtonStyles(String buttonStyles) {
       this.buttonStyles = buttonStyles;
+      return this;
+    }
+
+    public ModalBuilder setWidth(String width) {
+      this.width = Optional.of(width);
       return this;
     }
 


### PR DESCRIPTION
### Description
Allow `Modal` to have its width set, and then set the block name/desc modal to w-1/3.

old
![image](https://user-images.githubusercontent.com/12072571/124012934-8c791780-d996-11eb-8314-584e8ec88b5d.png)

new
![image](https://user-images.githubusercontent.com/12072571/124012888-7ff4bf00-d996-11eb-94b9-ca8200029660.png)
