### PR TITLE
Correct submit time to only update on application submit

### DIFF
--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -3,6 +3,12 @@ import { startSession, logout, loginAsTestUser, loginAsGuest, loginAsProgramAdmi
 describe('normal application flow', () => {
   it('all major steps', async () => {
     const { browser, page } = await startSession();
+    // Timeout for clicks and element fills. If your selector fails to locate
+    // the HTML element, the test hangs. If you find the tests time out, you
+    // want to verify that your selectors are working as expected first.
+    // Because all tests are run concurrently, it could be that your selector
+    // selects a different entity from another test.
+    page.setDefaultTimeout(4000);
 
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page);

--- a/browser-test/src/application_csv_download.test.ts
+++ b/browser-test/src/application_csv_download.test.ts
@@ -3,12 +3,6 @@ import { startSession, logout, loginAsTestUser, loginAsGuest, loginAsProgramAdmi
 describe('normal application flow', () => {
   it('all major steps', async () => {
     const { browser, page } = await startSession();
-    // Timeout for clicks and element fills. If your selector fails to locate
-    // the HTML element, the test hangs. If you find the tests time out, you
-    // want to verify that your selectors are working as expected first.
-    // Because all tests are run concurrently, it could be that your selector
-    // selects a different entity from another test.
-    page.setDefaultTimeout(4000);
 
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page);

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -33,10 +33,10 @@ public class Application extends BaseModel {
   @Constraints.Required private LifecycleStage lifecycleStage;
 
   @CreatedTimestamp private Instant createTime;
-  @Constraints.Required private Instant submitTime;
 
   @Constraints.Required @DbJson private String object;
 
+  private Instant submitTime;
   private String preferredLocale;
   private String submitterEmail;
 

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -45,7 +45,6 @@ public class Application extends BaseModel {
     setApplicantData(applicant.getApplicantData());
     this.program = program;
     this.lifecycleStage = lifecycleStage;
-    setSubmitTimeToNow();
   }
 
   public Optional<String> getSubmitterEmail() {

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -34,7 +34,7 @@ public class Application extends BaseModel {
   @Constraints.Required private LifecycleStage lifecycleStage;
 
   @CreatedTimestamp private Instant createTime;
-  @UpdatedTimestamp private Instant submitTime;
+  @Constraints.Required private Instant submitTime;
 
   @Constraints.Required @DbJson private String object;
 
@@ -46,6 +46,7 @@ public class Application extends BaseModel {
     setApplicantData(applicant.getApplicantData());
     this.program = program;
     this.lifecycleStage = lifecycleStage;
+    setSubmitTimeToNow();
   }
 
   public Optional<String> getSubmitterEmail() {
@@ -94,5 +95,9 @@ public class Application extends BaseModel {
 
   public void setLifecycleStage(LifecycleStage stage) {
     this.lifecycleStage = stage;
+  }
+
+  public void setSubmitTimeToNow() {
+    this.submitTime = Instant.now();
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -2,7 +2,6 @@ package models;
 
 import io.ebean.annotation.CreatedTimestamp;
 import io.ebean.annotation.DbJson;
-import io.ebean.annotation.UpdatedTimestamp;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -83,6 +83,7 @@ public class ApplicationRepository {
         // Delete any in-progress drafts, and mark obsolete any old applications.
         if (application.getLifecycleStage().equals(LifecycleStage.DRAFT)) {
           application.setLifecycleStage(LifecycleStage.ACTIVE);
+          application.setSubmitTimeToNow();
           completedApplication = Optional.of(application);
         } else {
           application.setLifecycleStage(LifecycleStage.OBSOLETE);

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -92,6 +92,7 @@ public class ApplicationRepository {
       }
       Application application =
           completedApplication.orElse(new Application(applicant, program, LifecycleStage.ACTIVE));
+      application.setSubmitTimeToNow();
 
       if (submitterEmail.isPresent()) {
         application.setSubmitterEmail(submitterEmail.get());

--- a/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
+++ b/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
@@ -92,7 +92,7 @@ public class CsvExporter {
           printer.print(application.getCreateTime().toString());
           break;
         case SUBMIT_TIME:
-          printer.print(application.getSubmitTime().toString());
+          printer.print(application.getSubmitTime() != null ? application.getSubmitTime().toString() : EMPTY_VALUE);
           break;
         case SUBMITTER_EMAIL_OPAQUE:
           if (this.secret.isEmpty()) {

--- a/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
+++ b/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
@@ -92,7 +92,10 @@ public class CsvExporter {
           printer.print(application.getCreateTime().toString());
           break;
         case SUBMIT_TIME:
-          printer.print(application.getSubmitTime() != null ? application.getSubmitTime().toString() : EMPTY_VALUE);
+          printer.print(
+              application.getSubmitTime() != null
+                  ? application.getSubmitTime().toString()
+                  : EMPTY_VALUE);
           break;
         case SUBMITTER_EMAIL_OPAQUE:
           if (this.secret.isEmpty()) {

--- a/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
@@ -50,8 +50,9 @@ public class ApplicationRepositoryTest extends WithPostgresContainer {
     assertThat(
             repo.getApplication(appOne.id).toCompletableFuture().join().get().getLifecycleStage())
         .isEqualTo(LifecycleStage.OBSOLETE);
+    // Ensure the second submitted app has a later submit time than the first.
     assertThat(appThree.getSubmitTime()).isAfter(appOne.getSubmitTime());
-    // Ensure the submit time didn't get changed when the application was set as obsolete
+    // Ensure the submit time didn't get changed when the application was set as obsolete.
     assertThat(appOne.getSubmitTime()).isEqualTo(initialSubmitTime);
     // And that the DRAFT is now ACTIVE.
     assertThat(

--- a/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicationRepositoryTest.java
@@ -70,6 +70,8 @@ public class ApplicationRepositoryTest extends WithPostgresContainer {
         repo.createOrUpdateDraft(applicant, program).toCompletableFuture().join();
 
     assertThat(application.id).isEqualTo(applicationTwo.id);
+    // Since this is a draft application, it shouldn't have a submit time set.
+    assertThat(applicationTwo.getSubmitTime()).isNull();
   }
 
   private Applicant saveApplicant(String name) {

--- a/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
@@ -307,6 +307,7 @@ public class CsvExporterTest extends WithPostgresContainer {
         100);
     firstApplicant.save();
     Application firstApplication = new Application(firstApplicant, program, LifecycleStage.ACTIVE);
+    firstApplication.setSubmitTimeToNow();
     firstApplication.save();
 
     // Second applicant has one household member that has two jobs.
@@ -362,10 +363,12 @@ public class CsvExporterTest extends WithPostgresContainer {
     secondApplicant.save();
     Application secondApplication =
         new Application(secondApplicant, program, LifecycleStage.ACTIVE);
+    secondApplication.setSubmitTimeToNow();
     secondApplication.save();
 
     Application thirdApplication =
         new Application(secondApplicant, program, LifecycleStage.OBSOLETE);
+    thirdApplication.setSubmitTimeToNow();
     thirdApplication.save();
 
     // Generate default CSV


### PR DESCRIPTION
### Description
Previously, the submit date would get updated each time the db row was updated, which included when a new version of an application was submitted and the old one was marked as obsolete. Now, the submit time is updated when an application is first submitted and when a draft application is submitted, but not when an application changes from active to obsolete or when an application draft is saved. 

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1711