### PR TITLE
Fix localstack failure

### DIFF
--- a/bin/localstack/wait
+++ b/bin/localstack/wait
@@ -18,7 +18,7 @@ deadline=$(($start_time + 200))
 echo "Waiting for localstack to get set up. This may take a minute or two..."
 
 healthy() {
-    [[ $1 == *'"s3": "running"'* && $1 == *'"ses": "running"'* ]]
+    [[ $1 == *'"s3": "available"'* && $1 == *'"ses": "available"'* ]]
 }
 
 until HEALTHCHECK=$(curl --silent --fail --max-time 2 $localstack_endpoint/health) && healthy "$HEALTHCHECK"; do


### PR DESCRIPTION
### Description
Localstack used to say services were "running", but they have updated to use "available" instead. We debugged by adding  logs to the healthy() check in the wait script and saw that all services were appearing as "available".  Tested and this fixes the browser test failures. 

Paired with @bion 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

