### PR TITLE
Disable the export/no export/ export obfuscated radio buttons in View Mode

### DIFF
--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^14.14.31",
     "jest": "^26.6.3",
     "jest-playwright-preset": "^1.5.1",
-    "playwright": "latest",
+    "playwright": "^1.9.2",
     "ts-jest": "^26.5.1",
     "ts-node": "^9.1.1",
     "ts-node-dev": "^1.1.1",

--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^14.14.31",
     "jest": "^26.6.3",
     "jest-playwright-preset": "^1.5.1",
-    "playwright": "^1.9.2",
+    "playwright": "latest",
     "ts-jest": "^26.5.1",
     "ts-node": "^9.1.1",
     "ts-node-dev": "^1.1.1",

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -106,8 +106,8 @@ describe('normal application flow', () => {
     await adminQuestions.expectActiveQuestionExist('second-static-q')
     await adminQuestions.expectActiveQuestionExist('monthly-income-q')
 
-    await adminQuestions.goToViewQuestionPage('ice-cream-q')
-    await adminQuestions.expectViewOnlyQuestion('ice-cream-q')
+    await adminQuestions.goToViewQuestionPage('date-q')
+    await adminQuestions.expectViewOnlyQuestion('date-q')
 
     await logout(page)
     await loginAsTestUser(page)

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -106,6 +106,9 @@ describe('normal application flow', () => {
     await adminQuestions.expectActiveQuestionExist('second-static-q')
     await adminQuestions.expectActiveQuestionExist('monthly-income-q')
 
+    await adminQuestions.goToViewQuestionPage('ice-cream-q')
+    await adminQuestions.expectViewOnlyQuestion('ice-cream-q')
+
     await logout(page)
     await loginAsTestUser(page)
     await selectApplicantLanguage(page, 'English')
@@ -224,7 +227,6 @@ describe('normal application flow', () => {
 
     await logout(page)
     await loginAsAdmin(page)
-    await adminQuestions.expectViewableQuestion('ice-cream-q')
     await adminQuestions.createNewVersion('favorite-trees-q')
     await adminQuestions.gotoQuestionEditPage('favorite-trees-q')
     await page.click('#question-settings button:text("Remove"):visible')

--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -224,6 +224,7 @@ describe('normal application flow', () => {
 
     await logout(page)
     await loginAsAdmin(page)
+    await adminQuestions.expectViewableQuestion('ice-cream-q')
     await adminQuestions.createNewVersion('favorite-trees-q')
     await adminQuestions.gotoQuestionEditPage('favorite-trees-q')
     await page.click('#question-settings button:text("Remove"):visible')

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -25,6 +25,12 @@ export class AdminQuestions {
     await this.expectAdminQuestionsPage()
   }
 
+  async goToViewQuestionPage(questionName: string) {
+      await this.gotoAdminQuestionsPage()
+      await this.page.click('text=View')
+      await waitForPageJsLoad(this.page)
+  }
+
   async clickSubmitButtonAndNavigate(buttonText: string) {
     await this.page.click(`button:has-text("${buttonText}")`)
     await waitForPageJsLoad(this.page)
@@ -32,6 +38,12 @@ export class AdminQuestions {
 
   async expectAdminQuestionsPage() {
     expect(await this.page.innerText('h1')).toEqual('All Questions')
+  }
+
+  async expectViewOnlyQuestion(questionName: string) {
+    goToViewQuestionPage(questionName)
+    expect(await (await this.page.$(`text=${questionName}`)).isDisabled()).toEqual(true)
+    expect(await (await this.page.$('text=No Export')).isDisabled()).toEqual(true)
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -42,7 +42,7 @@ export class AdminQuestions {
 
   async expectViewOnlyQuestion(questionName: string) {
     expect(await (await this.page.$('text=No Export')).isDisabled()).toEqual(true)
-    expect(await (await this.page.$(`text=${questionName}`)).isDisabled()).toEqual(true)
+    expect(await (await this.page.$(`input:below(:text("${questionName}"))`)).isDisabled()).toEqual(true)
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -42,7 +42,7 @@ export class AdminQuestions {
 
   async expectViewOnlyQuestion(questionName: string) {
     expect(await this.page.isDisabled('text=No Export')).toEqual(true)
-    expect(await this.page.isDisabled('input')).toEqual(true)
+    expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -42,7 +42,7 @@ export class AdminQuestions {
 
   async expectViewOnlyQuestion(questionName: string) {
     expect(await this.page.isDisabled('text=No Export')).toEqual(true)
-    expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
+    // expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -41,8 +41,8 @@ export class AdminQuestions {
   }
 
   async expectViewOnlyQuestion(questionName: string) {
-    expect(await (await this.page.$(`text=${questionName}`)).isDisabled()).toEqual(true)
     expect(await (await this.page.$('text=No Export')).isDisabled()).toEqual(true)
+    expect(await (await this.page.$(`text=${questionName}`)).isDisabled()).toEqual(true)
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -41,8 +41,8 @@ export class AdminQuestions {
   }
 
   async expectViewOnlyQuestion(questionName: string) {
-    expect(await (await this.page.$('text=No Export')).isDisabled()).toEqual(true)
-    expect(await (await this.page.$(`input:below(:text("${questionName}"))`)).isDisabled()).toEqual(true)
+    expect(await this.page.isDisabled('text=No Export')).toEqual(true)
+    expect(await this.page.isDisabled('input')).toEqual(true)
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -41,7 +41,6 @@ export class AdminQuestions {
   }
 
   async expectViewOnlyQuestion(questionName: string) {
-    goToViewQuestionPage(questionName)
     expect(await (await this.page.$(`text=${questionName}`)).isDisabled()).toEqual(true)
     expect(await (await this.page.$('text=No Export')).isDisabled()).toEqual(true)
   }

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -42,6 +42,7 @@ export class AdminQuestions {
 
   async expectViewOnlyQuestion(questionName: string) {
     expect(await this.page.isDisabled('text=No Export')).toEqual(true)
+    // TODO(sgoldblatt): This test does not find any questions need to look into
     // expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
   }
 

--- a/browser-test/yarn.lock
+++ b/browser-test/yarn.lock
@@ -678,7 +678,7 @@ acorn@^8.0.5:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"
   integrity sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -1210,6 +1210,11 @@ commander@^6.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
+commander@^8.2.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -1336,6 +1341,13 @@ debug@^2.2.0, debug@^2.3.3:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.3.1:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
@@ -2065,6 +2077,11 @@ ini@^1.3.4:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -3475,6 +3492,28 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+playwright-core@=1.17.2:
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.17.2.tgz#916254fa8fb3eb76c160b5c2e06bc979d6ec2cf8"
+  integrity sha512-TCYIt2UNHvqGxvD79bBjBv9osDLAH1gn7AZD5kRpMNQJG6BAmJt8B4Ek8fzdKmCQOnHf9ASJmcYRszoIZxcdVA==
+  dependencies:
+    commander "^8.2.0"
+    debug "^4.1.1"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
+    jpeg-js "^0.4.2"
+    mime "^2.4.6"
+    pngjs "^5.0.0"
+    progress "^2.0.3"
+    proper-lockfile "^4.1.1"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    socks-proxy-agent "^6.1.0"
+    stack-utils "^2.0.3"
+    ws "^7.4.6"
+    yauzl "^2.10.0"
+    yazl "^2.5.1"
+
 playwright-core@>=1.2.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.9.2.tgz#cef51ac7e9b862528a860b6531628598b485ac17"
@@ -3494,24 +3533,12 @@ playwright-core@>=1.2.0:
     stack-utils "^2.0.3"
     ws "^7.3.1"
 
-playwright@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.9.2.tgz#294910950b76ec4c3dfed6a1e9d28e9b8560b0f4"
-  integrity sha512-Hsgfk3GZO+hgewRNW9xl9/tHjdZvVwxTseHagbiNpDf90PXICEh8UHXy/2eykeIXrZFMA6W6petEtRWNPi3gfQ==
+playwright@latest:
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.17.2.tgz#918b9a7e43ac8640fa3e2162ce0cb8b395c55fb7"
+  integrity sha512-u1HZmVoeLCLptNcpuOyp5KfBzsdsLxE9CReK82i/p8j5i7EPqtY3fX77SMHqDGeO7tLBSYk2a6eFDVlQfSSANg==
   dependencies:
-    commander "^6.1.0"
-    debug "^4.1.1"
-    extract-zip "^2.0.1"
-    https-proxy-agent "^5.0.0"
-    jpeg-js "^0.4.2"
-    mime "^2.4.6"
-    pngjs "^5.0.0"
-    progress "^2.0.3"
-    proper-lockfile "^4.1.1"
-    proxy-from-env "^1.1.0"
-    rimraf "^3.0.2"
-    stack-utils "^2.0.3"
-    ws "^7.3.1"
+    playwright-core "=1.17.2"
 
 pngjs@^5.0.0:
   version "5.0.0"
@@ -3929,6 +3956,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+smart-buffer@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -3958,6 +3990,23 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+socks-proxy-agent@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz#e664e8f1aaf4e1fb3df945f09e3d94f911137f87"
+  integrity sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "^4.3.1"
+    socks "^2.6.1"
+
+socks@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -4593,6 +4642,11 @@ ws@^7.3.1, ws@^7.4.4:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
   integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
 
+ws@^7.4.6:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
+  integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -4655,6 +4709,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yn@3.1.1:
   version "3.1.1"

--- a/browser-test/yarn.lock
+++ b/browser-test/yarn.lock
@@ -3533,7 +3533,7 @@ playwright-core@>=1.2.0:
     stack-utils "^2.0.3"
     ws "^7.3.1"
 
-playwright@latest:
+playwright@^1.9.2:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.17.2.tgz#918b9a7e43ac8640fa3e2162ce0cb8b395c55fb7"
   integrity sha512-u1HZmVoeLCLptNcpuOyp5KfBzsdsLxE9CReK82i/p8j5i7EPqtY3fX77SMHqDGeO7tLBSYk2a6eFDVlQfSSANg==

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -334,13 +334,16 @@ public final class QuestionEditView extends BaseHtmlView {
 
     if (!ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(questionType)) {
       formTag.with(
-          div().withId("demographic-field-content").with(buildDemographicFields(questionForm, submittable)));
+          div()
+              .withId("demographic-field-content")
+              .with(buildDemographicFields(questionForm, submittable)));
     }
 
     return formTag;
   }
 
-  private ImmutableList<DomContent> buildDemographicFields(QuestionForm questionForm, boolean submittable) {
+  private ImmutableList<DomContent> buildDemographicFields(
+      QuestionForm questionForm, boolean submittable) {
     return ImmutableList.of(
         FieldWithLabel.radio()
             .setId("question-demographic-no-export")

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -334,16 +334,17 @@ public final class QuestionEditView extends BaseHtmlView {
 
     if (!ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(questionType)) {
       formTag.with(
-          div().withId("demographic-field-content").with(buildDemographicFields(questionForm)));
+          div().withId("demographic-field-content").with(buildDemographicFields(questionForm, submittable)));
     }
 
     return formTag;
   }
 
-  private ImmutableList<DomContent> buildDemographicFields(QuestionForm questionForm) {
+  private ImmutableList<DomContent> buildDemographicFields(QuestionForm questionForm, boolean submittable) {
     return ImmutableList.of(
         FieldWithLabel.radio()
             .setId("question-demographic-no-export")
+            .setDisabled(!submittable)
             .setFieldName("questionExportState")
             .setLabelText("No export")
             .setValue(QuestionTag.NON_DEMOGRAPHIC.getValue())
@@ -354,6 +355,7 @@ public final class QuestionEditView extends BaseHtmlView {
             .getContainer(),
         FieldWithLabel.radio()
             .setId("question-demographic-export-demographic")
+            .setDisabled(!submittable)
             .setFieldName("questionExportState")
             .setLabelText("Export Value")
             .setValue(QuestionTag.DEMOGRAPHIC.getValue())
@@ -362,6 +364,7 @@ public final class QuestionEditView extends BaseHtmlView {
             .getContainer(),
         FieldWithLabel.radio()
             .setId("question-demographic-export-pii")
+            .setDisabled(!submittable)
             .setFieldName("questionExportState")
             .setLabelText("Export Obfuscated")
             .setValue(QuestionTag.DEMOGRAPHIC_PII.getValue())


### PR DESCRIPTION
### Description
Pass in the submittable param to the buildDemographicFields function which makes the radio's uneditable in the view only mode and editable in the edit question mode. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1746
<img width="894" alt="Screen Shot 2022-01-06 at 4 44 49 PM" src="https://user-images.githubusercontent.com/6268375/148473356-11e0933b-58ba-4547-be7c-fe94226e9fdc.png">