### PR TITLE
Cache program definition database lookups to reduce export time.

### DIFF
--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -150,12 +150,20 @@ public class ExporterService {
     try {
       OutputStream inMemoryBytes = new ByteArrayOutputStream();
       Writer writer = new OutputStreamWriter(inMemoryBytes, StandardCharsets.UTF_8);
+      HashMap<Long, ProgramDefinition> programDefinitions = new HashMap<>();
       for (Application application : applications) {
+        Long programId = application.getProgram().id;
+        if (!programDefinitions.containsKey(programId)) {
+          try {
+            programDefinitions.put(programId, programService.getProgramDefinition(programId));
+          } catch (ProgramNotFoundException e) {
+            throw new RuntimeException("Cannot find a program that has applications for it.", e);
+          }
+        }
+        ProgramDefinition programDefinition = programDefinitions.get(programId);
+
         ReadOnlyApplicantProgramService roApplicantService =
-            applicantService
-                .getReadOnlyApplicantProgramService(application)
-                .toCompletableFuture()
-                .join();
+                applicantService.getReadOnlyApplicantProgramService(application, programDefinition);
         csvExporter.export(application, roApplicantService, writer);
       }
       writer.close();

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -150,7 +150,7 @@ public class ExporterService {
     try {
       OutputStream inMemoryBytes = new ByteArrayOutputStream();
       Writer writer = new OutputStreamWriter(inMemoryBytes, StandardCharsets.UTF_8);
-      // Cache Program data so we only look it up once rather than on every exported row.
+      // Cache Program data which doesn't change, so we only look it up once rather than on every exported row.
       // TODO: Lookup all relevant programs in one request to reduce cost of N lookups.
       // TODO: Consider Play's JavaCache over this caching.
       HashMap<Long, ProgramDefinition> programDefinitions = new HashMap<>();

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -193,6 +193,8 @@ public class ExporterService {
     // Create a map from a key <block id, question index> to an answer with every application. It
     // doesn't matter which answer ends up in the map, as long as every <block id, question index>
     // is accounted for.
+    // TODO: Lookup all relevant programs in one request to reduce cost of N lookups.
+    // TODO: Consider Play's JavaCache over this caching.
     Map<String, AnswerData> answerMap = new HashMap<>();
     for (Application application : applications) {
       ReadOnlyApplicantProgramService roApplicantService =

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -163,7 +163,7 @@ public class ExporterService {
         ProgramDefinition programDefinition = programDefinitions.get(programId);
 
         ReadOnlyApplicantProgramService roApplicantService =
-                applicantService.getReadOnlyApplicantProgramService(application, programDefinition);
+            applicantService.getReadOnlyApplicantProgramService(application, programDefinition);
         csvExporter.export(application, roApplicantService, writer);
       }
       writer.close();

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -150,6 +150,9 @@ public class ExporterService {
     try {
       OutputStream inMemoryBytes = new ByteArrayOutputStream();
       Writer writer = new OutputStreamWriter(inMemoryBytes, StandardCharsets.UTF_8);
+      // Cache Program data so we only look it up once rather than on every exported row.
+      // TODO: Lookup all relevant programs in one request to reduce cost of N lookups.
+      // TODO: Consider Play's JavaCache over this caching.
       HashMap<Long, ProgramDefinition> programDefinitions = new HashMap<>();
       for (Application application : applications) {
         Long programId = application.getProgram().id;
@@ -193,8 +196,6 @@ public class ExporterService {
     // Create a map from a key <block id, question index> to an answer with every application. It
     // doesn't matter which answer ends up in the map, as long as every <block id, question index>
     // is accounted for.
-    // TODO: Lookup all relevant programs in one request to reduce cost of N lookups.
-    // TODO: Consider Play's JavaCache over this caching.
     Map<String, AnswerData> answerMap = new HashMap<>();
     for (Application application : applications) {
       ReadOnlyApplicantProgramService roApplicantService =

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -150,9 +150,10 @@ public class ExporterService {
     try {
       OutputStream inMemoryBytes = new ByteArrayOutputStream();
       Writer writer = new OutputStreamWriter(inMemoryBytes, StandardCharsets.UTF_8);
-      // Cache Program data which doesn't change, so we only look it up once rather than on every exported row.
-      // TODO: Lookup all relevant programs in one request to reduce cost of N lookups.
-      // TODO: Consider Play's JavaCache over this caching.
+      // Cache Program data which doesn't change, so we only look it up once rather than on every
+      // exported row.
+      // TODO(#1750): Lookup all relevant programs in one request to reduce cost of N lookups.
+      // TODO(#1750): Consider Play's JavaCache over this caching.
       HashMap<Long, ProgramDefinition> programDefinitions = new HashMap<>();
       for (Application application : applications) {
         Long programId = application.getProgram().id;


### PR DESCRIPTION
Cache program definition database lookups to reduce export time.

This saves most of the per-row processing time.  Locally 4300 rows went from ~60s to 10s to export.

### Description
exportCsv method maintains a cache of Program data so that it's not looked up for every row that pertains to the Program.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1747