### PR TITLE
Deduplicate programs with draft applications.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramsController.java
@@ -6,6 +6,8 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import controllers.CiviFormController;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
@@ -14,6 +16,8 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import models.LifecycleStage;
 import org.pac4j.play.java.Secure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Http.Request;
@@ -38,6 +42,7 @@ public class ApplicantProgramsController extends CiviFormController {
   private final ProgramIndexView programIndexView;
   private final ApplicantProgramInfoView programInfoView;
   private final ProfileUtils profileUtils;
+  private final Logger logger = LoggerFactory.getLogger(ApplicantProgramsController.class);
 
   @Inject
   public ApplicantProgramsController(
@@ -66,23 +71,52 @@ public class ApplicantProgramsController extends CiviFormController {
             v -> applicantService.relevantPrograms(applicantId), httpContext.current())
         .thenApplyAsync(
             allPrograms -> {
-              Set<String> programsWithDraftApplication =
-                  allPrograms.get(LifecycleStage.DRAFT).stream()
+              ImmutableList<ProgramDefinition> programsWithDraftApplications =
+                  allPrograms.get(LifecycleStage.DRAFT);
+              Set<String> adminNames =
+                  programsWithDraftApplications.stream()
                       .map(ProgramDefinition::adminName)
                       .collect(Collectors.toSet());
               ImmutableList<ProgramDefinition> dedupedActivePrograms =
                   allPrograms.get(LifecycleStage.ACTIVE).stream()
                       .filter(
-                          programDefinition ->
-                              !programsWithDraftApplication.contains(programDefinition.adminName()))
+                          programDefinition -> !adminNames.contains(programDefinition.adminName()))
                       .collect(ImmutableList.toImmutableList());
+              // Deduplicate programs with draft applications. This is a temporary fix for a bug
+              // where some applicants were seeing duplicates of programs for which they had
+              // draft applications.
+              // We can remove this deduplication once we determine and resolve the root cause of
+              // the duplicate programs.
+              Map<String, Long> draftProgramDebugMap = new HashMap<>();
+              ImmutableList<ProgramDefinition> dedupedDraftPrograms =
+                  ImmutableList.copyOf(
+                      programsWithDraftApplications.stream()
+                          .filter(
+                              program -> {
+                                if (draftProgramDebugMap.containsKey(program.adminName())) {
+                                  // If we had to deduplicate, log data for debugging purposes.
+                                  logger.debug(
+                                      String.format(
+                                          "DEBUG LOG ID: 98afa07855eb8e69338b5af13236a6b7. Program"
+                                              + " Admin Name: %1$s, Duplicate Program Definition"
+                                              + " id: %2$s. Original Program Definition id: %3$s",
+                                          program.adminName(),
+                                          program.id(),
+                                          draftProgramDebugMap.get(program.adminName())));
+                                  return false;
+                                } else {
+                                  draftProgramDebugMap.put(program.adminName(), program.id());
+                                  return true;
+                                }
+                              })
+                          .collect(Collectors.toList()));
               return ok(
                   programIndexView.render(
                       messagesApi.preferred(request),
                       request,
                       applicantId,
                       applicantStage.toCompletableFuture().join(),
-                      allPrograms.get(LifecycleStage.DRAFT),
+                      dedupedDraftPrograms,
                       dedupedActivePrograms,
                       banner));
             },

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -77,7 +77,6 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     assertThat(contentAsString(result)).doesNotContain("three");
   }
 
-  // VersionRepositoryTest might have good examples
   @Test
   public void test_deduplicate_inProgressPrograms() {
     versionRepository = instanceOf(VersionRepository.class);


### PR DESCRIPTION
### Description
Deduplicate programs with draft applications. This PR addresses #1713 - it is a temporary fix but not a root cause fix. This change deduplicates programs that fall under the applicants "Continue" section, meaning they have a draft application for that program. 

To determine the root cause of the issue, I needed to add logging to help determine if the duplicate programs with draft applications are coming from the query response.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Addresses #1713
