### PR TITLE
Fix browser test flakiness from page JS load race conditions.

### DIFF
--- a/browser-test/src/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin_dropdown_create_and_edit.test.ts
@@ -1,4 +1,4 @@
-import { startSession, loginAsAdmin, AdminQuestions, endSession } from './support'
+import { startSession, loginAsAdmin, waitForPageJsLoad, AdminQuestions, endSession } from './support'
 
 describe('create dropdown question with options', () => {
   it('add remove buttons work correctly', async () => {
@@ -8,10 +8,11 @@ describe('create dropdown question with options', () => {
 
     const adminQuestions = new AdminQuestions(page);
     await page.click('text=Questions');
-    // Wait for dropdown event listener to be attached
-    await page.waitForLoadState('load');
+    await waitForPageJsLoad(page);
+
     await page.click('#create-question-button');
     await page.click('#create-dropdown-question');
+    await waitForPageJsLoad(page);
 
     // Verify question preview has default text.
     expect(await page.innerText('.cf-applicant-question-text'))
@@ -28,11 +29,11 @@ describe('create dropdown question with options', () => {
 
     // Add three options
     await page.click('#add-new-option');
-    await page.fill('#question-settings div.flex-row:last-of-type input', 'chocolate');
+    await page.fill('#question-settings div.flex-row:nth-of-type(1) input', 'chocolate');
     await page.click('#add-new-option');
-    await page.fill('#question-settings div.flex-row:last-of-type input', 'vanilla');
+    await page.fill('#question-settings div.flex-row:nth-of-type(2) input', 'vanilla');
     await page.click('#add-new-option');
-    await page.fill('#question-settings div.flex-row:last-of-type input', 'strawberry');
+    await page.fill('#question-settings div.flex-row:nth-of-type(3) input', 'strawberry');
 
     // Assert there are three options present
     var questionSettingsDiv = await page.innerHTML('#question-settings');
@@ -63,4 +64,3 @@ describe('create dropdown question with options', () => {
     await endSession(browser);
   })
 })
-

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -1,4 +1,5 @@
-import { startSession, loginAsAdmin, loginAsGuest, AdminQuestions, AdminPrograms, ApplicantQuestions, selectApplicantLanguage, endSession } from './support'
+import { waitForDebugger } from 'inspector';
+import { startSession, loginAsAdmin, loginAsGuest, AdminQuestions, AdminPrograms, ApplicantQuestions, selectApplicantLanguage, endSession, waitForPageJsLoad } from './support'
 
 describe('End to end enumerator test', () => {
   const programName = 'ete enumerator program';
@@ -134,6 +135,8 @@ describe('End to end enumerator test', () => {
 
     // Go back to delete enumerator answers
     await page.click('.cf-applicant-summary-row:has(div:has-text("Household members")) a:has-text("Edit")');
+    await waitForPageJsLoad(page);
+
     await applicantQuestions.deleteEnumeratorEntity("Bugs");
     await applicantQuestions.deleteEnumeratorEntity("Daffy");
     // Submit the answers by clicking next, and then go to review page.
@@ -153,6 +156,7 @@ describe('End to end enumerator test', () => {
 
     // Go back and add an enumerator answer.
     await page.click('.cf-applicant-summary-row:has(div:has-text("Household members")) a:has-text("Continue")');
+    await waitForPageJsLoad(page);
     await applicantQuestions.addEnumeratorAnswer("Tweety");
     await applicantQuestions.clickNext();
     await applicantQuestions.answerNameQuestion("Tweety", "Bird");

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -1,4 +1,3 @@
-import { waitForDebugger } from 'inspector';
 import { startSession, loginAsAdmin, loginAsGuest, AdminQuestions, AdminPrograms, ApplicantQuestions, selectApplicantLanguage, endSession, waitForPageJsLoad } from './support'
 
 describe('End to end enumerator test', () => {

--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright'
+import { waitForPageJsLoad } from './wait';
 
 export class AdminPredicates {
   public page!: Page
@@ -10,8 +11,8 @@ export class AdminPredicates {
   // For multi-option questions where the value is a checkbox of options, provide a comma-separated
   // list of the options you would like to check as the value. Ex: blue,red,green
   async addPredicate(questionName: string, action: string, scalar: string, operator: string, value: string) {
-    await this.page.waitForLoadState('load');
     await this.page.click(`text="${questionName}"`);
+
     await this.page.selectOption('.cf-predicate-action:visible select', { label: action });
     await this.page.selectOption('.cf-scalar-select:visible select', { label: scalar });
     await this.page.selectOption('.cf-operator-select:visible select', { label: operator });
@@ -28,6 +29,7 @@ export class AdminPredicates {
     }
 
     await this.page.click('button:visible:has-text("Submit")');
+    await waitForPageJsLoad(this.page);
   }
 
   async expectVisibilityConditionEquals(condition: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -17,7 +17,7 @@ export class AdminQuestions {
   }
 
   async clickSubmitButtonAndNavigate(buttonText: string) {
-    await this.page.click('button:has-text("' + buttonText + '")');
+    await this.page.click(`button:has-text("${buttonText}")`);
     await waitForPageJsLoad(this.page);
   }
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright'
+import { waitForPageJsLoad } from './wait';
 
 export class AdminQuestions {
   public page!: Page
@@ -11,14 +12,13 @@ export class AdminQuestions {
 
   async gotoAdminQuestionsPage() {
     await this.page.click('nav :text("Questions")');
+    await waitForPageJsLoad(this.page);
     await this.expectAdminQuestionsPage();
   }
 
   async clickSubmitButtonAndNavigate(buttonText: string) {
-    await Promise.all([
-      this.page.waitForNavigation(),
-      this.page.click('button:has-text("' + buttonText + '")'),
-    ]);
+    await this.page.click('button:has-text("' + buttonText + '")');
+    await waitForPageJsLoad(this.page);
   }
 
   async expectAdminQuestionsPage() {
@@ -92,8 +92,8 @@ export class AdminQuestions {
 
   async expectActiveQuestionNotExist(questionName: string) {
     await this.gotoAdminQuestionsPage();
+    await waitForPageJsLoad(this.page);
     const tableInnerText = await this.page.innerText('table');
-
     expect(tableInnerText).not.toContain(questionName);
   }
 
@@ -101,30 +101,35 @@ export class AdminQuestions {
   async gotoQuestionEditPage(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("Edit")'));
+    await waitForPageJsLoad(this.page);
     await this.expectQuestionEditPage(questionName);
   }
 
   async undeleteQuestion(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("Restore")'));
+    await waitForPageJsLoad(this.page);
     await this.expectAdminQuestionsPage();
   }
 
   async discardDraft(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("Discard Draft")'));
+    await waitForPageJsLoad(this.page);
     await this.expectAdminQuestionsPage();
   }
 
   async archiveQuestion(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("Archive")'));
+    await waitForPageJsLoad(this.page);
     await this.expectAdminQuestionsPage();
   }
 
   async goToQuestionTranslationPage(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("Manage Translations")'));
+    await waitForPageJsLoad(this.page);
     await this.expectQuestionTranslationPage();
   }
 
@@ -173,6 +178,7 @@ export class AdminQuestions {
   async createNewVersion(questionName: string) {
     await this.gotoAdminQuestionsPage();
     await this.page.click(this.selectWithinQuestionTableRow(questionName, ':text("New Version")'));
+    await waitForPageJsLoad(this.page);
     await this.expectQuestionEditPage(questionName);
     const newQuestionText = await this.updateQuestionText(' new version');
 
@@ -241,11 +247,10 @@ export class AdminQuestions {
     helpText = 'address question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-address-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -262,11 +267,10 @@ export class AdminQuestions {
     helpText = 'date question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-date-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -284,11 +288,10 @@ export class AdminQuestions {
     helpText = 'checkbox question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-checkbox-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -312,11 +315,10 @@ export class AdminQuestions {
     helpText = 'dropdown question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-dropdown-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -339,11 +341,10 @@ export class AdminQuestions {
     helpText = 'fileupload question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-fileupload-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -359,11 +360,10 @@ export class AdminQuestions {
     questionText = 'static question text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-static-question');
+    await waitForPageJsLoad(this.page);
 
     await this.page.fill('label:has-text("Name")', questionName);
     await this.page.fill('label:has-text("Description")', description);
@@ -383,11 +383,10 @@ export class AdminQuestions {
     helpText = 'name question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-name-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -404,11 +403,10 @@ export class AdminQuestions {
     helpText = 'number question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-number-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -426,11 +424,10 @@ export class AdminQuestions {
     helpText = 'radio button question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-radio_button-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -453,11 +450,10 @@ export class AdminQuestions {
     helpText = 'text question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-text-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -474,11 +470,10 @@ export class AdminQuestions {
     helpText = 'email question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-email-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 
@@ -498,11 +493,10 @@ export class AdminQuestions {
     helpText = 'enumerator question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION) {
     await this.gotoAdminQuestionsPage();
-    // Wait for dropdown event listener to be attached
-    await this.page.waitForLoadState('load');
-    await this.page.click('#create-question-button');
 
+    await this.page.click('#create-question-button');
     await this.page.click('#create-enumerator-question');
+    await waitForPageJsLoad(this.page);
 
     await this.fillInQuestionBasics(questionName, description, questionText, helpText, enumeratorName);
 

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright'
+import { waitForPageJsLoad } from './wait';
 
 export class ApplicantQuestions {
   public page!: Page
@@ -61,27 +62,33 @@ export class ApplicantQuestions {
 
   async addEnumeratorAnswer(entityName: string) {
     await this.page.click('button:text("add entity")');
+    // TODO(leonwong): may need to specify row index to wait for newly added row.
     await this.page.fill('#enumerator-fields .cf-enumerator-field:last-of-type input', entityName)
   }
 
   async applyProgram(programName: string) {
     // User clicks the apply button on an application card. It takes them to the application info page.
     await this.page.click(`.cf-application-card:has-text("${programName}") .cf-apply-button`);
+    await waitForPageJsLoad(this.page);
 
     // The user can see the application preview page. Clicking on apply sends them to the first unanswered question.
     await this.page.click(`#continue-application-button`);
+    await waitForPageJsLoad(this.page);
   }
 
   async clickNext() {
     await this.page.click('text="Next"');
+    await waitForPageJsLoad(this.page);
   }
 
   async clickReview() {
     await this.page.click('text="Review"');
+    await waitForPageJsLoad(this.page);
   }
 
   async clickUpload() {
     await this.page.click('text="Upload"');
+    await waitForPageJsLoad(this.page);
   }
 
   async deleteEnumeratorEntity(entityName: string) {
@@ -104,8 +111,10 @@ export class ApplicantQuestions {
 
     // Click on submit button.
     await this.page.click('text="Submit"');
+    await waitForPageJsLoad(this.page);
 
     await this.page.click('text="Apply to another program"');
+    await waitForPageJsLoad(this.page);
 
     // Ensure that we redirected to the programs list page.
     expect(await this.page.url().split('/').pop()).toEqual('programs');

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -1,10 +1,12 @@
 import { Browser, chromium, Page } from 'playwright'
+import { waitForPageJsLoad } from './wait'
 export { AdminQuestions } from './admin_questions'
 export { AdminPredicates } from './admin_predicates'
 export { AdminPrograms } from './admin_programs'
 export { AdminTranslations } from './admin_translations'
 export { AdminTIGroups } from './admin_ti_groups'
 export { ApplicantQuestions } from './applicant_questions'
+export { clickAndWaitForModal, waitForPageJsLoad } from './wait'
 
 const { BASE_URL = 'http://civiform:9000', TEST_USER_LOGIN = '', TEST_USER_PASSWORD = '' } = process.env
 
@@ -31,18 +33,24 @@ export const gotoEndpoint = async (page: Page, endpoint: string) => {
 
 export const logout = async (page: Page) => {
   await page.click('text=Logout');
+  // Logout is handled by the play framework so it doesn't land on a
+  // page with civiform js where we need to waitForPageJsLoad.
+  await page.waitForLoadState();
 }
 
 export const loginAsAdmin = async (page: Page) => {
   await page.click('#admin');
+  await waitForPageJsLoad(page);
 }
 
 export const loginAsProgramAdmin = async (page: Page) => {
   await page.click('#program-admin');
+  await waitForPageJsLoad(page);
 }
 
 export const loginAsGuest = async (page: Page) => {
   await page.click('#guest');
+  await waitForPageJsLoad(page);
 }
 
 export const loginAsTestUser = async (page: Page) => {
@@ -55,6 +63,7 @@ export const loginAsTestUser = async (page: Page) => {
   } else {
     await page.click('#guest');
   }
+  await waitForPageJsLoad(page);
 }
 
 function isTestUser() {
@@ -82,6 +91,7 @@ export const selectApplicantLanguage = async (page: Page, language: string) => {
     await page.click(languageOption + ' input');
     await page.click('button:visible');
   }
+  await waitForPageJsLoad(page);
 
   const programIndexRegex = /applicants\/\d+\/programs/;
   const maybeProgramIndexPage = await page.url();

--- a/browser-test/src/support/wait.ts
+++ b/browser-test/src/support/wait.ts
@@ -1,0 +1,23 @@
+import { Page } from 'playwright'
+
+/**
+ * Civiform attaches JS event handlers after pages load, so after any action
+ * that loads a new page, browser tests should call this function to wait
+ * for pages to be fully operational and ready to test.
+ */
+export const waitForPageJsLoad = async (page: Page) => {
+  await page.waitForLoadState('load');
+
+  // Wait for main.ts and modal.ts to signal that they're done initializing
+  await page.waitForSelector('body[data-load-main="true"]');
+  await page.waitForSelector('body[data-load-modal="true"]');
+}
+
+/**
+ * Click on the button to trigger a modal.ts dialog and wait for it to appear.
+ * @param modalId ID of the modal dialog without the leading #
+ */
+export const clickAndWaitForModal = async (page: Page, modalId: string) => {
+  await page.click(`#${modalId}-button`);
+  await page.waitForSelector(`#${modalId}:not(.hidden)`);
+}

--- a/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/main.ts
@@ -148,7 +148,7 @@ function removeExistingEnumeratorField(event: Event) {
 
 /**
  * Remove line-clamp from div on click.
- * 
+ *
  * NOTE: This is in no way discoverable, but it's just a temporary fix until we have a program
  * landing page.
  */
@@ -354,4 +354,7 @@ window.addEventListener('load', (event) => {
   // Configure existing enumerator entity remove buttons
   Array.from(document.querySelectorAll('.cf-enumerator-delete-button')).forEach(
     el => el.addEventListener('click', removeExistingEnumeratorField));
+
+  // Advertise (e.g., for browser tests) that main.ts initialization is done
+  document.body.dataset.loadMain = 'true';
 });

--- a/universal-application-tool-0.0.1/app/assets/javascripts/modal.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/modal.ts
@@ -24,11 +24,15 @@ class ModalController {
           modal.classList.toggle('hidden');
         });
       }
+
     });
   }
 
   constructor() {
     this.attachModalListeners();
+
+    // Advertise (e.g., for browser tests) that modal.ts initialization is done
+    document.body.dataset.loadModal = 'true';
   }
 }
 


### PR DESCRIPTION
### Description
Browser tests were flaky because they would start running while civiform JS would still be initializing (e.g., attaching event handlers). This PR adds some attributes for main.ts and modal.ts (the main causes of flakiness) to signal when they're done, and some browser test functions to wait for our pages to be ready and modals to be shown. Also tweaked a few selectors to make sure that playwright is waiting for DOM elements that signal when the page is actually ready for its next actions.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1309 
