### PR TITLE
Whitelabel civic entity name and logos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,9 @@ services:
       - ADFS_CLIENT_ID
       - ADFS_SECRET
       - CF_OPTIONAL_QUESTIONS
+      - WHITELABEL_SMALL_LOGO_URL
+      - WHITELABEL_LOGO_WITH_NAME_URL
+      - WHITELABEL_CIVIC_ENTITY_SHORT_NAME
+      - WHITELABEL_CIVIC_ENTITY_FULL_NAME
 
     command: -jvm-debug "*:8457" ~run -Dconfig.file=conf/application.dev.conf

--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -69,7 +69,7 @@ public class LoginForm extends BaseHtmlView {
       content.with(
           img()
               .withSrc(maybeLogoUrl.get())
-              .withAlt(civicEntityFullName + "logo")
+              .withAlt(civicEntityFullName + "Logo")
               .attr("aria-hidden", "true")
               .withClasses(Styles.W_1_4, Styles.PT_4));
     } else {

--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -35,6 +35,24 @@ akka {
   #log-config-on-start = true
 }
 
+## Whitelabeling
+whitelabel {
+  # The URL of images to be used as the civic entity's logo, will use local
+  # assets of the Seattle logo if not set.
+  # Small logo used on the login page.
+  small_logo_url = ${?WHITELABEL_SMALL_LOGO_URL}
+  # Logo with name used on the applicant-facing program index page.
+  logo_with_name_url = ${?WHITELABEL_LOGO_WITH_NAME_URL}
+
+  # The short display name of the civic entity, will use "Seattle" if not set.
+  civic_entity_short_name = "Seattle"
+  civic_entity_short_name = ${?WHITELABEL_CIVIC_ENTITY_SHORT_NAME}
+
+  # The full display name of the civic entity, will use "City of Seattle" if not set.
+  civic_entity_full_name = "City of Seattle"
+  civic_entity_full_name = ${?WHITELABEL_CIVIC_ENTITY_FULL_NAME}
+}
+
 ## Secret key
 # http://www.playframework.com/documentation/latest/ApplicationSecret
 # ~~~~~


### PR DESCRIPTION
Allows specifying a civic entity and logos other than Seattle via config file.

There is still hard-coded codepaths for serving the local asset files for the Seattle logos. We could avoid this by asking Seattle to make the logos available somewhere else and providing URLs for them. I'm inclined to not bother with them that though. If someone feels differently we can change this.