### PR TITLE
Separate hidden browser test to two tests; avoid login flakiness

### DIFF
--- a/browser-test/src/admin_program_hidden.test.ts
+++ b/browser-test/src/admin_program_hidden.test.ts
@@ -48,6 +48,7 @@ describe('Hide a program that should not be public yet', () => {
 
     // Verify applicants can now see the program
     await loginAsGuest(page);
+    const applicantQuestions = new ApplicantQuestions(page);
     await selectApplicantLanguage(page, 'English');
     await applicantQuestions.expectProgramPublic(programName, programDescription);
 

--- a/browser-test/src/admin_program_hidden.test.ts
+++ b/browser-test/src/admin_program_hidden.test.ts
@@ -1,7 +1,7 @@
-import { startSession, loginAsProgramAdmin, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsTestUser, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
+import { startSession, loginAsProgramAdmin, loginAsAdmin, AdminQuestions, AdminPrograms, endSession, logout, loginAsGuest, selectApplicantLanguage, ApplicantQuestions, userDisplayName } from './support'
 
 describe('Hide a program that should not be public yet', () => {
-  it('Create a new hidden program, verify applicants cannot see it on the home page, unhide the program, verify applicant access', async () => {
+  it('Create a new hidden program, verify applicants cannot see it on the home page', async () => {
     const { browser, page } = await startSession()
     page.setDefaultTimeout(5000);
 
@@ -17,7 +17,7 @@ describe('Hide a program that should not be public yet', () => {
 
     // Login as applicant
     await logout(page);
-    await loginAsTestUser(page);
+    await loginAsGuest(page);
     await selectApplicantLanguage(page, 'English');
     const applicantQuestions = new ApplicantQuestions(page);
     await applicantQuestions.validateHeader('en-US');
@@ -26,19 +26,31 @@ describe('Hide a program that should not be public yet', () => {
     await applicantQuestions.expectProgramHidden(programName);
 
     await logout(page);
-    await loginAsAdmin(page);
+    await endSession(browser);
+  });
 
-    // Unhide the program and publish
-    await adminPrograms.createPublicVersion(programName);
+  it('create a public program, verify applicants can see it on the home page', async () => {
+    const { browser, page } = await startSession()
+    page.setDefaultTimeout(5000);
+
+    await loginAsAdmin(page);
+    const adminQuestions = new AdminQuestions(page);
+    const adminPrograms = new AdminPrograms(page);
+
+    // Create a hidden program
+    const programName = 'Public Program';
+    const programDescription = 'Description';
+    await adminPrograms.addProgram(programName, programDescription, "", false);
     await adminPrograms.publishAllPrograms();
 
+    // Login as applicant
     await logout(page);
 
     // Verify applicants can now see the program
-    await loginAsTestUser(page);
+    await loginAsGuest(page);
     await selectApplicantLanguage(page, 'English');
     await applicantQuestions.expectProgramPublic(programName, programDescription);
 
     await endSession(browser);
-  })
+  });
 })


### PR DESCRIPTION
### Description
Logging in and out multiple times in the same test is causing flakiness when running probe and deploy.  Separating into two for better reliability.  

