### PR TITLE
Fix styles so that Seattle logo isn't covering h1 text

### DIFF
--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -101,7 +101,11 @@ public class ProgramIndexView extends BaseHtmlView {
     ContainerTag infoLine2Div =
         div()
             .withText(infoTextLine2)
-            .withClasses(Styles.TEXT_SM, Styles.PX_6, Styles.PB_6, StyleUtils.responsiveSmall(Styles.TEXT_BASE));
+            .withClasses(
+                Styles.TEXT_SM,
+                Styles.PX_6,
+                Styles.PB_6,
+                StyleUtils.responsiveSmall(Styles.TEXT_BASE));
 
     ContainerTag seattleLogoDiv =
         div()

--- a/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ProgramIndexView.java
@@ -90,17 +90,18 @@ public class ProgramIndexView extends BaseHtmlView {
                 StyleUtils.responsiveSmall(Styles.TEXT_5XL),
                 Styles.FONT_SEMIBOLD,
                 Styles.MB_2,
+                Styles.PX_6,
                 StyleUtils.responsiveSmall(Styles.MB_6));
 
     ContainerTag infoLine1Div =
         div()
             .withText(infoTextLine1)
-            .withClasses(Styles.TEXT_SM, StyleUtils.responsiveSmall(Styles.TEXT_BASE));
+            .withClasses(Styles.TEXT_SM, Styles.PX_6, StyleUtils.responsiveSmall(Styles.TEXT_BASE));
 
     ContainerTag infoLine2Div =
         div()
             .withText(infoTextLine2)
-            .withClasses(Styles.TEXT_SM, StyleUtils.responsiveSmall(Styles.TEXT_BASE));
+            .withClasses(Styles.TEXT_SM, Styles.PX_6, Styles.PB_6, StyleUtils.responsiveSmall(Styles.TEXT_BASE));
 
     ContainerTag seattleLogoDiv =
         div()
@@ -112,7 +113,7 @@ public class ProgramIndexView extends BaseHtmlView {
                     .attr("aria-hidden", "true")
                     .attr("width", 175)
                     .attr("height", 70))
-            .withClasses(Styles.ABSOLUTE, Styles.TOP_2, Styles.LEFT_2);
+            .withClasses(Styles.TOP_2, Styles.LEFT_2);
 
     return div()
         .withId("top-content")

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -17,11 +17,7 @@ public final class ApplicantStyles {
           StyleUtils.responsiveSmall(Styles.MY_12));
 
   public static final String PROGRAM_INDEX_TOP_CONTENT =
-      StyleUtils.joinStyles(
-          BaseStyles.BG_SEATTLE_BLUE,
-          Styles.TEXT_WHITE,
-          Styles.TEXT_CENTER,
-          Styles.W_FULL);
+      StyleUtils.joinStyles(BaseStyles.BG_SEATTLE_BLUE, Styles.TEXT_WHITE, Styles.TEXT_CENTER, Styles.W_FULL);
 
   public static final String CIVIFORM_LOGO =
       StyleUtils.joinStyles(

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -16,7 +16,7 @@ public final class ApplicantStyles {
           Styles.MY_8,
           StyleUtils.responsiveSmall(Styles.MY_12));
 
-  public static final String PROGRAM_INDEX_TOP_CONTENT = 
+  public static final String PROGRAM_INDEX_TOP_CONTENT =
       StyleUtils.joinStyles(
           BaseStyles.BG_SEATTLE_BLUE, Styles.TEXT_WHITE, Styles.TEXT_CENTER, Styles.W_FULL);
 

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -21,9 +21,7 @@ public final class ApplicantStyles {
           BaseStyles.BG_SEATTLE_BLUE,
           Styles.TEXT_WHITE,
           Styles.TEXT_CENTER,
-          Styles.W_FULL,
-          Styles.P_6,
-          StyleUtils.responsiveSmall(Styles.P_10));
+          Styles.W_FULL);
 
   public static final String CIVIFORM_LOGO =
       StyleUtils.joinStyles(

--- a/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/ApplicantStyles.java
@@ -16,8 +16,9 @@ public final class ApplicantStyles {
           Styles.MY_8,
           StyleUtils.responsiveSmall(Styles.MY_12));
 
-  public static final String PROGRAM_INDEX_TOP_CONTENT =
-      StyleUtils.joinStyles(BaseStyles.BG_SEATTLE_BLUE, Styles.TEXT_WHITE, Styles.TEXT_CENTER, Styles.W_FULL);
+  public static final String PROGRAM_INDEX_TOP_CONTENT = 
+      StyleUtils.joinStyles(
+          BaseStyles.BG_SEATTLE_BLUE, Styles.TEXT_WHITE, Styles.TEXT_CENTER, Styles.W_FULL);
 
   public static final String CIVIFORM_LOGO =
       StyleUtils.joinStyles(


### PR DESCRIPTION
### Description
Seattle logo was covering h1 text - changed logo from absolute positioning and added padding to child elements instead of parent. See more info about padding with tailwind [here](https://tailwindcss.com/docs/padding) and see screenshots below for updated versions on mobile and web.
![Screen Shot 2021-08-11 at 5 20 20 PM](https://user-images.githubusercontent.com/86739416/129105103-12d8df4b-bbbb-47de-86e6-c36d947466db.png)
![Screen Shot 2021-08-11 at 5 19 07 PM](https://user-images.githubusercontent.com/86739416/129105112-4951f9b8-0ed5-4136-a259-9224a079dc0b.png)


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1566
