### PR TITLE
Use updated dependency syntax

### DIFF
--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -89,12 +89,13 @@ lazy val root = (project in file("."))
       "-Werror"
     ),
     // Make verbose tests
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
+    Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     // Use test config for tests
-    javaOptions in Test += "-Dconfig.file=conf/application.test.conf",
+    Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     // Turn off scaladoc link warnings
-    scalacOptions in (Compile, doc) += "-no-link-warnings"
+    Compile / doc / scalacOptions += "-no-link-warnings"
   )
+
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
 resolvers += Resolver.bintrayRepo("webjars","maven")
 libraryDependencies ++= Seq(

--- a/universal-application-tool-0.0.1/tailwindbuilder.sbt
+++ b/universal-application-tool-0.0.1/tailwindbuilder.sbt
@@ -11,7 +11,5 @@ tailwindCli := {
 }
 
 dist := (dist dependsOn tailwindCli).value
-
 stage := (stage dependsOn tailwindCli).value
-
-test := ((test in Test) dependsOn tailwindCli).value
+test := (Test / test dependsOn tailwindCli).value


### PR DESCRIPTION
The `in` keyword is deprecated in sbt in favor of `/` syntax. This updates our build files to the newer syntax.