### PR TITLE
Closes #1698

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -119,6 +119,7 @@ public class ProgramServiceImpl implements ProgramService {
     validateProgramText(errorsBuilder, "admin description", adminDescription);
     validateProgramText(errorsBuilder, "display name", defaultDisplayName);
     validateProgramText(errorsBuilder, "display description", defaultDisplayDescription);
+    validateProgramText(errorsBuilder, "display mode", displayMode);
     ImmutableSet<CiviFormError> errors = errorsBuilder.build();
     if (!errors.isEmpty()) {
       return ErrorAnd.error(errors);

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -148,7 +148,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
-    assertThat(result.getErrors()).containsExactly(CiviFormError.of("program display mode cannot be blank"));
+    assertThat(result.getErrors()).containsExactly(
+        CiviFormError.of("program display mode cannot be blank"));
   }
 
   @Test
@@ -179,15 +180,15 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   @Test
   public void updateProgram_withNoProgram_throwsProgramNotFoundException() {
     assertThatThrownBy(
-            () ->
-                ps.updateProgramDefinition(
-                    1L,
-                    Locale.US,
-                    "new description",
-                    "name",
-                    "description",
-                    "",
-                    DisplayMode.PUBLIC.getValue()))
+        () ->
+            ps.updateProgramDefinition(
+                1L,
+                Locale.US,
+                "new description",
+                "name",
+                "description",
+                "",
+                DisplayMode.PUBLIC.getValue()))
         .isInstanceOf(ProgramNotFoundException.class)
         .hasMessage("Program not found for ID: 1");
   }
@@ -462,7 +463,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void
-      addRepeatedBlockToProgram_invalidEnumeratorId_throwsProgramBlockDefinitionNotFoundException() {
+  addRepeatedBlockToProgram_invalidEnumeratorId_throwsProgramBlockDefinitionNotFoundException() {
     Program program = ProgramBuilder.newActiveProgram().build();
 
     assertThatThrownBy(() -> ps.addRepeatedBlockToProgram(program.id, 5L))
@@ -595,7 +596,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void
-      addQuestionsToBlock_withDuplicatedQuestions_throwsDuplicateProgramQuestionException() {
+  addQuestionsToBlock_withDuplicatedQuestions_throwsDuplicateProgramQuestionException() {
     QuestionDefinition questionA = nameQuestion;
 
     Program program =
@@ -605,7 +606,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
             .build();
 
     assertThatThrownBy(
-            () -> ps.addQuestionsToBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
+        () -> ps.addQuestionsToBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
         .isInstanceOf(DuplicateProgramQuestionException.class)
         .hasMessage(
             String.format(
@@ -638,7 +639,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     Program program = ProgramBuilder.newDraftProgram().withBlock().build();
 
     assertThatThrownBy(
-            () -> ps.removeQuestionsFromBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
+        () -> ps.removeQuestionsFromBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
         .isInstanceOf(QuestionNotFoundException.class)
         .hasMessage(
             String.format(
@@ -714,15 +715,15 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   public void setBlockPredicate_withBogusBlockId_throwsProgramBlockDefinitionNotFoundException() {
     ProgramDefinition p = ProgramBuilder.newDraftProgram().buildDefinition();
     assertThatThrownBy(
-            () ->
-                ps.setBlockPredicate(
-                    p.id(),
-                    100L,
-                    PredicateDefinition.create(
-                        PredicateExpressionNode.create(
-                            LeafOperationExpressionNode.create(
-                                1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of(""))),
-                        PredicateAction.HIDE_BLOCK)))
+        () ->
+            ps.setBlockPredicate(
+                p.id(),
+                100L,
+                PredicateDefinition.create(
+                    PredicateExpressionNode.create(
+                        LeafOperationExpressionNode.create(
+                            1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of(""))),
+                    PredicateAction.HIDE_BLOCK)))
         .isInstanceOf(ProgramBlockDefinitionNotFoundException.class)
         .hasMessage(
             String.format(
@@ -820,41 +821,41 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     Long programId = programDefinition.id();
 
     assertThat(
-            programDefinition
-                .getBlockDefinitionByIndex(0)
-                .get()
-                .programQuestionDefinitions()
-                .get(0)
-                .optional())
+        programDefinition
+            .getBlockDefinitionByIndex(0)
+            .get()
+            .programQuestionDefinitions()
+            .get(0)
+            .optional())
         .isFalse();
 
     programDefinition =
         ps.setProgramQuestionDefinitionOptionality(programId, 1L, nameQuestion.getId(), true);
     assertThat(
-            programDefinition
-                .getBlockDefinitionByIndex(0)
-                .get()
-                .programQuestionDefinitions()
-                .get(0)
-                .optional())
+        programDefinition
+            .getBlockDefinitionByIndex(0)
+            .get()
+            .programQuestionDefinitions()
+            .get(0)
+            .optional())
         .isTrue();
 
     programDefinition =
         ps.setProgramQuestionDefinitionOptionality(programId, 1L, nameQuestion.getId(), false);
     assertThat(
-            programDefinition
-                .getBlockDefinitionByIndex(0)
-                .get()
-                .programQuestionDefinitions()
-                .get(0)
-                .optional())
+        programDefinition
+            .getBlockDefinitionByIndex(0)
+            .get()
+            .programQuestionDefinitions()
+            .get(0)
+            .optional())
         .isFalse();
 
     // Checking that there's no problem
     assertThatThrownBy(
-            () ->
-                ps.setProgramQuestionDefinitionOptionality(
-                    programId, 1L, nameQuestion.getId() + 1, false))
+        () ->
+            ps.setProgramQuestionDefinitionOptionality(
+                programId, 1L, nameQuestion.getId() + 1, false))
         .isInstanceOf(ProgramQuestionDefinitionNotFoundException.class);
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -148,8 +148,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
-    assertThat(result.getErrors()).containsExactly(
-        CiviFormError.of("program display mode cannot be blank"));
+    assertThat(result.getErrors())
+        .containsExactly(CiviFormError.of("program display mode cannot be blank"));
   }
 
   @Test
@@ -180,15 +180,15 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   @Test
   public void updateProgram_withNoProgram_throwsProgramNotFoundException() {
     assertThatThrownBy(
-        () ->
-            ps.updateProgramDefinition(
-                1L,
-                Locale.US,
-                "new description",
-                "name",
-                "description",
-                "",
-                DisplayMode.PUBLIC.getValue()))
+            () ->
+                ps.updateProgramDefinition(
+                    1L,
+                    Locale.US,
+                    "new description",
+                    "name",
+                    "description",
+                    "",
+                    DisplayMode.PUBLIC.getValue()))
         .isInstanceOf(ProgramNotFoundException.class)
         .hasMessage("Program not found for ID: 1");
   }
@@ -463,7 +463,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void
-  addRepeatedBlockToProgram_invalidEnumeratorId_throwsProgramBlockDefinitionNotFoundException() {
+      addRepeatedBlockToProgram_invalidEnumeratorId_throwsProgramBlockDefinitionNotFoundException() {
     Program program = ProgramBuilder.newActiveProgram().build();
 
     assertThatThrownBy(() -> ps.addRepeatedBlockToProgram(program.id, 5L))
@@ -596,7 +596,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void
-  addQuestionsToBlock_withDuplicatedQuestions_throwsDuplicateProgramQuestionException() {
+      addQuestionsToBlock_withDuplicatedQuestions_throwsDuplicateProgramQuestionException() {
     QuestionDefinition questionA = nameQuestion;
 
     Program program =
@@ -606,7 +606,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
             .build();
 
     assertThatThrownBy(
-        () -> ps.addQuestionsToBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
+            () -> ps.addQuestionsToBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
         .isInstanceOf(DuplicateProgramQuestionException.class)
         .hasMessage(
             String.format(
@@ -639,7 +639,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     Program program = ProgramBuilder.newDraftProgram().withBlock().build();
 
     assertThatThrownBy(
-        () -> ps.removeQuestionsFromBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
+            () -> ps.removeQuestionsFromBlock(program.id, 1L, ImmutableList.of(questionA.getId())))
         .isInstanceOf(QuestionNotFoundException.class)
         .hasMessage(
             String.format(
@@ -715,15 +715,15 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   public void setBlockPredicate_withBogusBlockId_throwsProgramBlockDefinitionNotFoundException() {
     ProgramDefinition p = ProgramBuilder.newDraftProgram().buildDefinition();
     assertThatThrownBy(
-        () ->
-            ps.setBlockPredicate(
-                p.id(),
-                100L,
-                PredicateDefinition.create(
-                    PredicateExpressionNode.create(
-                        LeafOperationExpressionNode.create(
-                            1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of(""))),
-                    PredicateAction.HIDE_BLOCK)))
+            () ->
+                ps.setBlockPredicate(
+                    p.id(),
+                    100L,
+                    PredicateDefinition.create(
+                        PredicateExpressionNode.create(
+                            LeafOperationExpressionNode.create(
+                                1L, Scalar.CITY, Operator.EQUAL_TO, PredicateValue.of(""))),
+                        PredicateAction.HIDE_BLOCK)))
         .isInstanceOf(ProgramBlockDefinitionNotFoundException.class)
         .hasMessage(
             String.format(
@@ -821,41 +821,41 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
     Long programId = programDefinition.id();
 
     assertThat(
-        programDefinition
-            .getBlockDefinitionByIndex(0)
-            .get()
-            .programQuestionDefinitions()
-            .get(0)
-            .optional())
+            programDefinition
+                .getBlockDefinitionByIndex(0)
+                .get()
+                .programQuestionDefinitions()
+                .get(0)
+                .optional())
         .isFalse();
 
     programDefinition =
         ps.setProgramQuestionDefinitionOptionality(programId, 1L, nameQuestion.getId(), true);
     assertThat(
-        programDefinition
-            .getBlockDefinitionByIndex(0)
-            .get()
-            .programQuestionDefinitions()
-            .get(0)
-            .optional())
+            programDefinition
+                .getBlockDefinitionByIndex(0)
+                .get()
+                .programQuestionDefinitions()
+                .get(0)
+                .optional())
         .isTrue();
 
     programDefinition =
         ps.setProgramQuestionDefinitionOptionality(programId, 1L, nameQuestion.getId(), false);
     assertThat(
-        programDefinition
-            .getBlockDefinitionByIndex(0)
-            .get()
-            .programQuestionDefinitions()
-            .get(0)
-            .optional())
+            programDefinition
+                .getBlockDefinitionByIndex(0)
+                .get()
+                .programQuestionDefinitions()
+                .get(0)
+                .optional())
         .isFalse();
 
     // Checking that there's no problem
     assertThatThrownBy(
-        () ->
-            ps.setProgramQuestionDefinitionOptionality(
-                programId, 1L, nameQuestion.getId() + 1, false))
+            () ->
+                ps.setProgramQuestionDefinitionOptionality(
+                    programId, 1L, nameQuestion.getId() + 1, false))
         .isInstanceOf(ProgramQuestionDefinitionNotFoundException.class);
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -142,6 +142,16 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
+  public void createProgram_withoutDisplayMode_returnsError() {
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.createProgramDefinition("ProgramService", "description", "name", "description", "", "");
+
+    assertThat(result.hasResult()).isFalse();
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors()).containsExactly(CiviFormError.of("program display mode cannot be blank"));
+  }
+
+  @Test
   public void createProgram_protectsAgainstProgramNameCollisions() {
     ps.createProgramDefinition(
         "name",

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -142,7 +142,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void createProgram_withoutDisplayMode_returnsError() {
+  public void createProgramWithoutDisplayMode_returnsError() {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition("ProgramService", "description", "name", "description", "", "");
 


### PR DESCRIPTION
Closes #1698

### Description
Makes display mode a required field for the front end when an admin creates a new program.

### Change in user behavior
In the past, when an admin tried to add a program without setting the display mode (public or hidden in index), they would be able to hit create, then they would see a generic backend error message. Now, while usesr are still on the program page, they will get an error message "display mode must be set".

Screenshot: 
<img width="1284" alt="Civiforrm program fix" src="https://user-images.githubusercontent.com/93745541/142148297-2860eea9-7305-4674-8e35-53723d3553b5.png">


### Issue(s)
Fixes #1698
