### PR TITLE
Switch to application IDs for admin application review UI.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminApplicationController.java
@@ -125,10 +125,8 @@ public class AdminApplicationController extends CiviFormController {
       return notFound(String.format("Application %d does not exist.", applicationId));
     }
     Application application = applicationMaybe.get();
-    String applicantNameWithId =
-        String.format(
-            "%s (%d)",
-            application.getApplicantData().getApplicantName(), application.getApplicant().id);
+    String applicantNameWithApplicationId =
+        String.format("%s (%d)", application.getApplicantData().getApplicantName(), application.id);
 
     ReadOnlyApplicantProgramService roApplicantService =
         applicantService
@@ -139,7 +137,12 @@ public class AdminApplicationController extends CiviFormController {
     ImmutableList<AnswerData> answers = roApplicantService.getSummaryData();
     return ok(
         applicationView.render(
-            programId, programName, applicationId, applicantNameWithId, blocks, answers));
+            programId,
+            programName,
+            applicationId,
+            applicantNameWithApplicationId,
+            blocks,
+            answers));
   }
 
   /** Return a paginated HTML page displaying (part of) all applications to the program. */

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -253,11 +253,12 @@ public class ApplicantServiceImpl implements ApplicantService {
         baseUrl
             + controllers.admin.routes.AdminApplicationController.show(programId, applicationId)
                 .url();
-    String subject = String.format("Applicant %d submitted a new application", applicantId);
+    String subject = String.format("New application %d submitted", applicationId);
     String message =
         String.format(
-            "Applicant %d submitted a new application to program %s.\nView the application at %s.",
-            applicantId, programName, viewLink);
+            "Applicant %d submitted a new application %d to program %s.\n"
+                + "View the application at %s.",
+            applicantId, applicationId, programName, viewLink);
     if (isStaging) {
       amazonSESClient.send(stagingProgramAdminNotificationMailingList, subject, message);
     } else {

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
@@ -118,10 +118,8 @@ public final class ProgramApplicationListView extends BaseHtmlView {
   private Tag renderApplicationListItem(long programId, Application application) {
     String downloadLinkText = "Download (PDF)";
     long applicationId = application.id;
-    String applicantNameWithId =
-        String.format(
-            "%s (%d)",
-            application.getApplicantData().getApplicantName(), application.getApplicant().id);
+    String applicantNameWithApplicationId =
+        String.format("%s (%d)", application.getApplicantData().getApplicantName(), application.id);
     String lastEditText;
     try {
       lastEditText = application.getSubmitTime().toString();
@@ -135,7 +133,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
     Tag topContent =
         div(
                 div(
-                    div(applicantNameWithId)
+                    div(applicantNameWithApplicationId)
                         .withClasses(
                             Styles.TEXT_BLACK, Styles.FONT_BOLD, Styles.TEXT_XL, Styles.MB_2)),
                 p().withClasses(Styles.FLEX_GROW))

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationView.java
@@ -40,7 +40,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
       long programId,
       String programName,
       long applicationId,
-      String applicantNameWithId,
+      String applicantNameWithApplicationId,
       ImmutableList<Block> blocks,
       ImmutableList<AnswerData> answers) {
     String title = "Program Application View";
@@ -60,7 +60,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .withClasses(Styles.PX_20)
             .with(
                 h2("Program: " + programName).withClasses(Styles.MY_4),
-                h1(applicantNameWithId).withClasses(Styles.MY_4),
+                h1(applicantNameWithApplicationId).withClasses(Styles.MY_4),
                 each(
                     blocks,
                     block -> renderApplicationBlock(programId, block, blockToAnswers.get(block))),


### PR DESCRIPTION
### Description
Using applicant IDs to alert admins of new applications, and to describe applications in admin list/detail views was confusing since the CSV export uses application IDs and there can be many applications for the same applicant. This PR switches to using application IDs instead if applicant IDs in most places, or makes it clear which one is being referenced.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Closes #1605 
