### PR TITLE
Remove error message on login page

### DIFF
--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -19,7 +19,6 @@ import play.i18n.Messages;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import services.MessageKey;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.Styles;
 

--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -49,11 +49,6 @@ public class LoginForm extends BaseHtmlView {
       htmlBundle.addMainContent(debugContent());
     }
 
-    if (message.isPresent()) {
-      String errorString = "Error: You are not logged in. " + message.get();
-      htmlBundle.addToastMessages(ToastMessage.error(errorString));
-    }
-
     return layout.render(htmlBundle);
   }
 


### PR DESCRIPTION
### Description
There's an error message that currently shows when the user is re-directed to the login page, which is unexpected. When a user is redirected to the login page, we don't want to show an error message.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1595
