### PR TITLE
Fix placeholder account bug

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -43,11 +43,19 @@ public class ProfileUtils {
     return Optional.of(profileFactory.wrapProfileData(p.get()));
   }
 
-  private static final String IDCS_PLACEHOLDER_EMAIL = "ITD_UCSS_UAT@seattle.gov";
+  // Testing account to allow for manual verification of the check.
+  private static final String IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE =
+      new String("CiviFormStagingTest@gmail.com").toLowerCase();
+  // A temporary placeholder email value, used while the user needs to verify their account.
+  private static final String IDCS_PLACEHOLDER_EMAIL_LOWERCASE =
+      new String("ITD_UCSS_UAT@seattle.gov").toLowerCase();
 
-  /** Return true if the account is a known problem account to the City of Seattle. */
+  /** Return true if the account is not a fully usable account to the City of Seattle. */
   public boolean accountIsIdcsPlaceholder(CiviFormProfile profile) {
-    return IDCS_PLACEHOLDER_EMAIL.equals(profile.getProfileData().getEmail());
+    String userEmailLowercase = profile.getProfileData().getEmail().toLowerCase();
+
+    return IDCS_PLACEHOLDER_EMAIL_LOWERCASE.equals(userEmailLowercase)
+        || IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE.equals(userEmailLowercase);
   }
 
   /** Return true if the account referenced by the profile exists. */

--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -43,12 +43,12 @@ public class ProfileUtils {
     return Optional.of(profileFactory.wrapProfileData(p.get()));
   }
 
-  // Testing account to allow for manual verification of the check.
-  private static final String IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE =
-      new String("CiviFormStagingTest@gmail.com").toLowerCase();
   // A temporary placeholder email value, used while the user needs to verify their account.
   private static final String IDCS_PLACEHOLDER_EMAIL_LOWERCASE =
-      new String("ITD_UCSS_UAT@seattle.gov").toLowerCase();
+      "ITD_UCSS_UAT@seattle.gov".toLowerCase();
+  // Testing account to allow for manual verification of the check.
+  private static final String IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE =
+      "CiviFormStagingTest@gmail.com".toLowerCase();
 
   /** Return true if the account is not a fully usable account to the City of Seattle. */
   public boolean accountIsIdcsPlaceholder(CiviFormProfile profile) {

--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -52,7 +52,11 @@ public class ProfileUtils {
 
   /** Return true if the account is not a fully usable account to the City of Seattle. */
   public boolean accountIsIdcsPlaceholder(CiviFormProfile profile) {
-    String userEmailLowercase = profile.getProfileData().getEmail().toLowerCase();
+    Optional<String> userEmail = Optional.ofNullable(profile.getProfileData().getEmail());
+    if (userEmail.isEmpty()) {
+      return false;
+    }
+    String userEmailLowercase = userEmail.get().toLowerCase();
 
     return IDCS_PLACEHOLDER_EMAIL_LOWERCASE.equals(userEmailLowercase)
         || IDCS_PLACEHOLDER_TEST_EMAIL_LOWERCASE.equals(userEmailLowercase);

--- a/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileUtils.java
@@ -43,6 +43,13 @@ public class ProfileUtils {
     return Optional.of(profileFactory.wrapProfileData(p.get()));
   }
 
+  private static final String IDCS_PLACEHOLDER_EMAIL = "ITD_UCSS_UAT@seattle.gov";
+
+  /** Return true if the account is a known problem account to the City of Seattle. */
+  public boolean accountIsIdcsPlaceholder(CiviFormProfile profile) {
+    return IDCS_PLACEHOLDER_EMAIL.equals(profile.getProfileData().getEmail());
+  }
+
   /** Return true if the account referenced by the profile exists. */
   public boolean validCiviFormProfile(CiviFormProfile profile) {
     try {

--- a/universal-application-tool-0.0.1/app/controllers/SupportController.java
+++ b/universal-application-tool-0.0.1/app/controllers/SupportController.java
@@ -1,0 +1,25 @@
+package controllers;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Inject;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.mvc.Result;
+import views.support.UnconfirmedIdcsEmailBugView;
+
+public class SupportController extends Controller {
+  private final UnconfirmedIdcsEmailBugView unconfirmedIdcsEmailBugView;
+
+  @Inject
+  public SupportController(UnconfirmedIdcsEmailBugView unconfirmedIdcsEmailBugView) {
+    this.unconfirmedIdcsEmailBugView = checkNotNull(unconfirmedIdcsEmailBugView);
+  }
+
+  public Result handleUnconfirmedIdcsEmail(Http.Request request) {
+    // TODO: log info about the user? maybe IP address along with a grep-able identifier to see how
+    // many different
+    //       IP addresses reach this endpoint?
+    return ok(unconfirmedIdcsEmailBugView.render());
+  }
+}

--- a/universal-application-tool-0.0.1/app/filters/ValidAccountFilter.java
+++ b/universal-application-tool-0.0.1/app/filters/ValidAccountFilter.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import controllers.routes;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.libs.streams.Accumulator;
@@ -36,6 +37,21 @@ public class ValidAccountFilter extends EssentialFilter {
                   Results.redirect(org.pac4j.play.routes.LogoutController.logout()));
             }
           }
+
+          // Check to see if the account is the unconfirmed email placeholder account from Seattle
+          // IDCS. If it is,
+          // redirect to a custom support page for that purpose.
+          if (profile.isPresent()
+              && profileUtils.accountIsIdcsPlaceholder(profile.get())
+              // Guard against a redirect loop
+              && !request
+                  .uri()
+                  .startsWith(routes.SupportController.handleUnconfirmedIdcsEmail().path())) {
+            return Accumulator.done(
+                Results.redirect(
+                    controllers.routes.SupportController.handleUnconfirmedIdcsEmail()));
+          }
+
           return next.apply(request);
         });
   }

--- a/universal-application-tool-0.0.1/app/views/support/UnconfirmedIdcsEmailBugView.java
+++ b/universal-application-tool-0.0.1/app/views/support/UnconfirmedIdcsEmailBugView.java
@@ -1,0 +1,34 @@
+package views.support;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.h1;
+
+import javax.inject.Inject;
+import play.twirl.api.Content;
+import views.BaseHtmlView;
+import views.HtmlBundle;
+import views.applicant.ApplicantLayout;
+
+public class UnconfirmedIdcsEmailBugView extends BaseHtmlView {
+
+  private final ApplicantLayout applicantLayout;
+
+  @Inject
+  public UnconfirmedIdcsEmailBugView(ApplicantLayout applicantLayout) {
+    this.applicantLayout = checkNotNull(applicantLayout);
+  }
+
+  public Content render() {
+    HtmlBundle bundle = applicantLayout.getBundle();
+
+    bundle.setTitle("Please contact support");
+    bundle.addMainContent(h1("Please contact support"));
+    bundle.addMainContent(
+        div(
+            "There has been an error with your CiviForm account. Please contact support at the"
+                + " City of Seattle at 206-555-5555"));
+
+    return applicantLayout.render(bundle);
+  }
+}

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -108,6 +108,9 @@ GET     /applicants/:applicantId/programs/:programId/blocks/:blockIndex/previous
 GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/updateFile/:inReview      controllers.applicant.ApplicantProgramBlocksController.updateFile(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview                 controllers.applicant.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: String, inReview: Boolean)
 
+# Methods for user support incidents
+GET     /support/unconfirmedIdcsEmail  controllers.SupportController.handleUnconfirmedIdcsEmail(request: Request)
+
 # Methods for program admins
 GET     /programAdmin       controllers.admin.ProgramAdminController.index(request: Request)
 


### PR DESCRIPTION
WORK IN PROGRESS

- [x] redirect users with credentials for the bad account to a custom support page
- [x] confirm support page content with Elise
- [x] update tests for `ProfileUtils` and `ValidAccountFilter`
- [x] log user out and display prompt telling them to log back in
- [ ] confirm getting the profile email address will work as expected for an already logged-in user

Doc on the filter feature used in this PR: https://www.playframework.com/documentation/2.8.x/JavaHttpFilters

Screencap of the support page:

![image](https://user-images.githubusercontent.com/473671/148284264-33181dd5-8b19-49ff-85f6-7ca75f32a5b6.png)