### PR TITLE
Updated text for 2nd address line prompt.

### DIFF
--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -190,7 +190,7 @@ content.pleaseCreateAccount=If you sign into a city account now, your informatio
 #----------------------------------------------------------#
 
 # Address question labels - these are shown as the field label before an input box.
-label.addressLine2=Address line 2
+label.addressLine2=Unit/Apartment Number
 label.city=City
 label.state=State
 label.street=Address line 1

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -46,7 +46,7 @@ content.description2=Get started by choosing an application below.
 
 label.street=Address line 1
 placeholder.street=Street address
-label.addressLine2=Address line 2
+label.addressLine2=Unit/Apartment Number
 placeholder.line2=Apartment, suite, unit, building, floor, etc.
 label.city=City
 placeholder.city=City


### PR DESCRIPTION
### Description
Updated messages and messages.en-US with requested replacement text for "Address line 2" address field prompt. Translations should be handled by #1629.


### Issue(s)
Fixes #1622 
