### PR TITLE
squashed changes

### DIFF
--- a/browser-test/src/admin_program_hidden.test.ts
+++ b/browser-test/src/admin_program_hidden.test.ts
@@ -1,0 +1,44 @@
+import { startSession, loginAsProgramAdmin, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
+
+describe('Hide a program that should not be public yet', () => {
+  it('Create a new hidden program, verify applicants cannot see it on the home page, unhide the program, verify applicant access', async () => {
+    const { browser, page } = await startSession()
+    page.setDefaultTimeout(5000);
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+    const adminPrograms = new AdminPrograms(page);
+
+    // Create a hidden program
+    const programName = 'Hidden Program';
+    const programDescription = 'Description';
+    await adminPrograms.addProgram(programName, programDescription, "", true); // Will this work? lol
+    await adminPrograms.publishAllPrograms();
+
+    // Login as applicant
+    await logout(page);
+    await loginAsTestUser(page);
+    await selectApplicantLanguage(page, 'English');
+    const applicantQuestions = new ApplicantQuestions(page);
+    await applicantQuestions.validateHeader('en-US');
+
+    // Verify the program cannot be seen
+    await applicantQuestions.expectProgramNotExist(programName);
+
+    await logout(page);
+    await loginAsAdmin(page);
+
+    // Unhide the program and publish
+    await adminPrograms.createUnhiddenVersion(programName);
+    await adminPrograms.publishAllPrograms();
+
+    await logout(page);
+
+    // Verify applicants can now see the program
+    await loginAsTestUser(page);
+    await selectApplicantLanguage(page, 'English');
+    await applicantQuestions.expectProgramExist(programName, programDescription);
+
+    await endSession(browser);
+  })
+})

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -25,7 +25,7 @@ export class AdminPrograms {
     expect(tableInnerText).toContain(description);
   }
 
-  async addProgram(programName: string, description = 'program description', externalLink = '') {
+  async addProgram(programName: string, description = 'program description', externalLink = '', hidden = false) {
     await this.gotoAdminProgramsPage();
     await this.page.click('#new-program-button');
 
@@ -34,6 +34,10 @@ export class AdminPrograms {
     await this.page.fill('#program-display-name-input', programName);
     await this.page.fill('#program-display-description-textarea', description);
     await this.page.fill('#program-external-link-input', externalLink);
+
+    if (hidden) {
+      await this.page.check(`label:has-text("Hide this program")`);
+    }
 
     await this.page.click('#program-update-button');
 
@@ -199,6 +203,16 @@ export class AdminPrograms {
     await this.page.click('#program-update-button');
     await this.expectDraftProgram(programName);
   }
+
+  async createUnhiddenVersion(programName: string) {
+    await this.gotoAdminProgramsPage();
+    await this.expectActiveProgram(programName);
+    await this.page.click(this.selectWithinProgramCard(programName, 'ACTIVE', ':text("New Version")'));
+    await this.page.uncheck(`label:has-text("Hide this program")`);
+    //await this.page.pause();
+    await this.page.click('#program-update-button');
+    await this.expectDraftProgram(programName);
+    }
 
   async viewApplications(programName: string) {
     await this.page.click(this.selectWithinProgramCard(programName, 'ACTIVE', 'a:text("Applications")'));

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -72,6 +72,19 @@ export class ApplicantQuestions {
     await this.page.click(`#continue-application-button`);
   }
 
+  async expectProgramExist(programName: string, description: string) {
+    const tableInnerText = await this.page.innerText('main');
+
+    expect(tableInnerText).toContain(programName);
+    expect(tableInnerText).toContain(description);
+  }
+
+  async expectProgramNotExist(programName: string) {
+    const tableInnerText = await this.page.innerText('main');
+
+    expect(tableInnerText).not.toContain(programName);
+    }
+
   async clickNext() {
     await this.page.click('text="Next"');
   }

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -81,7 +81,8 @@ public class AdminProgramController extends CiviFormController {
             program.getAdminDescription(),
             program.getLocalizedDisplayName(),
             program.getLocalizedDisplayDescription(),
-            program.getExternalLink());
+            program.getExternalLink(),
+            program.getHideFromView());
     if (result.isError()) {
       String errorMessage = joinErrors(result.getErrors());
       return ok(newOneView.render(request, program, errorMessage));
@@ -136,7 +137,8 @@ public class AdminProgramController extends CiviFormController {
               program.getAdminDescription(),
               program.getLocalizedDisplayName(),
               program.getLocalizedDisplayDescription(),
-              program.getExternalLink());
+              program.getExternalLink(),
+              program.getHideFromView());
       if (result.isError()) {
         String errorMessage = joinErrors(result.getErrors());
         return ok(editView.render(request, id, program, errorMessage));

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -206,7 +206,8 @@ public class DatabaseSeedController extends DevController {
                   "desc",
                   name,
                   "display description",
-                  "https://github.com/seattle-uat/civiform")
+                  "https://github.com/seattle-uat/civiform",
+                  false)
               .getResult();
       long programId = programDefinition.id();
 

--- a/universal-application-tool-0.0.1/app/forms/ProgramForm.java
+++ b/universal-application-tool-0.0.1/app/forms/ProgramForm.java
@@ -7,6 +7,7 @@ public class ProgramForm {
   private String localizedDisplayName;
   private String localizedDisplayDescription;
   private String externalLink;
+  private boolean hideFromView;
 
   public ProgramForm() {
     adminName = "";
@@ -14,6 +15,7 @@ public class ProgramForm {
     localizedDisplayName = "";
     localizedDisplayDescription = "";
     externalLink = "";
+    hideFromView = false;
   }
 
   public String getAdminName() {
@@ -38,6 +40,14 @@ public class ProgramForm {
 
   public void setExternalLink(String externalLink) {
     this.externalLink = externalLink;
+  }
+
+  public boolean getHideFromView() {
+    return hideFromView;
+  }
+
+  public void setHideFromView(boolean hideFromView) {
+    this.hideFromView = hideFromView;
   }
 
   public String getLocalizedDisplayName() {

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -54,6 +54,9 @@ public class Program extends BaseModel {
   /** Link to external site for this program. */
   @Constraints.Required private String externalLink;
 
+  /** Whether the Program should be hidden from the home page. */
+  @Constraints.Required private boolean hideFromView;
+
   // Not required - will be autofilled if not present.
   private String slug;
 
@@ -103,6 +106,7 @@ public class Program extends BaseModel {
     this.localizedDescription = definition.localizedDescription();
     this.blockDefinitions = definition.blockDefinitions();
     this.exportDefinitions = definition.exportDefinitions();
+    this.hideFromView = definition.hideFromView();
 
     orderBlockDefinitionsBeforeUpdate();
   }
@@ -116,13 +120,15 @@ public class Program extends BaseModel {
       String adminDescription,
       String defaultDisplayName,
       String defaultDisplayDescription,
-      String externalLink) {
+      String externalLink,
+      boolean hideFromView) {
     this.name = adminName;
     this.description = adminDescription;
     // A program is always created with the default CiviForm locale first, then localized.
     this.localizedName = LocalizedStrings.withDefaultValue(defaultDisplayName);
     this.localizedDescription = LocalizedStrings.withDefaultValue(defaultDisplayDescription);
     this.externalLink = externalLink;
+    this.hideFromView = hideFromView;
     BlockDefinition emptyBlock =
         BlockDefinition.builder()
             .setId(1L)
@@ -146,6 +152,7 @@ public class Program extends BaseModel {
     blockDefinitions = programDefinition.blockDefinitions();
     exportDefinitions = programDefinition.exportDefinitions();
     slug = programDefinition.slug();
+    hideFromView = programDefinition.hideFromView();
 
     orderBlockDefinitionsBeforeUpdate();
   }
@@ -162,7 +169,8 @@ public class Program extends BaseModel {
             .setAdminDescription(description)
             .setBlockDefinitions(blockDefinitions)
             .setExportDefinitions(exportDefinitions)
-            .setExternalLink(externalLink);
+            .setExternalLink(externalLink)
+            .setHideFromView(hideFromView);
 
     setLocalizedName(builder);
     setLocalizedDescription(builder);

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -61,7 +61,7 @@ public class UserRepository {
 
   /**
    * Returns all programs that are appropriate to serve to an applicant - which is any program
-   * program where they have an application in the draft stage, and any active program.
+   * where they have an application in the draft stage, and any active program that is not hidden.
    */
   public CompletionStage<ImmutableMap<LifecycleStage, ImmutableList<ProgramDefinition>>>
       programsForApplicant(long applicantId) {
@@ -88,6 +88,7 @@ public class UserRepository {
           ImmutableList<ProgramDefinition> activePrograms =
               versionRepositoryProvider.get().getActiveVersion().getPrograms().stream()
                   .map(Program::getProgramDefinition)
+                  .filter(pdef -> !pdef.hideFromView())
                   .collect(ImmutableList.toImmutableList());
           return ImmutableMap.of(
               LifecycleStage.DRAFT, inProgressPrograms,

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -80,7 +80,7 @@ public interface ApplicantService {
 
   /**
    * Return all programs that are appropriate to serve to an applicant - which is any active
-   * program, plus any program where they have an application in the draft stage.
+   * program that is not hidden and any program where they have an application in the draft stage.
    *
    * <p>The programs do not have question definitions loaded into its program question definitions.
    */

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -50,6 +50,9 @@ public abstract class ProgramDefinition {
   /** An external link to a page containing more details for this program. */
   public abstract String externalLink();
 
+  /** Whether the program should be hidden from the Applicant's program overview page. */
+  public abstract boolean hideFromView();
+
   /**
    * Descriptive name of a Program, e.g. Car Tab Rebate Program, localized for each supported
    * locale.
@@ -556,6 +559,8 @@ public abstract class ProgramDefinition {
     public abstract Builder setAdminName(String adminName);
 
     public abstract Builder setExternalLink(String externalLink);
+
+    public abstract Builder setHideFromView(boolean hideFromView);
 
     public abstract Builder setAdminDescription(String adminDescription);
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -57,6 +57,7 @@ public interface ProgramService {
    * @param defaultDisplayName the name of this program to display to applicants
    * @param defaultDisplayDescription a description for this program to display to applicants
    * @param externalLink A link to an external page containing additional program details
+   * @param hideFromView Control whether the program should be hidden from applicants
    * @return the {@link ProgramDefinition} that was created if succeeded, or a set of errors if
    *     failed
    */
@@ -65,7 +66,8 @@ public interface ProgramService {
       String adminDescription,
       String defaultDisplayName,
       String defaultDisplayDescription,
-      String externalLink);
+      String externalLink,
+      boolean hideFromView);
 
   /**
    * Update a program's mutable fields: admin description, display name and description for
@@ -78,6 +80,7 @@ public interface ProgramService {
    * @param displayName a name for this program
    * @param displayDescription the description of what the program provides
    * @param externalLink A link to an external page containing additional program details
+   * @param hideFromView Control whether the program should be hidden from applicants
    * @return the {@link ProgramDefinition} that was updated if succeeded, or a set of errors if
    *     failed
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
@@ -88,7 +91,8 @@ public interface ProgramService {
       String adminDescription,
       String displayName,
       String displayDescription,
-      String externalLink)
+      String externalLink,
+      boolean hideFromView)
       throws ProgramNotFoundException;
 
   /**

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -101,7 +101,8 @@ public class ProgramServiceImpl implements ProgramService {
       String adminDescription,
       String defaultDisplayName,
       String defaultDisplayDescription,
-      String externalLink) {
+      String externalLink,
+      boolean hideFromView) {
 
     ImmutableSet.Builder<CiviFormError> errorsBuilder = ImmutableSet.builder();
     if (hasProgramNameCollision(adminName)) {
@@ -122,7 +123,8 @@ public class ProgramServiceImpl implements ProgramService {
             adminDescription,
             defaultDisplayName,
             defaultDisplayDescription,
-            externalLink);
+            externalLink,
+            hideFromView);
     program.addVersion(versionRepository.getDraftVersion());
     return ErrorAnd.of(programRepository.insertProgramSync(program).getProgramDefinition());
   }
@@ -134,7 +136,8 @@ public class ProgramServiceImpl implements ProgramService {
       String adminDescription,
       String displayName,
       String displayDescription,
-      String externalLink)
+      String externalLink,
+      boolean hideFromView)
       throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getProgramDefinition(programId);
     ImmutableSet.Builder<CiviFormError> errorsBuilder = ImmutableSet.builder();
@@ -156,6 +159,7 @@ public class ProgramServiceImpl implements ProgramService {
                     .localizedDescription()
                     .updateTranslation(locale, displayDescription))
             .setExternalLink(externalLink)
+            .setHideFromView(hideFromView)
             .build()
             .toProgram();
     return ErrorAnd.of(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramFormBuilder.java
@@ -24,6 +24,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
         program.getLocalizedDisplayName(),
         program.getLocalizedDisplayDescription(),
         program.getExternalLink(),
+        program.getHideFromView(),
         editExistingProgram);
   }
 
@@ -36,6 +37,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
         program.localizedName().getDefault(),
         program.localizedDescription().getDefault(),
         program.externalLink(),
+        program.hideFromView(),
         editExistingProgram);
   }
 
@@ -45,6 +47,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
       String displayName,
       String displayDescription,
       String externalLink,
+      boolean hideFromView,
       boolean editExistingProgram) {
     ContainerTag formTag = form().withMethod("POST");
     formTag.with(
@@ -62,6 +65,13 @@ public class ProgramFormBuilder extends BaseHtmlView {
             .setFieldName("adminDescription")
             .setLabelText("Describe this program for administrative use")
             .setValue(adminDescription)
+            .getContainer(),
+        FieldWithLabel.checkbox()
+            .setId("program-hide-from-view-checkbox")
+            .setFieldName("hideFromView")
+            .setLabelText("Hide this program")
+            .setValue("true")
+            .setChecked(hideFromView)
             .getContainer(),
         h2("Public program information"),
         h3("This will be visible to the public"),

--- a/universal-application-tool-0.0.1/conf/evolutions/default/34.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/34.sql
@@ -1,0 +1,7 @@
+# --- Allow programs to be hidden from the applicant home view
+
+# --- !Ups
+alter table programs add column hide_from_view boolean default false not null;
+
+# --- !Downs
+alter table programs drop column hide_from_view;

--- a/universal-application-tool-0.0.1/test/models/ProgramTest.java
+++ b/universal-application-tool-0.0.1/test/models/ProgramTest.java
@@ -67,6 +67,7 @@ public class ProgramTest extends WithPostgresContainer {
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "desc"))
             .setBlockDefinitions(ImmutableList.of(blockDefinition))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
     Program program = new Program(definition);
 
@@ -135,6 +136,7 @@ public class ProgramTest extends WithPostgresContainer {
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "desc"))
             .setBlockDefinitions(ImmutableList.of(blockDefinition))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
     Program program = new Program(definition);
     program.save();
@@ -176,6 +178,7 @@ public class ProgramTest extends WithPostgresContainer {
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "desc"))
             .setBlockDefinitions(ImmutableList.of(blockDefinition))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
     Program program = new Program(definition);
     program.save();
@@ -266,6 +269,7 @@ public class ProgramTest extends WithPostgresContainer {
             .setAdminName("test program")
             .setAdminDescription("test description")
             .setExternalLink("")
+            .setHideFromView(false)
             .setLocalizedName(LocalizedStrings.withDefaultValue("test name"))
             .setLocalizedDescription(LocalizedStrings.withDefaultValue("test description"))
             .setBlockDefinitions(unorderedBlocks)

--- a/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
@@ -76,7 +76,7 @@ public class ApplicationRepositoryTest extends WithPostgresContainer {
   }
 
   private Program saveProgram(String name) {
-    Program program = new Program(name, "desc", name, "desc", "");
+    Program program = new Program(name, "desc", name, "desc", "", false);
     program.save();
     return program;
   }

--- a/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ProgramRepositoryTest.java
@@ -100,7 +100,7 @@ public class ProgramRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void insertProgramSync() throws Exception {
-    Program program = new Program("ProgramRepository", "desc", "name", "description", "");
+    Program program = new Program("ProgramRepository", "desc", "name", "description", "", false);
 
     Program withId = repo.insertProgramSync(program);
 

--- a/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ReadOnlyApplicantProgramServiceImplTest.java
@@ -546,6 +546,7 @@ public class ReadOnlyApplicantProgramServiceImplTest extends WithPostgresContain
                 .setLocalizedDescription(
                     LocalizedStrings.of(Locale.US, "This program is for testing."))
                 .setExternalLink("")
+                .setHideFromView(false)
                 .build(),
             FAKE_BASE_URL);
 

--- a/universal-application-tool-0.0.1/test/services/export/PdfExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/PdfExporterTest.java
@@ -44,6 +44,7 @@ public class PdfExporterTest extends WithPostgresContainer {
             .setLocalizedName(LocalizedStrings.of(Locale.US, "fake program"))
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "fake program description"))
             .setExternalLink("")
+            .setHideFromView(false)
             .addExportDefinition(
                 ExportDefinition.builder()
                     .setEngine(ExportEngine.PDF)

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -41,6 +41,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
         .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
         .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
         .setExternalLink("")
+        .setHideFromView(false)
         .addBlockDefinition(blockA)
         .build();
   }
@@ -61,6 +62,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
             .setExternalLink("")
+            .setHideFromView(false)
             .addBlockDefinition(blockA)
             .build();
 
@@ -77,6 +79,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
 
     assertThat(program.getBlockDefinitionByIndex(0)).isEmpty();
@@ -116,6 +119,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
             .setExternalLink("")
+            .setHideFromView(false)
             .addBlockDefinition(blockA)
             .addBlockDefinition(blockB)
             .build();
@@ -135,6 +139,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setLocalizedName(LocalizedStrings.of(Locale.US, "Applicant friendly name"))
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "English description"))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
 
     assertThat(program.adminName()).isEqualTo("Admin name");
@@ -163,6 +168,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setLocalizedName(LocalizedStrings.of(Locale.US, "existing name"))
             .setLocalizedDescription(LocalizedStrings.of(Locale.US, "existing description"))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
 
     program =
@@ -191,6 +197,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .setLocalizedDescription(
                 LocalizedStrings.of(Locale.US, "English description", Locale.GERMAN, "test"))
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
 
     assertThat(definition.getSupportedLocales()).containsExactly(Locale.US);
@@ -233,6 +240,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
                 LocalizedStrings.of(
                     Locale.US, "English description", Locale.GERMAN, "test", Locale.FRANCE, "test"))
             .setExternalLink("")
+            .setHideFromView(false)
             .addBlockDefinition(blockA)
             .addBlockDefinition(blockB)
             .build();
@@ -289,6 +297,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
             .addBlockDefinition(blockB)
             .addBlockDefinition(blockC)
             .setExternalLink("")
+            .setHideFromView(false)
             .build();
 
     // blockA
@@ -371,6 +380,7 @@ public class ProgramDefinitionTest extends WithPostgresContainer {
                 LocalizedStrings.of(
                     Locale.US, "English description", Locale.GERMAN, "test", Locale.FRANCE, "test"))
             .setExternalLink("")
+            .setHideFromView(false)
             .addBlockDefinition(blockA)
             .addBlockDefinition(blockB)
             .addBlockDefinition(blockC)

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -96,7 +96,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     assertThat(ps.getActiveAndDraftPrograms().getDraftSize()).isEqualTo(0);
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.createProgramDefinition("ProgramService", "description", "name", "description", "");
+        ps.createProgramDefinition("ProgramService", "description", "name", "description", "", false);
 
     assertThat(result.hasResult()).isTrue();
     assertThat(result.getResult().id()).isNotNull();
@@ -105,7 +105,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   @Test
   public void createProgram_hasEmptyBlock() {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.createProgramDefinition("ProgramService", "description", "name", "description", "");
+        ps.createProgramDefinition("ProgramService", "description", "name", "description", "", false);
 
     assertThat(result.hasResult()).isTrue();
     assertThat(result.getResult().blockDefinitions()).hasSize(1);
@@ -116,7 +116,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   @Test
   public void createProgram_returnsErrors() {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.createProgramDefinition("", "", "", "", "");
+        ps.createProgramDefinition("", "", "", "", "", false);
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
@@ -130,11 +130,11 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void createProgram_protectsAgainstProgramNameCollisions() {
-    ps.createProgramDefinition("name", "description", "display name", "display description", "");
+    ps.createProgramDefinition("name", "description", "display name", "display description", "", false);
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
-            "name", "description", "display name", "display description", "");
+            "name", "description", "display name", "display description", "", false);
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
@@ -147,7 +147,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     assertThatThrownBy(
             () ->
                 ps.updateProgramDefinition(
-                    1L, Locale.US, "new description", "name", "description", ""))
+                    1L, Locale.US, "new description", "name", "description", "", false))
         .isInstanceOf(ProgramNotFoundException.class)
         .hasMessage("Program not found for ID: 1");
   }
@@ -158,7 +158,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
         ProgramBuilder.newDraftProgram("original", "original description").buildDefinition();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateProgramDefinition(
-            originalProgram.id(), Locale.US, "new description", "name", "description", "");
+            originalProgram.id(), Locale.US, "new description", "name", "description", "", false);
 
     assertThat(result.hasResult()).isTrue();
     ProgramDefinition updatedProgram = result.getResult();
@@ -177,7 +177,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     ProgramDefinition found =
         ps.updateProgramDefinition(
-                program.id(), Locale.US, "new description", "name", "description", "")
+                program.id(), Locale.US, "new description", "name", "description", "", false)
             .getResult();
 
     QuestionDefinition foundQuestion =
@@ -190,7 +190,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
-        ps.updateProgramDefinition(program.id(), Locale.US, "", "", "", "");
+        ps.updateProgramDefinition(program.id(), Locale.US, "", "", "", "", false);
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
@@ -484,7 +484,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   @Test
   public void setBlockQuestions_withBogusBlockId_throwsProgramBlockDefinitionNotFoundException() {
     ProgramDefinition p =
-        ps.createProgramDefinition("name", "description", "name", "description", "").getResult();
+        ps.createProgramDefinition("name", "description", "name", "description", "", false).getResult();
     assertThatThrownBy(() -> ps.setBlockQuestions(p.id(), 100L, ImmutableList.of()))
         .isInstanceOf(ProgramBlockDefinitionNotFoundException.class)
         .hasMessage(

--- a/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
+++ b/universal-application-tool-0.0.1/test/support/ProgramBuilder.java
@@ -59,7 +59,7 @@ public class ProgramBuilder {
   /** Creates a {@link ProgramBuilder} with a new {@link Program} in draft state. */
   public static ProgramBuilder newDraftProgram(String name, String description) {
     VersionRepository versionRepository = injector.instanceOf(VersionRepository.class);
-    Program program = new Program(name, description, name, description, "");
+    Program program = new Program(name, description, name, description, "", false);
     program.addVersion(versionRepository.getDraftVersion());
     program.save();
     ProgramDefinition.Builder builder =
@@ -88,7 +88,7 @@ public class ProgramBuilder {
   /** Creates a {@link ProgramBuilder} with a new {@link Program} in active state. */
   public static ProgramBuilder newActiveProgram(String name, String description) {
     VersionRepository versionRepository = injector.instanceOf(VersionRepository.class);
-    Program program = new Program(name, description, name, description, "");
+    Program program = new Program(name, description, name, description, "", false);
     program.addVersion(versionRepository.getActiveVersion());
     program.save();
     ProgramDefinition.Builder builder =


### PR DESCRIPTION
### Description
Allow the civiform admin to hide a program that they don't want to appear on the civiform applicant landing page.  This program can still be accessed through its deeplink, and will still act normally once accessed.

This change adds a new boolean hideFromView field to the programs DB that is then set by the civiform admin for a program and is accessed when showing programs on the applicant home screen.  The boolean defaults to false when it is not set; programs default to not being hidden.

Civiform admin checks the 'Hide from view' box in the program info page, and publishes the new version of the program with this update.

<img width="1415" alt="Screen Shot 2021-09-13 at 2 57 17 PM" src="https://user-images.githubusercontent.com/66492295/133162034-cebf2f23-7614-4c6d-9188-389ec6a2c582.png">

Depending on the hide from view status, the program is or is not visible in the applicant home screen.
<img width="1423" alt="Screen Shot 2021-09-09 at 3 55 02 PM" src="https://user-images.githubusercontent.com/66492295/133162093-e976f628-caf8-4377-91f2-77aaa73300e4.png">
<img width="1431" alt="Screen Shot 2021-09-09 at 4 41 33 PM" src="https://user-images.githubusercontent.com/66492295/133162094-33e3abfb-834f-413c-96b0-ea350ebd4070.png">


### Checklist
- [ X ] Created tests which fail without the change (if possible). This change includes a browser test that verifies a program can be hidden, unhidden, and seen or not as intended by the applicant

### Issue(s)
Fixes #1604
