### PR TITLE
Make sure static questions are always shown

### DIFF
--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -21,13 +21,16 @@ describe('normal application flow', () => {
     await adminQuestions.addNumberQuestion('number-q');
     await adminQuestions.addTextQuestion('text-q');
     await adminQuestions.addRadioButtonQuestion('radio-q', ['one', 'two', 'three']);
+    await adminQuestions.addStaticQuestion('static-q');
+    await adminQuestions.addStaticQuestion('second-static-q');
 
     const programName = 'a shiny new program';
     await adminPrograms.addProgram(programName);
     await adminPrograms.editProgramBlock(programName, 'block description', ['date-q', 'address-q', 'name-q', 'radio-q', 'email-q']);
     await adminPrograms.addProgramBlock(programName, 'another description', ['ice-cream-q', 'favorite-trees-q', 'number-q', 'text-q']);
-    await adminPrograms.addProgramBlock(programName, 'third description', ['fileupload-q']);
+    await adminPrograms.addProgramBlock(programName, 'third description', ['fileupload-q', 'static-q']);
     await adminPrograms.addProgramBlock(programName, 'fourth description', ['scared-of-q', 'favorite-rats-q']);
+    await adminPrograms.addProgramBlock(programName, 'fifth description', ['second-static-q']);
 
     await adminPrograms.gotoAdminProgramsPage();
     await adminPrograms.expectDraftProgram(programName);
@@ -46,6 +49,8 @@ describe('normal application flow', () => {
     await adminQuestions.expectActiveQuestionExist('text-q');
     await adminQuestions.expectActiveQuestionExist('radio-q');
     await adminQuestions.expectActiveQuestionExist('email-q');
+    await adminQuestions.expectActiveQuestionExist('static-q');
+    await adminQuestions.expectActiveQuestionExist('second-static-q');
 
     await logout(page);
     await loginAsTestUser(page);
@@ -88,11 +93,16 @@ describe('normal application flow', () => {
 
     // fill 3rd application block.
     await applicantQuestions.answerFileUploadQuestion('file key');
+    await applicantQuestions.seeStaticQuestion('static question text');
     await applicantQuestions.clickUpload();
 
     // fill 4th application block.
     await applicantQuestions.answerCheckboxQuestion(['clowns']);
     await applicantQuestions.answerCheckboxQuestion(['sewage']);
+    await applicantQuestions.clickNext();
+
+    // verify we can see static question on 5th block.
+    await applicantQuestions.seeStaticQuestion('static question text');
     await applicantQuestions.clickNext();
 
     // submit

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -354,6 +354,29 @@ export class AdminQuestions {
     await this.expectDraftQuestionExist(questionName, questionText);
   }
 
+  async addStaticQuestion(questionName: string,
+      description = 'static description',
+      questionText = 'static question text',
+      enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
+      await this.gotoAdminQuestionsPage();
+      // Wait for dropdown event listener to be attached
+      await this.page.waitForLoadState('load');
+      await this.page.click('#create-question-button');
+
+      await this.page.click('#create-static-question');
+
+     await this.page.fill('label:has-text("Name")', questionName);
+     await this.page.fill('label:has-text("Description")', description);
+     await this.page.fill('label:has-text("Question Text")', questionText);
+     await this.page.selectOption('#question-enumerator-select', { label: enumeratorName });
+
+      await this.clickSubmitButtonAndNavigate('Create');
+
+      await this.expectAdminQuestionsPage();
+
+      await this.expectDraftQuestionExist(questionName, questionText);
+    }
+
   async addNameQuestion(questionName: string,
     description = 'name description',
     questionText = 'name question text',

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -116,4 +116,8 @@ export class ApplicantQuestions {
     expect(await this.page.innerHTML('head'))
       .toContain('<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">');
   }
+
+  async seeStaticQuestion(questionText: string){
+      expect(await this.page.textContent('html')).toContain(questionText);
+    }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -14,6 +14,7 @@ import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.PresentsErrors;
 import services.program.BlockDefinition;
 import services.program.predicate.PredicateDefinition;
+import services.question.types.QuestionType;
 import services.question.types.ScalarType;
 
 /**
@@ -134,6 +135,16 @@ public final class Block {
       path = path.withoutArrayReference();
     }
     return Optional.ofNullable(getContextualizedScalars().get(path));
+  }
+
+  /**
+   * Returns whether the block contains any static questions regardless of what other questions are
+   * present and whether they are answered or not.
+   */
+  public boolean containsStatic() {
+    return getQuestions().stream()
+        .map(ApplicantQuestion::getType)
+        .anyMatch(type -> type.equals(QuestionType.STATIC));
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -68,7 +68,8 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
           getBlocks(
               block ->
                   (!block.isCompleteWithoutErrors()
-                          || block.wasCompletedInProgram(programDefinition.id()))
+                          || block.wasCompletedInProgram(programDefinition.id())
+                          || block.containsStatic())
                       && showBlock(block));
     }
     return currentBlockList;
@@ -106,7 +107,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   @Override
   public Optional<Block> getFirstIncompleteBlock() {
     return getInProgressBlocks().stream()
-        .filter(block -> !block.isCompleteWithoutErrors())
+        .filter(block -> !block.isCompleteWithoutErrors() || block.containsStatic())
         .findFirst();
   }
 

--- a/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/BlockTest.java
@@ -4,8 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import org.junit.Test;
+import services.LocalizedStrings;
 import services.Path;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.Scalar;
@@ -14,6 +17,7 @@ import services.program.ProgramQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.ScalarType;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import support.QuestionAnswerer;
 import support.TestQuestionBank;
@@ -28,6 +32,14 @@ public class BlockTest {
       (NameQuestionDefinition) testQuestionBank.applicantName().getQuestionDefinition();
   private static final TextQuestionDefinition COLOR_QUESTION =
       (TextQuestionDefinition) testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
+  private static final StaticContentQuestionDefinition STATIC_QUESTION =
+      new StaticContentQuestionDefinition(
+          OptionalLong.of(123L),
+          "more info about something",
+          Optional.empty(),
+          "Shows more info to the applicant",
+          LocalizedStrings.of(Locale.US, "This is more info"),
+          LocalizedStrings.of(Locale.US, ""));
 
   @Test
   public void createNewBlock() {
@@ -180,6 +192,7 @@ public class BlockTest {
     Block block = new Block("1", definition, new ApplicantData(), Optional.empty());
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
+    assertThat(block.containsStatic()).isFalse();
   }
 
   @Test
@@ -191,6 +204,7 @@ public class BlockTest {
 
     // No questions filled in yet.
     assertThat(block.isCompleteWithoutErrors()).isFalse();
+    assertThat(block.containsStatic()).isFalse();
   }
 
   @Test
@@ -216,6 +230,48 @@ public class BlockTest {
     Block block = new Block("1", definition, applicantData, Optional.empty());
 
     assertThat(block.isCompleteWithoutErrors()).isTrue();
+  }
+
+  @Test
+  public void isComplete_returnsTrueIsAllQuestionsAnswered_includesStatic() {
+    ApplicantData applicantData = new ApplicantData();
+    // Fill in all questions.
+    answerNameQuestion(applicantData, UNUSED_PROGRAM_ID);
+    answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
+    BlockDefinition definition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(ProgramQuestionDefinition.create(NAME_QUESTION, Optional.empty()))
+            .addQuestion(ProgramQuestionDefinition.create(COLOR_QUESTION, Optional.empty()))
+            .addQuestion(ProgramQuestionDefinition.create(STATIC_QUESTION, Optional.empty()))
+            .build();
+
+    Block block = new Block("1", definition, applicantData, Optional.empty());
+
+    assertThat(block.isCompleteWithoutErrors()).isTrue();
+    assertThat(block.containsStatic()).isTrue();
+  }
+
+  @Test
+  public void isComplete_onlyStatic() {
+    ApplicantData applicantData = new ApplicantData();
+    // Fill in all questions.
+    answerNameQuestion(applicantData, UNUSED_PROGRAM_ID);
+    answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
+    BlockDefinition definition =
+        BlockDefinition.builder()
+            .setId(20L)
+            .setName("")
+            .setDescription("")
+            .addQuestion(ProgramQuestionDefinition.create(STATIC_QUESTION, Optional.empty()))
+            .build();
+
+    Block block = new Block("1", definition, applicantData, Optional.empty());
+
+    assertThat(block.isCompleteWithoutErrors()).isTrue();
+    assertThat(block.containsStatic()).isTrue();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -33,6 +33,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
   private QuestionDefinition nameQuestion;
   private QuestionDefinition colorQuestion;
   private QuestionDefinition addressQuestion;
+  private QuestionDefinition staticQuestion;
   private ApplicantData applicantData;
   private ProgramDefinition programDefinition;
 
@@ -42,6 +43,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
     colorQuestion = testQuestionBank.applicantFavoriteColor().getQuestionDefinition();
     addressQuestion = testQuestionBank.applicantAddress().getQuestionDefinition();
+    staticQuestion = testQuestionBank.staticContent().getQuestionDefinition();
     programDefinition =
         ProgramBuilder.newDraftProgram("My Program")
             .withLocalizedName(Locale.GERMAN, "Mein Programm")
@@ -72,16 +74,57 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
 
   @Test
   public void getAllBlocks_includesPreviouslyCompletedBlocks() {
+    ProgramDefinition programDefinitionWithStatic =
+        ProgramBuilder.newDraftProgram("My Program")
+            .withLocalizedName(Locale.GERMAN, "Mein Programm")
+            .withBlock("Block one")
+            .withRequiredQuestionDefinition(nameQuestion)
+            .withBlock("Block two")
+            .withRequiredQuestionDefinition(colorQuestion)
+            .withRequiredQuestionDefinition(addressQuestion)
+            .withBlock("Block three")
+            .withRequiredQuestionDefinition(staticQuestion)
+            .buildDefinition();
     // Answer first block in a separate program
-    answerNameQuestion(programDefinition.id() + 1);
+    answerNameQuestion(programDefinitionWithStatic.id() + 1);
 
     ReadOnlyApplicantProgramService subject =
-        new ReadOnlyApplicantProgramServiceImpl(applicantData, programDefinition, FAKE_BASE_URL);
+        new ReadOnlyApplicantProgramServiceImpl(
+            applicantData, programDefinitionWithStatic, FAKE_BASE_URL);
     ImmutableList<Block> allBlocks = subject.getAllActiveBlocks();
 
-    assertThat(allBlocks).hasSize(2);
+    assertThat(allBlocks).hasSize(3);
     assertThat(allBlocks.get(0).getName()).isEqualTo("Block one");
     assertThat(allBlocks.get(1).getName()).isEqualTo("Block two");
+    assertThat(allBlocks.get(2).getName()).isEqualTo("Block three");
+  }
+
+  @Test
+  public void getAllBlocks_onlyStaticBlock() {
+    ProgramDefinition programDefinitionWithStatic =
+        ProgramBuilder.newDraftProgram("My Program")
+            .withLocalizedName(Locale.GERMAN, "Mein Programm")
+            .withBlock("Block one")
+            .withRequiredQuestionDefinition(staticQuestion)
+            .buildDefinition();
+
+    ReadOnlyApplicantProgramService subject =
+        new ReadOnlyApplicantProgramServiceImpl(
+            applicantData, programDefinitionWithStatic, FAKE_BASE_URL);
+    ImmutableList<Block> allBlocks = subject.getAllActiveBlocks();
+
+    assertThat(allBlocks).hasSize(1);
+    assertThat(allBlocks.get(0).getName()).isEqualTo("Block one");
+
+    ImmutableList<Block> inProgressBlocks = subject.getInProgressBlocks();
+
+    assertThat(inProgressBlocks).hasSize(1);
+    assertThat(inProgressBlocks.get(0).getName()).isEqualTo("Block one");
+
+    Optional<Block> firstIncompleteBlock = subject.getFirstIncompleteBlock();
+
+    assertThat(firstIncompleteBlock.isPresent()).isTrue();
+    assertThat(firstIncompleteBlock.get().getName()).isEqualTo("Block one");
   }
 
   @Test
@@ -113,6 +156,31 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     ImmutableList<Block> allBlocks = subject.getAllActiveBlocks();
 
     assertThat(allBlocks).hasSize(1);
+  }
+
+  @Test
+  public void getAllBlocks_includesBlockWithStaticEvenWhenOthersAreAnswered() {
+    ProgramDefinition program =
+        ProgramBuilder.newActiveProgram()
+            .withBlock("Block one") // Previous block with color question
+            .withRequiredQuestionDefinition(colorQuestion)
+            .withRequiredQuestionDefinition(staticQuestion)
+            .withBlock("Block two") // Block required unanswered question
+            .withRequiredQuestionDefinition(addressQuestion)
+            .buildDefinition();
+
+    // Answer color question
+    answerColorQuestion(program.id(), "blue");
+
+    ReadOnlyApplicantProgramService subject =
+        new ReadOnlyApplicantProgramServiceImpl(applicantData, program, FAKE_BASE_URL);
+
+    ImmutableList<Block> allBlocks = subject.getAllActiveBlocks();
+    Optional<Block> maybeBlock = subject.getFirstIncompleteBlock();
+
+    assertThat(allBlocks).hasSize(2);
+    assertThat(maybeBlock).isNotEmpty();
+    assertThat(maybeBlock.get().getName()).isEqualTo("Block one");
   }
 
   @Test


### PR DESCRIPTION
### Description
Change the logic to return blocks so that if a block contains a static question it is always shown to the user.  This is regardless of whether there are other questions on the block that have already been answered and would not have been shown again beforehand.  See issue #1555 for more detail.

Includes:
 - unit tests for all scenarios that could arise
 - Changed logic
 - browser test for a static question block to make sure it is shown to the user.

Fixes #1555

Peer programmed with ettengererin and dkatzz
