### PR TITLE
Make email addresses case sensitive when promoting accounts to Program Admin Role

### DIFF
--- a/universal-application-tool-0.0.1/app/services/role/RoleService.java
+++ b/universal-application-tool-0.0.1/app/services/role/RoleService.java
@@ -61,13 +61,9 @@ public class RoleService {
         getGlobalAdmins().stream()
             .map(Account::getEmailAddress)
             .filter(address -> !Strings.isNullOrEmpty(address))
-            .map(String::toLowerCase)
             .collect(toImmutableSet());
     ImmutableSet.Builder<String> invalidEmailBuilder = ImmutableSet.builder();
-    // Make all email strings lowercase so that email comparison is case insensitive.
-    ImmutableSet<String> accountEmailsLowerCase =
-        accountEmails.stream().map(String::toLowerCase).collect(toImmutableSet());
-    accountEmailsLowerCase.forEach(
+    accountEmails.forEach(
         email -> {
           if (sysAdminEmails.contains(email)) {
             invalidEmailBuilder.add(email);

--- a/universal-application-tool-0.0.1/test/services/role/RoleServiceTest.java
+++ b/universal-application-tool-0.0.1/test/services/role/RoleServiceTest.java
@@ -53,8 +53,8 @@ public class RoleServiceTest extends WithPostgresContainer {
     assertThat(account2.getAdministeredProgramNames()).containsOnly(programName);
   }
 
-    @Test
-    public void makeProgramAdmins_emailsAreCaseSensitive() throws ProgramNotFoundException {
+  @Test
+  public void makeProgramAdmins_emailsAreCaseSensitive() throws ProgramNotFoundException {
     String emailUpperCase = "Fake.Person@email.com";
     String emailLowerCase = "fake.person@email.com";
     Account account = new Account();
@@ -82,7 +82,6 @@ public class RoleServiceTest extends WithPostgresContainer {
     // Lookup the upper case account. They now have permissions to the program.
     account = userRepository.lookupAccount(emailUpperCase).get();
     assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
-
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/role/RoleServiceTest.java
+++ b/universal-application-tool-0.0.1/test/services/role/RoleServiceTest.java
@@ -54,49 +54,6 @@ public class RoleServiceTest extends WithPostgresContainer {
   }
 
   @Test
-  public void makeProgramAdmins_emailsAreCaseInsensitive() throws ProgramNotFoundException {
-    String emailUpperCase = "Fake.Person@email.com";
-    String emailLowerCase = "fake.person@email.com";
-    Account account = new Account();
-    account.setEmailAddress(emailLowerCase);
-    account.save();
-
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
-
-    Optional<CiviFormError> result =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(emailUpperCase));
-
-    assertThat(result).isEmpty();
-
-    account = userRepository.lookupAccount(emailLowerCase).get();
-
-    assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
-  }
-
-  @Test
-  public void makeProgramAdmins_emailsAreCaseInsensitive_accountHasUpperCaseEmail()
-      throws ProgramNotFoundException {
-    String emailUpperCase = "Fake.Person@email.com";
-    String emailLowerCase = "fake.person@email.com";
-    Account account = new Account();
-    account.setEmailAddress(emailUpperCase);
-    account.save();
-
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
-
-    Optional<CiviFormError> result =
-        service.makeProgramAdmins(program.id, ImmutableSet.of(emailLowerCase));
-
-    assertThat(result).isEmpty();
-
-    account = userRepository.lookupAccount(emailLowerCase).get();
-
-    assertThat(account.getAdministeredProgramNames()).containsOnly(programName);
-  }
-
-  @Test
   public void makeProgramAdmins_emptyList_returnsEmptyOptional() throws ProgramNotFoundException {
     assertThat(service.makeProgramAdmins(1L, ImmutableSet.of())).isEmpty();
   }


### PR DESCRIPTION
### Description
This change reverts the change in https://github.com/seattle-uat/civiform/pull/1641. 

This will allow Seattle city admins to be added as program admins and they will be case sensitive. This means that Seattle city admins will have to be added with title case.

This fix is a step in the right direction of figuring out how Civiform will handle case sensitivity for accounts. We still need to make a larger design decision about how Civiform will handle case sensitivity for accounts. Until then, this fix will do!

### Checklist
- [X] Created tests which fail without the change (if possible) -- removed tests
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Addresses #1612, #1665
