### PR TITLE
Modify review button so that changes are saved

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -137,8 +137,7 @@ describe('End to end enumerator test', () => {
 
     await applicantQuestions.deleteEnumeratorEntity("Bugs");
     await applicantQuestions.deleteEnumeratorEntity("Daffy");
-    // Submit the answers by clicking next, and then go to review page.
-    await applicantQuestions.clickNext();
+    // Submit the answers and then go to review page.
     await applicantQuestions.clickReview();
 
     // Make sure there are no enumerators or repeated things in the review page
@@ -158,7 +157,6 @@ describe('End to end enumerator test', () => {
     await applicantQuestions.addEnumeratorAnswer("Tweety");
     await applicantQuestions.clickNext();
     await applicantQuestions.answerNameQuestion("Tweety", "Bird");
-    await applicantQuestions.clickNext();
     await applicantQuestions.clickReview();
 
     // Make sure there are no enumerators or repeated things in the review page

--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -254,7 +254,7 @@ class ValidationController {
       this.updateFieldErrorState(question, '.cf-address-zip', hasValidZip);
 
       const hasEmptyInputs = addressLine1Empty || cityEmpty || stateEmpty || zipEmpty;
-      const hasValidPresentInputs = !hasEmptyInputs && hasValidZip ;
+      const hasValidPresentInputs = !hasEmptyInputs && hasValidZip;
 
       // If this question isn't required then it's also valid if it is empty.
       const isOptional = !question.classList.contains(ValidationController.REQUIRED_QUESTION_CLASS);
@@ -273,13 +273,13 @@ class ValidationController {
   validateCurrencyQuestion(): boolean {
     let isAllValid = true;
     const questions = Array.from(document.querySelectorAll(ValidationController.CURRENCY_QUESTION_CLASS));
-    for( const question of questions) {
+    for (const question of questions) {
       const currencyInput = <HTMLInputElement>question.querySelector("input[currency]");
       const currencyValue = currencyInput.value;
 
       const isValidCurrency = ValidationController.CURRENCY_NO_COMMAS.test(currencyValue) ||
-          ValidationController.CURRENCY_WITH_COMMAS.test(currencyValue) ||
-          ValidationController.CURRENCY_ZERO_DOLLARS.test(currencyValue);
+        ValidationController.CURRENCY_WITH_COMMAS.test(currencyValue) ||
+        ValidationController.CURRENCY_ZERO_DOLLARS.test(currencyValue);
 
       // If this question isn't required then it's also valid if it is empty.
       const isEmpty = currencyValue.length === 0;

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -1,7 +1,6 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
@@ -268,8 +267,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
     String reviewUrl =
         routes.ApplicantProgramReviewController.review(params.applicantId(), params.programId())
             .url();
-    return a().attr(HREF, reviewUrl)
-        .withText(params.messages().at(MessageKey.BUTTON_REVIEW.getKeyName()))
+    return submitButton(params.messages().at(MessageKey.BUTTON_REVIEW.getKeyName()))
+        .attr(HREF, reviewUrl)
         .withId("review-application-button")
         .withClasses(ApplicantStyles.BUTTON_REVIEW);
   }


### PR DESCRIPTION
### Description
Modify Applicant review button at bottom of block so that edits to the applicant's answers are saved.  Updated browser test so that places where next was hit to save and then review, now review is hit itself and the answers are saved

### Checklist
- [X] Created tests which fail without the change (if possible)

### Issue(s)
Fixes #1670 
