### PR TITLE
Fix image push in building browser tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -36,7 +36,7 @@ jobs:
         id: build_browser_tests
         env:
           DOCKER_BUILDKIT: 1
-          PUSH_TO_CIVIFORM_ECR: 1
+          PUSH_BROWSER_TEST_IMAGE: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}

--- a/bin/build-browser-tests
+++ b/bin/build-browser-tests
@@ -13,21 +13,21 @@ docker build -t civiform-browser-test \
   --cache-from docker.io/civiform/civiform-browser-test:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1
 
-if [ "$PUSH_TO_CIVIFORM_ECR" ]; then
+if [ "$PUSH_BROWSER_TEST_IMAGE" ]; then
   export AWS_DEFAULT_REGION=us-west-2
   aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
   docker tag civiform-browser-test:latest public.ecr.aws/t1q6b4h2/civiform-browser-tests:latest
   docker push public.ecr.aws/t1q6b4h2/civiform-browser-tests:latest
+
+  # clear AWS login state
+  docker logout public.ecr.aws/t1q6b4h2
+
+  # log the docker CLI into the Docker Hub container registry
+  echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
+
+  # push the new image to the Docker Hub registry
+  docker tag civiform-browser-test:latest docker.io/civiform/civiform-browser-test:latest
+  docker push docker.io/civiform/civiform-browser-test:latest
 fi
-
-# clear AWS login state
-docker logout public.ecr.aws/t1q6b4h2
-
-# log the docker CLI into the Docker Hub container registry
-echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
-
-# push the new image to the Docker Hub registry
-docker tag civiform-browser-test:latest docker.io/civiform/civiform-browser-test:latest
-docker push docker.io/civiform/civiform-browser-test:latest
 
 popd


### PR DESCRIPTION
### Description
Change so that pushing the browser test images happens only in the [push workflow](https://github.com/seattle-uat/civiform/blob/main/.github/workflows/push.yaml#L35-L44) and not the other two workflows that run the `bin/build-browser-tests` script

Without fix this I was getting `Error: Cannot perform an interactive login from a non TTY device` from the [Build browser testing container](https://github.com/seattle-uat/civiform/blob/main/.github/workflows/pr.yaml#L33-L38) workflow