### PR TITLE
Don't include trailing punctuation in parsed URLs.

### DIFF
--- a/universal-application-tool-0.0.1/test/views/components/TextFormatterTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/TextFormatterTest.java
@@ -12,17 +12,22 @@ public class TextFormatterTest {
   @Test
   public void urlsRenderCorrectly() {
     ImmutableList<DomContent> content =
-        TextFormatter.createLinksAndEscapeText("hello google.com http://internet.website");
+        TextFormatter.createLinksAndEscapeText(
+            "Hello google.com (http://internet.website), http://mysite.com...!");
 
-    assertThat(content).hasSize(4);
-    assertThat(content.get(0).render()).isEqualTo(new Text("hello ").render());
+    assertThat(content).hasSize(7);
+    assertThat(content.get(0).render()).isEqualTo(new Text("Hello ").render());
     assertThat(content.get(1).render())
         .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
-    assertThat(content.get(2).render()).isEqualTo(new Text(" ").render());
+    assertThat(content.get(2).render()).isEqualTo(new Text(" (").render());
     assertThat(content.get(3).render())
         .isEqualTo(
             "<a href=\"http://internet.website/\""
                 + " class=\"opacity-75\">http://internet.website</a>");
+    assertThat(content.get(4).render()).isEqualTo(new Text("), ").render());
+    assertThat(content.get(5).render())
+        .isEqualTo("<a href=\"http://mysite.com/\" class=\"opacity-75\">http://mysite.com</a>");
+    assertThat(content.get(6).render()).isEqualTo(new Text("...!").render());
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/views/components/TextFormatterTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/TextFormatterTest.java
@@ -37,9 +37,7 @@ public class TextFormatterTest {
         .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
     assertThat(content.get(2).render()).isEqualTo(new Text(", crawl (").render());
     assertThat(content.get(3).render())
-        .isEqualTo(
-            "<a href=\"http://seattle.gov/\""
-                + " class=\"opacity-75\">http://seattle.gov/</a>");
+        .isEqualTo("<a href=\"http://seattle.gov/\" class=\"opacity-75\">http://seattle.gov/</a>");
     assertThat(content.get(4).render()).isEqualTo(new Text("); and ").render());
     assertThat(content.get(5).render())
         .isEqualTo("<a href=\"http://mysite.com/\" class=\"opacity-75\">http://mysite.com</a>");

--- a/universal-application-tool-0.0.1/test/views/components/TextFormatterTest.java
+++ b/universal-application-tool-0.0.1/test/views/components/TextFormatterTest.java
@@ -12,19 +12,35 @@ public class TextFormatterTest {
   @Test
   public void urlsRenderCorrectly() {
     ImmutableList<DomContent> content =
+        TextFormatter.createLinksAndEscapeText("hello google.com http://internet.website");
+
+    assertThat(content).hasSize(4);
+    assertThat(content.get(0).render()).isEqualTo(new Text("hello ").render());
+    assertThat(content.get(1).render())
+        .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
+    assertThat(content.get(2).render()).isEqualTo(new Text(" ").render());
+    assertThat(content.get(3).render())
+        .isEqualTo(
+            "<a href=\"http://internet.website/\""
+                + " class=\"opacity-75\">http://internet.website</a>");
+  }
+
+  @Test
+  public void urlParserSkipsTrailingPunctuation() {
+    ImmutableList<DomContent> content =
         TextFormatter.createLinksAndEscapeText(
-            "Hello google.com (http://internet.website), http://mysite.com...!");
+            "Hello google.com, crawl (http://seattle.gov/); and http://mysite.com...!");
 
     assertThat(content).hasSize(7);
     assertThat(content.get(0).render()).isEqualTo(new Text("Hello ").render());
     assertThat(content.get(1).render())
         .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
-    assertThat(content.get(2).render()).isEqualTo(new Text(" (").render());
+    assertThat(content.get(2).render()).isEqualTo(new Text(", crawl (").render());
     assertThat(content.get(3).render())
         .isEqualTo(
-            "<a href=\"http://internet.website/\""
-                + " class=\"opacity-75\">http://internet.website</a>");
-    assertThat(content.get(4).render()).isEqualTo(new Text("), ").render());
+            "<a href=\"http://seattle.gov/\""
+                + " class=\"opacity-75\">http://seattle.gov/</a>");
+    assertThat(content.get(4).render()).isEqualTo(new Text("); and ").render());
     assertThat(content.get(5).render())
         .isEqualTo("<a href=\"http://mysite.com/\" class=\"opacity-75\">http://mysite.com</a>");
     assertThat(content.get(6).render()).isEqualTo(new Text("...!").render());


### PR DESCRIPTION
### Description
The UrlDetector class we're using includes some types of trailing punctuation characters in detected URLs. While these are legal URL path characters, in the context of Civiform free text fields, these are more likely to be part of the surrounding text instead of the URL. This PR strips typical trailing punctuation from detected URLs.


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1579 
