### PR TITLE
Add github workflow for deploying prod without first running probers

### DIFF
--- a/.github/workflows/direct-deploy.yaml
+++ b/.github/workflows/direct-deploy.yaml
@@ -1,0 +1,15 @@
+name: Dangerously deploy prod
+on:
+  workflow_dispatch: {}
+
+jobs:
+  run_prober:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out pr branch
+        uses: actions/checkout@v2
+      - name: Deploy prod
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
+        run: bin/deploy-prod


### PR DESCRIPTION
Adds a new github actions workflow for performing a prod deployment without first running the staging probers. Hopefully we won't need this, but some recent turbulence on staging along with an urgent prod incident may require it.