### PR TITLE
Dates should display correctly on CSV exports

### DIFF
--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -18,11 +18,11 @@ describe('normal application flow', () => {
     const programName = 'test program for csv export';
     await adminQuestions.addNameQuestion('name-csv-download');
     await adminQuestions.addDropdownQuestion('dropdown-csv-download', ['op1', 'op2', 'op3']);
-    await adminQuestions.addDateQuestion('predicate-date');
+    await adminQuestions.addDateQuestion('csv-date');
     await adminQuestions.exportQuestion('name-csv-download');
     await adminQuestions.exportQuestion('dropdown-csv-download');
-    await adminQuestions.exportQuestion('predicate-date');
-    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv-download', 'dropdown-csv-download', 'predicate-date'], programName);
+    await adminQuestions.exportQuestion('csv-date');
+    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv-download', 'dropdown-csv-download', 'csv-date'], programName);
 
     await logout(page);
     await loginAsTestUser(page);
@@ -68,8 +68,8 @@ describe('normal application flow', () => {
 
     await adminPrograms.gotoAdminProgramsPage();
     const demographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name),predicatedate (date)');
-    expect(demographicsCsvContent).toContain('op2,sarah,,smith,05/10/2021');
+    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,csvdate (date),dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
+    expect(demographicsCsvContent).toContain('05/10/2021,op2,sarah,,smith');
 
     await adminQuestions.createNewVersion('name-csv-download');
     await adminQuestions.exportQuestionOpaque('name-csv-download');
@@ -77,7 +77,7 @@ describe('normal application flow', () => {
 
     await adminPrograms.gotoAdminProgramsPage();
     const newDemographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),predicatedate (date),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
+    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,csvdate (date),dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
     expect(newDemographicsCsvContent).not.toContain(',sarah,,smith');
     expect(newDemographicsCsvContent).toContain(',op2,');
     if (isLocalDevEnvironment()) {

--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -18,9 +18,11 @@ describe('normal application flow', () => {
     const programName = 'test program for csv export';
     await adminQuestions.addNameQuestion('name-csv-download');
     await adminQuestions.addDropdownQuestion('dropdown-csv-download', ['op1', 'op2', 'op3']);
+    await adminQuestions.addDateQuestion('predicate-date');
     await adminQuestions.exportQuestion('name-csv-download');
     await adminQuestions.exportQuestion('dropdown-csv-download');
-    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv-download', 'dropdown-csv-download'], programName);
+    await adminQuestions.exportQuestion('predicate-date');
+    await adminPrograms.addAndPublishProgramWithQuestions(['name-csv-download', 'dropdown-csv-download', 'predicate-date'], programName);
 
     await logout(page);
     await loginAsTestUser(page);
@@ -31,6 +33,7 @@ describe('normal application flow', () => {
     // Applicant fills out first application block.
     await applicantQuestions.answerNameQuestion('sarah', 'smith');
     await applicantQuestions.answerDropdownQuestion('op2');
+    await applicantQuestions.answerDateQuestion('2021-05-10');
     await applicantQuestions.clickNext();
 
     // Application submits answers from review page.
@@ -41,7 +44,7 @@ describe('normal application flow', () => {
 
     await adminPrograms.viewApplications(programName);
     const csvContent = await adminPrograms.getCsv();
-    expect(csvContent).toContain('sarah,,smith,op2');
+    expect(csvContent).toContain('sarah,,smith,op2,05/10/2021');
 
     await logout(page);
     await loginAsAdmin(page)
@@ -58,15 +61,15 @@ describe('normal application flow', () => {
     await adminPrograms.viewApplications(programName);
     await adminPrograms.viewApplicationsInOldVersion();
     const postEditCsvContent = await adminPrograms.getCsv();
-    expect(postEditCsvContent).toContain('sarah,,smith,op2');
+    expect(postEditCsvContent).toContain('sarah,,smith,op2,05/10/2021');
 
     await logout(page);
     await loginAsAdmin(page)
 
     await adminPrograms.gotoAdminProgramsPage();
     const demographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
-    expect(demographicsCsvContent).toContain('op2,sarah,,smith');
+    expect(demographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name),predicatedate (date)');
+    expect(demographicsCsvContent).toContain('op2,sarah,,smith,05/10/2021');
 
     await adminQuestions.createNewVersion('name-csv-download');
     await adminQuestions.exportQuestionOpaque('name-csv-download');
@@ -74,7 +77,7 @@ describe('normal application flow', () => {
 
     await adminPrograms.gotoAdminProgramsPage();
     const newDemographicsCsvContent = await adminPrograms.getDemographicsCsv();
-    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
+    expect(newDemographicsCsvContent).toContain('Opaque ID,Program,Submitter Email (Opaque),TI Organization,Create time,Submit time,dropdowncsvdownload (selection),predicatedate (date),namecsvdownload (first_name),namecsvdownload (middle_name),namecsvdownload (last_name)');
     expect(newDemographicsCsvContent).not.toContain(',sarah,,smith');
     expect(newDemographicsCsvContent).toContain(',op2,');
     if (isLocalDevEnvironment()) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -14,6 +14,7 @@ import services.Path;
 import services.applicant.predicate.JsonPathPredicateGenerator;
 import services.applicant.predicate.PredicateEvaluator;
 import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.DateQuestion;
 import services.applicant.question.FileUploadQuestion;
 import services.applicant.question.Scalar;
 import services.program.BlockDefinition;
@@ -319,6 +320,9 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
         return ImmutableMap.of(
             question.getContextualizedPath(),
             question.createEnumeratorQuestion().getAnswerString());
+      case DATE:
+        DateQuestion dateQuestion = question.createDateQuestion();
+        return ImmutableMap.of(dateQuestion.getDatePath(), dateQuestion.getAnswerString());
       default:
         return question.getContextualizedScalars().keySet().stream()
             .filter(path -> !Scalar.getMetadataScalarKeys().contains(path.keyName()))


### PR DESCRIPTION
### Description
Dates were appearing as long numbers (i.e. 1631404800000) on the CSV exports, but these should show in the MM/dd/yyyy format (i.e. 05/21/2021). 

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1611

Worked on with @ettengererin 
