### PR TITLE
Success toast should appear when action is completed successfully

### DIFF
--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -18,6 +18,21 @@ export class AdminQuestions {
     expect(await this.page.innerText('h1')).toEqual('All Questions');
   }
 
+  async expectAdminQuestionsPageWithSuccessToast(successText: string) {
+    const toastContainer = await this.page.innerHTML('#toast-container');
+    expect(toastContainer).toContain('bg-green-200');
+    expect(toastContainer).toContain(successText);
+    await this.expectAdminQuestionsPage();
+  }
+
+  async expectAdminQuestionsPageWithUpdateSuccessToast() {
+    await this.expectAdminQuestionsPageWithSuccessToast('updated');
+  }
+
+  async expectAdminQuestionsPageWithCreateSuccessToast() {
+    await this.expectAdminQuestionsPageWithSuccessToast('created');
+  }
+
   async fillInQuestionBasics(questionName: string,
     description: string,
     questionText: string,
@@ -117,6 +132,7 @@ export class AdminQuestions {
     await this.gotoQuestionEditPage(questionName);
     const newQuestionText = await this.updateQuestionText(' updated');
     await this.page.click('button:text("Update")');
+    await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName, newQuestionText);
   }
 
@@ -124,6 +140,7 @@ export class AdminQuestions {
     await this.gotoQuestionEditPage(questionName);
     await this.page.fill('text=Question Help Text', questionHelpText);
     await this.page.click('button:text("Update")');
+    await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName);
   }
 
@@ -131,6 +148,7 @@ export class AdminQuestions {
     await this.gotoQuestionEditPage(questionName);
     await this.page.click('text="Export Value"');
     await this.page.click('button:text("Update")');
+    await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName);
   }
 
@@ -138,6 +156,7 @@ export class AdminQuestions {
     await this.gotoQuestionEditPage(questionName);
     await this.page.click('text="Export Obfuscated"');
     await this.page.click('button:text("Update")');
+    await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName);
   }
 
@@ -147,6 +166,7 @@ export class AdminQuestions {
     await this.expectQuestionEditPage(questionName);
     const newQuestionText = await this.updateQuestionText(' new version');
     await this.page.click('button:text("Update")');
+    await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName, newQuestionText);
   }
 
@@ -220,7 +240,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -241,7 +261,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -269,7 +289,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -297,7 +317,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -318,7 +338,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -339,7 +359,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -360,7 +380,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -388,7 +408,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")')
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -409,7 +429,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -430,7 +450,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }
@@ -456,7 +476,7 @@ export class AdminQuestions {
 
     await this.page.click('button:has-text("Create")');
 
-    await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPageWithCreateSuccessToast();
 
     await this.expectDraftQuestionExist(questionName, questionText);
   }

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -27,6 +27,7 @@ export class AdminQuestions {
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {
     const toastContainer = await this.page.innerHTML('#toast-container');
+
     expect(toastContainer).toContain('bg-green-200');
     expect(toastContainer).toContain(successText);
     await this.expectAdminQuestionsPage();
@@ -57,6 +58,7 @@ export class AdminQuestions {
     // This function should only be called on question create/edit page.
     const questionText = await this.page.textContent('#question-text-textarea');
     const updatedText = questionText + updateText;
+
     await this.page.fill('text=Question Text', updatedText);
     return updatedText;
   }
@@ -138,6 +140,7 @@ export class AdminQuestions {
   async updateQuestion(questionName: string) {
     await this.gotoQuestionEditPage(questionName);
     const newQuestionText = await this.updateQuestionText(' updated');
+
     await this.clickSubmitButtonAndNavigate('Update');
     await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName, newQuestionText);
@@ -172,6 +175,7 @@ export class AdminQuestions {
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("New Version")'));
     await this.expectQuestionEditPage(questionName);
     const newQuestionText = await this.updateQuestionText(' new version');
+
     await this.clickSubmitButtonAndNavigate('Update');
     await this.expectAdminQuestionsPageWithUpdateSuccessToast();
     await this.expectDraftQuestionExist(questionName, newQuestionText);

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
@@ -63,7 +63,8 @@ public final class QuestionsListView extends BaseHtmlView {
                 renderSummary(activeAndDraftQuestions));
 
     if (maybeFlash.isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.error(maybeFlash.get()).setDismissible(false));
+      // Right now, we only show success messages on render of this page, so the ToastMessage is rendered that way by default.
+      htmlBundle.addToastMessages(ToastMessage.success(maybeFlash.get()).setDismissible(false));
     }
 
     return layout.renderCentered(htmlBundle);

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
@@ -63,7 +63,8 @@ public final class QuestionsListView extends BaseHtmlView {
                 renderSummary(activeAndDraftQuestions));
 
     if (maybeFlash.isPresent()) {
-      // Right now, we only show success messages on render of this page, so the ToastMessage is rendered that way by default.
+      // Right now, we only show success messages when this page is rendered with maybeFlash set,
+      // so we use the success ToastMessage type by default.
       htmlBundle.addToastMessages(ToastMessage.success(maybeFlash.get()).setDismissible(false));
     }
 


### PR DESCRIPTION
### Description
Previously, error toasts were displaying on redirect to the questions page. When the render function on the QuestionListView file is called with the optional "maybeFlash" set, it always should be a success message (since we only render to this page with that set on "Create" or "Update"). I also considered having a "maybeToastType" optional param that can be passed along with the type (success / error / etc.) that the toast should be, but this seems like over-engineering considering we don't know if there would be an error case where we navigate to the questions list (all error cases right now we stay on the question page).  

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary - N/A

### Issue(s)
Fixes #1356
