### PR TITLE
Only show errors when a question is required or partially filled in

### DIFF
--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -315,13 +315,6 @@ describe('address applicant flow', () => {
       })
 
       it('optional has no errors', async () => {
-        await loginAsGuest(pageObject)
-        await selectApplicantLanguage(pageObject, 'English')
-
-        await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.answerAddressQuestion('', '', '', '', '', 1)
-        await applicantQuestions.clickNext()
-
         // First question has no errors.
         let error = await pageObject.$('.cf-address-street-1-error >> nth=0')
         expect(await error.isHidden()).toEqual(true)

--- a/browser-test/src/address.test.ts
+++ b/browser-test/src/address.test.ts
@@ -314,27 +314,24 @@ describe('address applicant flow', () => {
         expect(await error.isHidden()).toEqual(false)
       })
 
-      // TODO: Fix code so this test passes. Issue #1652
-      /*
       it('optional has no errors', async () => {
-        await loginAsGuest(pageObject);
-        await selectApplicantLanguage(pageObject, 'English');
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
 
-        await applicantQuestions.applyProgram(programName);
-        await applicantQuestions.answerAddressQuestion('', '', '', '', '', 1);
-        await applicantQuestions.clickNext();
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerAddressQuestion('', '', '', '', '', 1)
+        await applicantQuestions.clickNext()
 
         // First question has no errors.
-        let error = await pageObject.$('.cf-address-street-1-error >> nth=0');
-        expect(await error.isHidden()).toEqual(true);
-        error = await pageObject.$('.cf-address-city-error >> nth=0');
-        expect(await error.isHidden()).toEqual(true);
-        error = await pageObject.$('.cf-address-state-error >> nth=0');
-        expect(await error.isHidden()).toEqual(true);
-        error = await pageObject.$('.cf-address-zip-error >> nth=0');
-        expect(await error.isHidden()).toEqual(true);
-      });
-       */
+        let error = await pageObject.$('.cf-address-street-1-error >> nth=0')
+        expect(await error.isHidden()).toEqual(true)
+        error = await pageObject.$('.cf-address-city-error >> nth=0')
+        expect(await error.isHidden()).toEqual(true)
+        error = await pageObject.$('.cf-address-state-error >> nth=0')
+        expect(await error.isHidden()).toEqual(true)
+        error = await pageObject.$('.cf-address-zip-error >> nth=0')
+        expect(await error.isHidden()).toEqual(true)
+      })
     })
   })
 })

--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -269,6 +269,12 @@ class ValidationController {
     fieldName: string,
     isValid: boolean
   ) {
+    const isOptional = !question.classList.contains(ValidationController.REQUIRED_QUESTION_CLASS)
+    const filledInputs = Array.from(question.querySelectorAll('input')).filter(input => input.value !== "")
+    if (isOptional && filledInputs.length === 0) {
+      return
+    }
+
     const errorDiv = question.querySelector(fieldName + '-error')
     if (errorDiv) {
       errorDiv.classList.toggle('hidden', isValid)


### PR DESCRIPTION
### Description
Error validation shows on optional question if it is empty and the required question has error. This change ensures errors only show when a question is required or (if it's optional), the errors will only show if that question is partially filled in.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1652

