### PR TITLE
Tag builds with commit SHA and timestamp

### DIFF
--- a/bin/build-and-push
+++ b/bin/build-and-push
@@ -9,9 +9,9 @@ set +x
 
 short_sha=$(git rev-parse --short HEAD)
 date_in_unix_seconds=$(date +%s)
-snapshot_tag="SNAPSHOT-$short_sha-$date_in_unix_seconds"
+snapshot_tag="SNAPSHOT-${short_sha}-${date_in_unix_seconds}"
 
-echo "Building $snapshot_tag..."
+echo "Building ${snapshot_tag}..."
 
 docker build -f prod.Dockerfile \
   -t civiform:latest \
@@ -22,7 +22,7 @@ docker build -f prod.Dockerfile \
 echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
 
 docker tag civiform:latest civiform/civiform:latest
-docker tag civiform:latest "civiform/civiform:$snapshot_tag"
+docker tag civiform:latest "civiform/civiform:${snapshot_tag}"
 
 # push the new image to the Docker Hub registry
 docker push --all-tags civiform/civiform

--- a/bin/build-and-push
+++ b/bin/build-and-push
@@ -1,11 +1,17 @@
 #! /bin/bash
 
-# DOC: Build a new production docker image, push to Docker Hub.
+# DOC: Build a new production docker image, push to Docker Hub tagged with short commit SHA and unix seconds timestamp.
 
 pushd $(git rev-parse --show-toplevel)
 
 set -e
 set +x
+
+short_sha=$(git rev-parse --short HEAD)
+date_in_unix_seconds=$(date +%s)
+snapshot_tag="SNAPSHOT-$short_sha-$date_in_unix_seconds"
+
+echo "Building $snapshot_tag..."
 
 docker build -f prod.Dockerfile \
   -t civiform:latest \
@@ -16,8 +22,9 @@ docker build -f prod.Dockerfile \
 echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
 
 docker tag civiform:latest civiform/civiform:latest
+docker tag civiform:latest "civiform/civiform:$snapshot_tag"
 
 # push the new image to the Docker Hub registry
-docker push civiform/civiform:latest
+docker push --all-tags civiform/civiform
 
 popd


### PR DESCRIPTION
Tagging builds uploaded to Docker Hub as per [CiviForm Federated Deployment Design](https://docs.google.com/document/d/1xLlKwq-2lkAOFPpgu0t1HQgbzkBwXBfdsICdo0udf48/edit):

> All merged pull requests trigger a snapshot image build tagged with SNAPSHOT-[short commit SHA]-[date in unix seconds].
