### PR TITLE
Use docker hub container registry for everything except deployment

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from public.ecr.aws/t1q6b4h2/civiform-dev:latest ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Run tests
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform test
 
@@ -29,7 +29,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from public.ecr.aws/t1q6b4h2/civiform-dev:latest ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -58,7 +58,7 @@ jobs:
       - name: Build prod container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f prod.Dockerfile -t civiform:prod --cache-from public.ecr.aws/t1q6b4h2/universal-application-tool:latest ./
+        run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
       - name: Build the stack
         env:
           SECRET_KEY: notarealsecret

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,6 +33,8 @@ jobs:
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: bin/build-browser-tests
       - name: Start localstack
         run: docker-compose -f browser-test/browser-test-compose.yml up -d localstack

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -10,7 +10,7 @@ set +x
 docker build -t civiform-browser-test \
   browser-test \
   -f browser-test/playwright.Dockerfile \
-  --cache-from public.ecr.aws/t1q6b4h2/civiform-browser-tests:latest \
+  --cache-from docker.io/civiform/civiform-browser-test:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1
 
 if [ "$PUSH_TO_CIVIFORM_ECR" ]; then
@@ -19,5 +19,15 @@ if [ "$PUSH_TO_CIVIFORM_ECR" ]; then
   docker tag civiform-browser-test:latest public.ecr.aws/t1q6b4h2/civiform-browser-tests:latest
   docker push public.ecr.aws/t1q6b4h2/civiform-browser-tests:latest
 fi
+
+# clear AWS login state
+docker logout public.ecr.aws/t1q6b4h2
+
+# log the docker CLI into the Docker Hub container registry
+echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
+
+# push the new image to the Docker Hub registry
+docker tag civiform-browser-test:latest docker.io/civiform/civiform-browser-test:latest
+docker push docker.io/civiform/civiform-browser-test:latest
 
 popd

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -11,7 +11,7 @@ REGION=us-west-2
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
 
 # build the new image based
-docker build -t civiform-dev --cache-from public.ecr.aws/t1q6b4h2/civiform-dev:latest --build-arg BUILDKIT_INLINE_CACHE=1 .
+docker build -t civiform-dev --cache-from docker.io/civiform/civiform-browser-test:latest --build-arg BUILDKIT_INLINE_CACHE=1 .
 
 # push the new image to the AWS registry
 docker tag civiform-dev:latest public.ecr.aws/t1q6b4h2/civiform-dev:latest

--- a/bin/deploy-staging
+++ b/bin/deploy-staging
@@ -8,7 +8,7 @@ export AWS_DEFAULT_REGION=us-west-2
 REGION=us-west-2
 
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
-docker build -f prod.Dockerfile -t universal-application-tool --cache-from public.ecr.aws/t1q6b4h2/universal-application-tool:latest --build-arg BUILDKIT_INLINE_CACHE=1 .
+docker build -f prod.Dockerfile -t universal-application-tool --cache-from docker.io/civiform/civiform-browser-test:latest --build-arg BUILDKIT_INLINE_CACHE=1 .
 docker tag universal-application-tool:latest public.ecr.aws/t1q6b4h2/universal-application-tool:latest
 docker push public.ecr.aws/t1q6b4h2/universal-application-tool:latest
 

--- a/bin/npm
+++ b/bin/npm
@@ -5,6 +5,6 @@
 pushd $(git rev-parse --show-toplevel)
 
 # allocate a tty for better test output even though not strictly needed.
-docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 --entrypoint npm civiform $@
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 --entrypoint npm civiform-dev $@
 
 popd

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -4,10 +4,6 @@
 
 if [ -z "$USE_LOCAL_CIVIFORM" ]; then
   echo "Making sure we're up to date with the latest dev... set environment variable USE_LOCAL_CIVIFORM=1 to skip"
-  if ! docker pull public.ecr.aws/t1q6b4h2/civiform-dev:latest; then
-    echo "Failed to pull - possibly some stuck credentials.  De-authenticating then retrying..."
-    docker logout https://public.ecr.aws/t1q6b4h2/civiform-dev
-    docker pull public.ecr.aws/t1q6b4h2/civiform-dev:latest
-  fi
-  docker tag public.ecr.aws/t1q6b4h2/civiform-dev:latest civiform
+  docker pull docker.io/civiform/civiform-dev:latest
+  docker tag docker.io/civiform/civiform-dev:latest civiform-dev
 fi

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -21,7 +21,7 @@ services:
       POSTGRES_PASSWORD: example
 
   fake-idcs:
-    image: public.ecr.aws/t1q6b4h2/oidc-provider:latest
+    image: docker.io/civiform/oidc-provider:latest
     restart: always
     container_name: fake-idcs
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       POSTGRES_PASSWORD: example
 
   civiform:
-    image: civiform
+    image: civiform-dev
     restart: always
     container_name: civiform
     links:

--- a/universal-application-tool-0.0.1/test/app/SecurityBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/SecurityBrowserTest.java
@@ -20,7 +20,7 @@ import support.TestConstants;
 
 public class SecurityBrowserTest extends BaseBrowserTest {
   public static final DockerImageName OIDC_IMAGE =
-      DockerImageName.parse("public.ecr.aws/t1q6b4h2/oidc-provider:latest");
+      DockerImageName.parse("docker.io/civiform/oidc-provider:latest");
 
   @ClassRule
   public static GenericContainer<?> oidcProvider =


### PR DESCRIPTION
Stage 2 of 3 for moving away from AWS ECR. Stage 1 was uploading logging in to docker hub and uploading our main image. 

This PR switches to using docker hub for all day-to-day docker image management while continuing to upload images to AWS ECR in case there's a problem with our docker hub approach.

The final stage will be removing ECR from the regular development cycle altogether.