### PR TITLE
Fix sizing of box around a radio or checkbox input

### DIFF
--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -46,7 +46,6 @@ public final class BaseStyles {
           Styles.BLOCK,
           Styles.OUTLINE_NONE,
           Styles.BOX_BORDER,
-          Styles.H_12,
           Styles.M_AUTO,
           Styles.PX_3,
           Styles.PY_2,

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -59,7 +59,8 @@ public final class BaseStyles {
           Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
+  public static final String INPUT = 
+    StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -59,7 +59,7 @@ public final class BaseStyles {
           Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500);
+  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -59,7 +59,7 @@ public final class BaseStyles {
           Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT = 
+  public static final String INPUT =
       StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -60,7 +60,7 @@ public final class BaseStyles {
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = 
-    StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
+      StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -60,7 +60,7 @@ public final class BaseStyles {
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = 
-      StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
+      StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =


### PR DESCRIPTION
### Description
Text in a checkbox and radio button option in an application was overflowing if there was too much text for the size of the screen. This bug occurred on desktop and mobile.

We removed the height specification (H_12) for radio button and checkbox inputs. We kept the height tag for all other inputs to be safe. We may be able to remove the height tag in the future once we verify it doesn't break any other experiences.

Before:
![image](https://user-images.githubusercontent.com/86738827/129111793-b4ebe130-6d87-4bbd-a82a-61d3535dbb44.png)

After:
![image](https://user-images.githubusercontent.com/86738827/129111825-5e26a724-ae26-4c02-9beb-5503f1e65d66.png)


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1572
