### PR TITLE
Ignore static questions while in review

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -289,7 +289,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
 
     if (inReview) {
       Optional<String> nextBlockIdMaybe =
-          roApplicantProgramService.getFirstIncompleteBlock().map(Block::getId);
+          roApplicantProgramService.getFirstIncompleteBlockExcludingStatic().map(Block::getId);
       return nextBlockIdMaybe.isEmpty()
           ? supplyAsync(
               () ->

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -43,8 +43,13 @@ public interface ReadOnlyApplicantProgramService {
   /** Returns the index of the given block in the context of all blocks of the program. */
   int getBlockIndex(String blockId);
 
-  /** Get the program block with the lowest index that has missing answer data if there is one. */
+  /** Get the program block with the lowest index that has missing answer data if there is one. Static questions are
+   * marked as incomplete. */
   Optional<Block> getFirstIncompleteBlock();
+
+  /** Get the program block with the lowest index that has missing answer data if there is one. Static questions are
+   * marked as complete. */
+  Optional<Block> getFirstIncompleteBlockExcludingStatic();
 
   /** Returns summary data for each question in this application. */
   ImmutableList<AnswerData> getSummaryData();

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -46,13 +46,13 @@ public interface ReadOnlyApplicantProgramService {
   /**
    * Get the program block with the lowest index that has missing answer data if there is one.
    * Static questions are marked as incomplete.
-   * */
+   */
   Optional<Block> getFirstIncompleteBlock();
 
   /**
    * Get the program block with the lowest index that has missing answer data if there is one.
    * Static questions are marked as complete.
-   * */
+   */
   Optional<Block> getFirstIncompleteBlockExcludingStatic();
 
   /** Returns summary data for each question in this application. */

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -43,12 +43,16 @@ public interface ReadOnlyApplicantProgramService {
   /** Returns the index of the given block in the context of all blocks of the program. */
   int getBlockIndex(String blockId);
 
-  /** Get the program block with the lowest index that has missing answer data if there is one. Static questions are
-   * marked as incomplete. */
+  /**
+   * Get the program block with the lowest index that has missing answer data if there is one.
+   * Static questions are marked as incomplete.
+   * */
   Optional<Block> getFirstIncompleteBlock();
 
-  /** Get the program block with the lowest index that has missing answer data if there is one. Static questions are
-   * marked as complete. */
+  /**
+   * Get the program block with the lowest index that has missing answer data if there is one.
+   * Static questions are marked as complete.
+   * */
   Optional<Block> getFirstIncompleteBlockExcludingStatic();
 
   /** Returns summary data for each question in this application. */

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -114,6 +114,13 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
+  public Optional<Block> getFirstIncompleteBlockExcludingStatic() {
+    return getInProgressBlocks().stream()
+            .filter(block -> !block.isCompleteWithoutErrors())
+            .findFirst();
+  }
+
+  @Override
   public boolean preferredLanguageSupported() {
     return programDefinition.getSupportedLocales().contains(applicantData.preferredLocale());
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -116,8 +116,8 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   @Override
   public Optional<Block> getFirstIncompleteBlockExcludingStatic() {
     return getInProgressBlocks().stream()
-            .filter(block -> !block.isCompleteWithoutErrors())
-            .findFirst();
+        .filter(block -> !block.isCompleteWithoutErrors())
+        .findFirst();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -122,9 +122,11 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     assertThat(inProgressBlocks.get(0).getName()).isEqualTo("Block one");
 
     Optional<Block> firstIncompleteBlock = subject.getFirstIncompleteBlock();
+    Optional<Block> firstIncompleteExcludingStatic = subject.getFirstIncompleteBlockExcludingStatic();
 
     assertThat(firstIncompleteBlock.isPresent()).isTrue();
     assertThat(firstIncompleteBlock.get().getName()).isEqualTo("Block one");
+    assertThat(firstIncompleteExcludingStatic.isPresent()).isFalse();
   }
 
   @Test
@@ -177,10 +179,13 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
 
     ImmutableList<Block> allBlocks = subject.getAllActiveBlocks();
     Optional<Block> maybeBlock = subject.getFirstIncompleteBlock();
+    Optional<Block> maybeBlockExcludeStatic = subject.getFirstIncompleteBlockExcludingStatic();
 
     assertThat(allBlocks).hasSize(2);
     assertThat(maybeBlock).isNotEmpty();
     assertThat(maybeBlock.get().getName()).isEqualTo("Block one");
+    assertThat(maybeBlockExcludeStatic).isNotEmpty();
+    assertThat(maybeBlockExcludeStatic.get().getName()).isEqualTo("Block two");
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -122,7 +122,8 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
     assertThat(inProgressBlocks.get(0).getName()).isEqualTo("Block one");
 
     Optional<Block> firstIncompleteBlock = subject.getFirstIncompleteBlock();
-    Optional<Block> firstIncompleteExcludingStatic = subject.getFirstIncompleteBlockExcludingStatic();
+    Optional<Block> firstIncompleteExcludingStatic =
+        subject.getFirstIncompleteBlockExcludingStatic();
 
     assertThat(firstIncompleteBlock.isPresent()).isTrue();
     assertThat(firstIncompleteBlock.get().getName()).isEqualTo("Block one");

--- a/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
+++ b/universal-application-tool-0.0.1/test/support/TestQuestionBank.java
@@ -26,6 +26,7 @@ import services.question.types.NumberQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
 import services.question.types.RadioButtonQuestionDefinition;
+import services.question.types.StaticContentQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 
 /**
@@ -352,7 +353,7 @@ public class TestQuestionBank {
   // Static
   private Question staticContent(QuestionEnum ignore) {
     QuestionDefinition definition =
-        new TextQuestionDefinition(
+        new StaticContentQuestionDefinition(
             "more info about something",
             Optional.empty(),
             "Shows more info to the applicant",


### PR DESCRIPTION
### Description
Usually, static questions are incomplete so that the screens will pop up for users to take notice of.  However, when an applicant selects 'Review', consider static questions to be complete.  Once an applicant selects 'Review', static questions will only be shown if they are on the same screen as an incomplete question that needs to be answered.  This will allow for the screen to be progressed from and the application submitted.

### Checklist
- [X ] Created tests which fail without the change (if possible)

Done in collaboration with dkatzz
