### PR TITLE
Only include submitted applications in the program admin view and download

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
@@ -159,7 +159,7 @@ public class AdminApplicationController extends CiviFormController {
     }
     try {
       ImmutableList<Application> applications =
-          programService.getProgramApplications(programId, search);
+          programService.getSubmittedProgramApplications(programId, search);
       PaginationInfo<Application> pageInfo =
           PaginationInfo.paginate(applications, PAGE_SIZE, page.get());
       ImmutableList<Program> previousVersions = programService.getOtherProgramVersions(programId);

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -190,9 +190,11 @@ public class Program extends BaseModel {
     builder.setLocalizedDescription(LocalizedStrings.create(legacyLocalizedDescription));
   }
 
-  /** Returns program applications sorted by descending application id. */
-  public ImmutableList<Application> getApplications() {
-    return ImmutableList.copyOf(applications);
+  /** Returns submitted program applications sorted by descending application id. */
+  public ImmutableList<Application> getSubmittedApplications() {
+    return applications.stream()
+        .filter(application -> application.getLifecycleStage().equals(LifecycleStage.ACTIVE))
+        .collect(ImmutableList.toImmutableList());
   }
 
   public void addVersion(Version version) {

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -73,7 +73,7 @@ public class ExporterService {
    * @throws ProgramNotFoundException If the program ID refers to a program that does not exist.
    */
   public String getProgramCsv(long programId) throws ProgramNotFoundException {
-    ImmutableList<Application> applications = programService.getProgramApplications(programId);
+    ImmutableList<Application> applications = programService.getSubmittedProgramApplications(programId);
     ProgramDefinition program = programService.getProgramDefinition(programId);
     CsvExporter csvExporter;
     if (program.exportDefinitions().stream()
@@ -115,7 +115,7 @@ public class ExporterService {
   CsvExportConfig generateDefaultCsvConfig(long programId) {
     ImmutableList<Application> applications;
     try {
-      applications = programService.getProgramApplications(programId);
+      applications = programService.getSubmittedProgramApplications(programId);
     } catch (ProgramNotFoundException e) {
       throw new RuntimeException("Cannot find a program we are trying to generate CSVs for.", e);
     }

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -82,7 +82,7 @@ public class ExporterService {
       csvExporter = exporterFactory.csvExporter(generateDefaultCsvConfig(programId));
     }
     ImmutableList<Application> applications =
-            programService.getSubmittedProgramApplications(programId);
+        programService.getSubmittedProgramApplications(programId);
     return exportCsv(csvExporter, applications);
   }
 

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -73,8 +73,6 @@ public class ExporterService {
    * @throws ProgramNotFoundException If the program ID refers to a program that does not exist.
    */
   public String getProgramCsv(long programId) throws ProgramNotFoundException {
-    ImmutableList<Application> applications =
-        programService.getSubmittedProgramApplications(programId);
     ProgramDefinition program = programService.getProgramDefinition(programId);
     CsvExporter csvExporter;
     if (program.exportDefinitions().stream()
@@ -83,6 +81,8 @@ public class ExporterService {
     } else {
       csvExporter = exporterFactory.csvExporter(generateDefaultCsvConfig(programId));
     }
+    ImmutableList<Application> applications =
+            programService.getSubmittedProgramApplications(programId);
     return exportCsv(csvExporter, applications);
   }
 

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -73,7 +73,8 @@ public class ExporterService {
    * @throws ProgramNotFoundException If the program ID refers to a program that does not exist.
    */
   public String getProgramCsv(long programId) throws ProgramNotFoundException {
-    ImmutableList<Application> applications = programService.getSubmittedProgramApplications(programId);
+    ImmutableList<Application> applications =
+        programService.getSubmittedProgramApplications(programId);
     ProgramDefinition program = programService.getProgramDefinition(programId);
     CsvExporter csvExporter;
     if (program.exportDefinitions().stream()

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -299,10 +299,11 @@ public interface ProgramService {
    * @return A list of Application objects for the specified program.
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
-  ImmutableList<Application> getSubmittedProgramApplications(long programId) throws ProgramNotFoundException;
+  ImmutableList<Application> getSubmittedProgramApplications(long programId)
+          throws ProgramNotFoundException;
 
-  ImmutableList<Application> getSubmittedProgramApplications(long programId, Optional<String> search)
-      throws ProgramNotFoundException;
+  ImmutableList<Application> getSubmittedProgramApplications(
+      long programId, Optional<String> search) throws ProgramNotFoundException;
 
   /** Create a new draft starting from the program specified by `id`. */
   ProgramDefinition newDraftOf(long id) throws ProgramNotFoundException;

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -293,15 +293,15 @@ public interface ProgramService {
           ProgramQuestionDefinitionNotFoundException;
 
   /**
-   * Get all the program's applications.
+   * Get all the program's submitted applications. Does not include drafts or deleted applications.
    *
    * @param programId the program id.
    * @return A list of Application objects for the specified program.
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
-  ImmutableList<Application> getProgramApplications(long programId) throws ProgramNotFoundException;
+  ImmutableList<Application> getSubmittedProgramApplications(long programId) throws ProgramNotFoundException;
 
-  ImmutableList<Application> getProgramApplications(long programId, Optional<String> search)
+  ImmutableList<Application> getSubmittedProgramApplications(long programId, Optional<String> search)
       throws ProgramNotFoundException;
 
   /** Create a new draft starting from the program specified by `id`. */

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -300,7 +300,7 @@ public interface ProgramService {
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   ImmutableList<Application> getSubmittedProgramApplications(long programId)
-          throws ProgramNotFoundException;
+      throws ProgramNotFoundException;
 
   ImmutableList<Application> getSubmittedProgramApplications(
       long programId, Optional<String> search) throws ProgramNotFoundException;

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -514,8 +514,8 @@ public class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
-  public ImmutableList<Application> getSubmittedProgramApplications(long programId, Optional<String> search)
-      throws ProgramNotFoundException {
+  public ImmutableList<Application> getSubmittedProgramApplications(
+      long programId, Optional<String> search) throws ProgramNotFoundException {
     return getSubmittedProgramApplications(programId).stream()
         .filter(
             application ->

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -503,20 +503,20 @@ public class ProgramServiceImpl implements ProgramService {
   }
 
   @Override
-  public ImmutableList<Application> getProgramApplications(long programId)
+  public ImmutableList<Application> getSubmittedProgramApplications(long programId)
       throws ProgramNotFoundException {
     Optional<Program> programMaybe =
         programRepository.lookupProgram(programId).toCompletableFuture().join();
     if (programMaybe.isEmpty()) {
       throw new ProgramNotFoundException(programId);
     }
-    return programMaybe.get().getApplications();
+    return programMaybe.get().getSubmittedApplications();
   }
 
   @Override
-  public ImmutableList<Application> getProgramApplications(long programId, Optional<String> search)
+  public ImmutableList<Application> getSubmittedProgramApplications(long programId, Optional<String> search)
       throws ProgramNotFoundException {
-    return getProgramApplications(programId).stream()
+    return getSubmittedProgramApplications(programId).stream()
         .filter(
             application ->
                 application

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
@@ -97,7 +97,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                         .withClasses(Styles.TEXT_GRAY_700, Styles.ITALIC),
                     p().withClasses(Styles.FLEX_GROW),
                     renderApplicationsLink(
-                        String.format("Applications (%d) →", program.getApplications().size()),
+                        String.format("Applications (%d) →", program.getSubmittedApplications().size()),
                         program.id))
                 .withClasses(Styles.FLEX, Styles.TEXT_SM, Styles.W_FULL))
         .withClasses(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
@@ -97,7 +97,8 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                         .withClasses(Styles.TEXT_GRAY_700, Styles.ITALIC),
                     p().withClasses(Styles.FLEX_GROW),
                     renderApplicationsLink(
-                        String.format("Applications (%d) →", program.getSubmittedApplications().size()),
+                        String.format(
+                            "Applications (%d) →", program.getSubmittedApplications().size()),
                         program.id))
                 .withClasses(Styles.FLEX, Styles.TEXT_SM, Styles.W_FULL))
         .withClasses(


### PR DESCRIPTION
### Description
Updated the program getApplications to be getSubmittedApplications, filtering by lifecycleStage.Active.  This makes it so that draft applications, as well as deleted or obsolete applications, will not be shown.  They will not show up on the program admin view page or in the downloaded csv

### Checklist
- May need a follow up cl with a browser test replicating this.  The ProgramServiceImplTest file only makes changes from the program admin perspective; there is no mocking the program to return apps or actually filling out apps in that file.  Adding tests would require a larger test system refactor here, or adding something such as browser test that can cover both the admin roles and applicant roles in one file.  Changes to other files are all trivial; renaming so it is clear what the function provides

### Issue(s)
Fixes #1603 
