### PR TITLE
Fix text wrapping on program summary and preview view.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
@@ -223,7 +223,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
             Styles.P_2,
             Styles.PT_4,
             Styles.BORDER_B,
-            Styles.BORDER_GRAY_300);
+            Styles.BORDER_GRAY_300)
+        .attr("style", "word-break:break-word"); 
   }
 
   private ContainerTag renderRepeatedEntitySection(

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
@@ -224,7 +224,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
             Styles.PT_4,
             Styles.BORDER_B,
             Styles.BORDER_GRAY_300)
-        .attr("style", "word-break:break-word"); 
+        .attr("style", "word-break:break-word");
   }
 
   private ContainerTag renderRepeatedEntitySection(

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -46,7 +46,6 @@ public final class BaseStyles {
           Styles.BLOCK,
           Styles.OUTLINE_NONE,
           Styles.BOX_BORDER,
-          Styles.H_12,
           Styles.M_AUTO,
           Styles.PX_3,
           Styles.PY_2,

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -59,7 +59,8 @@ public final class BaseStyles {
           Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
+  public static final String INPUT = 
+    StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -59,7 +59,7 @@ public final class BaseStyles {
           Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500);
+  public static final String INPUT = StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -59,7 +59,7 @@ public final class BaseStyles {
           Styles.TEXT_LG);
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
-  public static final String INPUT = 
+  public static final String INPUT =
       StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -60,7 +60,7 @@ public final class BaseStyles {
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = 
-    StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
+      StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =

--- a/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/BaseStyles.java
@@ -60,7 +60,7 @@ public final class BaseStyles {
 
   /** For use on `input` elements that are not of type "checkbox" or "radio". */
   public static final String INPUT = 
-      StyleUtils.joinStyles(INPUT_BASE,Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
+      StyleUtils.joinStyles(INPUT_BASE, Styles.PLACEHOLDER_GRAY_500, Styles.H_12);
 
   /** For use on `label` elements that label non-checkbox and non-radio `input` elements. */
   public static final String INPUT_LABEL =


### PR DESCRIPTION
### Description
Bug addressed: Text does not wrap for long words, like copy/pasted URLs, in the application summary rows. We added custom CSS to break long words in order to wrap text. 

There is a similar tailwind.css property - https://tailwindcss.com/docs/word-break#break-words. However, the tailwind css does not actually behave as expected and does not solve the issue (looks like this property is not maintained by tailwind anymore).

Adding Bion as a reviewer here to confirm that adding custom css in this way is safe and to recommend any alternatives.

Before: 
![image](https://user-images.githubusercontent.com/86738827/129279837-3aa259cf-bdef-42f7-b68e-b4eb71448579.png)

After:
![image](https://user-images.githubusercontent.com/86738827/129279847-9ecb3cbe-0238-48cf-8cdc-7715622defd0.png)


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1567
