### PR TITLE
Update registration URI for new IDCS deployment

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -18,7 +18,7 @@ Mappings:
       group: ad\ITD_CiviForm_Admins_Test
   Registration:
     prod:
-      uri: https://login.seattle.gov/#/registration
+      uri: https://login.seattle.gov/#/registration?appName=CiviForm
     staging:
       uri: https://qalogin.seattle.gov:12443/#/registration?appName=CIVIFORM_STAGE
 Parameters:


### PR DESCRIPTION
### Description
Updated registration URL after new IDCS deployment to fix redirect back to civiform after registration.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1585 
