### PR TITLE
Summary data + unanswered questions

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -152,7 +152,7 @@ describe('End to end enumerator test', () => {
     expect(await page.innerText("#application-summary")).not.toContain("12");
 
     // Go back and add an enumerator answer.
-    await page.click('.cf-applicant-summary-row:has(div:has-text("Household members")) a:has-text("Edit")');
+    await page.click('.cf-applicant-summary-row:has(div:has-text("Household members")) a:has-text("Continue")');
     await applicantQuestions.addEnumeratorAnswer("Tweety");
     await applicantQuestions.clickNext();
     await applicantQuestions.answerNameQuestion("Tweety", "Bird");

--- a/universal-application-tool-0.0.1/app/services/applicant/AnswerData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/AnswerData.java
@@ -37,6 +37,9 @@ public abstract class AnswerData {
   /** The localized question text */
   public abstract String questionText();
 
+  /** True if this answer represents an answer, or false for a skipped question. */
+  public abstract boolean isAnswered();
+
   /** The applicant's response to the question. */
   public abstract String answerText();
 
@@ -68,6 +71,8 @@ public abstract class AnswerData {
     public abstract Builder setQuestionIndex(int questionIndex);
 
     public abstract Builder setQuestionText(String questionText);
+
+    public abstract Builder setIsAnswered(boolean isAnswered);
 
     public abstract Builder setAnswerText(String answerText);
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -124,9 +124,10 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
       for (int questionIndex = 0; questionIndex < questions.size(); questionIndex++) {
         ApplicantQuestion question = questions.get(questionIndex);
         // Don't include static content in summary data.
-        if (question.getType() == QuestionType.STATIC) {
+        if (question.getType().equals(QuestionType.STATIC)) {
           continue;
         }
+        boolean isAnswered = question.errorsPresenter().isAnswered();
         String questionText = question.getQuestionText();
         String answerText = question.errorsPresenter().getAnswerString();
         Optional<Long> timestamp = question.getLastUpdatedTimeMetadata();
@@ -141,6 +142,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
                 .setRepeatedEntity(block.getRepeatedEntity())
                 .setQuestionIndex(questionIndex)
                 .setQuestionText(questionText)
+                .setIsAnswered(isAnswered)
                 .setAnswerText(answerText)
                 .setFileKey(getFileKey(question))
                 .setTimestamp(timestamp.orElse(AnswerData.TIMESTAMP_NOT_SET))

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
@@ -77,7 +77,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       applicationSummary.with(
           renderQuestionSummary(
               answerData, messages, params.applicantId(), params.inReview(), isFirstUnanswered));
-      isFirstUnanswered = isFirstUnanswered && answerData.timestamp() > 0;
+      isFirstUnanswered = isFirstUnanswered && answerData.isAnswered();
       previousRepeatedEntity = currentRepeatedEntity;
     }
 
@@ -134,8 +134,6 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       long applicantId,
       boolean inReview,
       boolean isFirstUnanswered) {
-    boolean isAnswered = data.timestamp() > 0;
-
     ContainerTag questionPrompt =
         div(data.questionText()).withClasses(Styles.FLEX_AUTO, Styles.FONT_SEMIBOLD);
     ContainerTag questionContent =
@@ -175,16 +173,16 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
         div(answerContent).withClasses(Styles.FLEX, Styles.FLEX_ROW, Styles.PR_2);
 
     // Maybe link to block containing specific question.
-    if (isAnswered || isFirstUnanswered) {
+    if (data.isAnswered() || isFirstUnanswered) {
       String editText = messages.at(MessageKey.LINK_EDIT.getKeyName());
-      if (!isAnswered) {
+      if (!data.isAnswered()) {
         editText =
             inReview
                 ? messages.at(MessageKey.BUTTON_CONTINUE.getKeyName())
                 : messages.at(MessageKey.LINK_BEGIN.getKeyName());
       }
       String editLink =
-          (!isAnswered && !inReview)
+          (!data.isAnswered() && !inReview)
               ? routes.ApplicantProgramBlocksController.edit(
                       applicantId, data.programId(), data.blockId())
                   .url()
@@ -219,7 +217,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
         .withClasses(
             ReferenceClasses.APPLICANT_SUMMARY_ROW,
             marginIndentClass(data.repeatedEntity().map(RepeatedEntity::depth).orElse(0)),
-            isAnswered ? "" : Styles.BG_YELLOW_50,
+            data.isAnswered() ? "" : Styles.BG_YELLOW_50,
             Styles.MY_0,
             Styles.P_2,
             Styles.PT_4,


### PR DESCRIPTION
### Description
Rendering summary data checks the timestamp to see if it answered. That isn't how it works anymore. Metadata exists if a question is visited - whether it is answered or not. 

This PR adds an explicit `isAnswered` member to `SummaryData` which is used instead of checking the timestamp metadata.

Problem:
![image](https://user-images.githubusercontent.com/12072571/124054784-92431d00-d9d7-11eb-8e77-e69ccb4b14a3.png)