### PR TITLE
Fix Nav bar error

### DIFF
--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -355,27 +355,27 @@ export class AdminQuestions {
   }
 
   async addStaticQuestion(questionName: string,
-      description = 'static description',
-      questionText = 'static question text',
-      enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
-      await this.gotoAdminQuestionsPage();
-      // Wait for dropdown event listener to be attached
-      await this.page.waitForLoadState('load');
-      await this.page.click('#create-question-button');
+    description = 'static description',
+    questionText = 'static question text',
+    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
+    await this.gotoAdminQuestionsPage();
+    // Wait for dropdown event listener to be attached
+    await this.page.waitForLoadState('load');
+    await this.page.click('#create-question-button');
 
-      await this.page.click('#create-static-question');
+    await this.page.click('#create-static-question');
 
-     await this.page.fill('label:has-text("Name")', questionName);
-     await this.page.fill('label:has-text("Description")', description);
-     await this.page.fill('label:has-text("Question Text")', questionText);
-     await this.page.selectOption('#question-enumerator-select', { label: enumeratorName });
+    await this.page.fill('label:has-text("Name")', questionName);
+    await this.page.fill('label:has-text("Description")', description);
+    await this.page.fill('label:has-text("Question Text")', questionText);
+    await this.page.selectOption('#question-enumerator-select', { label: enumeratorName });
 
-      await this.clickSubmitButtonAndNavigate('Create');
+    await this.clickSubmitButtonAndNavigate('Create');
 
-      await this.expectAdminQuestionsPage();
+    await this.expectAdminQuestionsPage();
 
-      await this.expectDraftQuestionExist(questionName, questionText);
-    }
+    await this.expectDraftQuestionExist(questionName, questionText);
+  }
 
   async addNameQuestion(questionName: string,
     description = 'name description',

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -117,7 +117,7 @@ export class ApplicantQuestions {
       .toContain('<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">');
   }
 
-  async seeStaticQuestion(questionText: string){
-      expect(await this.page.textContent('html')).toContain(questionText);
-    }
+  async seeStaticQuestion(questionText: string) {
+    expect(await this.page.textContent('html')).toContain(questionText);
+  }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -29,7 +29,7 @@ public class AdminLayout extends BaseHtmlLayout {
 
   private static final String[] FOOTER_SCRIPTS = {"preview", "questionBank"};
 
-  private AdminType adminType = AdminType.CIVI_FORM_ADMIN;
+  private AdminType primaryAdminType = AdminType.CIVI_FORM_ADMIN;
 
   @Inject
   public AdminLayout(ViewUtils viewUtils, Config configuration) {
@@ -39,8 +39,8 @@ public class AdminLayout extends BaseHtmlLayout {
   /**
    * Sets this layout's admin type to PROGRAM_ADMIN, used to determine which navigation to include.
    */
-  public AdminLayout setProgramAdminType() {
-    adminType = AdminType.PROGRAM_ADMIN;
+  public AdminLayout setOnlyProgramAdminType() {
+    primaryAdminType = AdminType.PROGRAM_ADMIN;
     return this;
   }
 
@@ -91,7 +91,7 @@ public class AdminLayout extends BaseHtmlLayout {
         nav().with(headerIcon, headerTitle).withClasses(AdminStyles.NAV_STYLES);
 
     // Don't include nav links for program admin.
-    if (adminType.equals(AdminType.PROGRAM_ADMIN)) {
+    if (primaryAdminType.equals(AdminType.PROGRAM_ADMIN)) {
       return adminHeader.with(headerLink("Logout", logoutLink, Styles.FLOAT_RIGHT));
     }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -42,7 +42,9 @@ public class ProgramAdministratorProgramListView extends BaseHtmlView {
       ActiveAndDraftPrograms programs,
       List<String> authorizedPrograms,
       Optional<CiviFormProfile> civiformProfile) {
-    if (civiformProfile.isPresent() && civiformProfile.get().isProgramAdmin() && !civiformProfile.get().isCiviFormAdmin()) {
+    if (civiformProfile.isPresent()
+        && civiformProfile.get().isProgramAdmin()
+        && !civiformProfile.get().isCiviFormAdmin()) {
       layout.setOnlyProgramAdminType();
     }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -42,8 +42,8 @@ public class ProgramAdministratorProgramListView extends BaseHtmlView {
       ActiveAndDraftPrograms programs,
       List<String> authorizedPrograms,
       Optional<CiviFormProfile> civiformProfile) {
-    if (civiformProfile.isPresent() && civiformProfile.get().isProgramAdmin()) {
-      layout.setProgramAdminType();
+    if (civiformProfile.isPresent() && civiformProfile.get().isProgramAdmin() && !civiformProfile.get().isCiviFormAdmin()) {
+      layout.setOnlyProgramAdminType();
     }
 
     String title = "Your programs";

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationListView.java
@@ -35,7 +35,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
 
   @Inject
   public ProgramApplicationListView(AdminLayout layout) {
-    this.layout = checkNotNull(layout).setProgramAdminType();
+    this.layout = checkNotNull(layout).setOnlyProgramAdminType();
   }
 
   public Content render(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramApplicationView.java
@@ -33,7 +33,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
 
   @Inject
   public ProgramApplicationView(AdminLayout layout) {
-    this.layout = checkNotNull(layout).setProgramAdminType();
+    this.layout = checkNotNull(layout).setOnlyProgramAdminType();
   }
 
   public Content render(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramIndexView.java
@@ -43,8 +43,8 @@ public final class ProgramIndexView extends BaseHtmlView {
 
   public Content render(
       ActiveAndDraftPrograms programs, Http.Request request, Optional<CiviFormProfile> profile) {
-    if (profile.isPresent() && profile.get().isProgramAdmin()) {
-      layout.setProgramAdminType();
+    if (profile.isPresent() && profile.get().isProgramAdmin() && !profile.get().isCiviFormAdmin()) {
+      layout.setOnlyProgramAdminType();
     }
 
     String pageTitle = "All programs";


### PR DESCRIPTION
### Description
Nav bar not displaying correctly for civiform admins.
Run formatting script on browser tests

Previously: Nav bar is not present for civiform admin.  No way to select 'Questions', 'Versions', etc
![Screen Shot 2021-09-02 at 12 16 25 PM](https://user-images.githubusercontent.com/66492295/131903299-fc5c5004-88bd-40d1-9c88-7af1c29bb6ea.png)

Now: nav bar for civiform admins is restored
![Screen Shot 2021-09-02 at 12 16 34 PM](https://user-images.githubusercontent.com/66492295/131903302-82d53e47-a03e-4c86-8623-18a9ae0d95e3.png)


One Open Q; Why didn't browser tests catch this broken nav bar? Locally and in past PRs browser tests all passed, only the prober successfully caught it