### PR TITLE
Make localstack change backwards compatible

### DIFF
--- a/bin/localstack/wait
+++ b/bin/localstack/wait
@@ -18,7 +18,7 @@ deadline=$(($start_time + 200))
 echo "Waiting for localstack to get set up. This may take a minute or two..."
 
 healthy() {
-    [[ $1 == *'"s3": "available"'* && $1 == *'"ses": "available"'* ]]
+    [[ ($1 == *'"s3": "available"'* || $1 == *'"s3": "running"'*) && ($1 == *'"ses": "available"'* || $1 == *'"ses": "running"'*) ]]
 }
 
 until HEALTHCHECK=$(curl --silent --fail --max-time 2 $localstack_endpoint/health) && healthy "$HEALTHCHECK"; do

--- a/bin/localstack/wait
+++ b/bin/localstack/wait
@@ -18,7 +18,7 @@ deadline=$(($start_time + 200))
 echo "Waiting for localstack to get set up. This may take a minute or two..."
 
 healthy() {
-    [[ $1 == *'"s3": "running"'* && $1 == *'"ses": "running"'* ]]
+    [[ $1 == *'"s3": "available"'* && $1 == *'"ses": "available"'* ]]
 }
 
 until HEALTHCHECK=$(curl --silent --fail --max-time 2 $localstack_endpoint/health) && healthy "$HEALTHCHECK"; do


### PR DESCRIPTION
### Description
Make localstack change backwards compatible by accepting "running" and "available". Since localstack is cached locally, we have the old version but github has the new one

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary


