### PR TITLE
Deploy staging on all merges into main

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -49,7 +49,6 @@ jobs:
         run: bin/build-and-push
 
       - name: Run deploy-staging.
-        if: "contains(toJSON(steps.file_changes.outputs.files), 'infra/')"
         id: deploy_staging
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -51,6 +51,8 @@ jobs:
         id: deploy_staging
         env:
           DOCKER_BUILDKIT: 1
+          AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
         run: bin/deploy-staging
 
       - name: Run prober test

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -40,7 +40,6 @@ jobs:
         run: bin/build-browser-tests
 
       - name: Run build-and-push.
-        if: "!contains(toJSON(steps.file_changes.outputs.files), 'infra/')"
         id: build_and_push
         env:
           DOCKER_BUILDKIT: 1


### PR DESCRIPTION
It used to be we deployed to staging as part of the build-and-push task. I removed that code since it seemed a poor place to do it given the name and responsibility of the task and didn't notice that the deploy-staging task only run if there were changes in `infra/*`. This PR makes that step run on every merge into main.