### PR TITLE
Allowig the staging hostname to be set from the application conf

### DIFF
--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -81,6 +81,7 @@ adfs.admin_group = ${?ADFS_GLOBAL_ADMIN_GROUP}
 base_url = "http://localhost:9000"
 base_url = ${?BASE_URL}
 staging_hostname = "staging.seattle.civiform.com"
+staging_hostname = ${?STAGING_HOSTNAME}
 
 measurement_id = "G-HXM0Y35TGE"
 measurement_id = ${?MEASUREMENT_ID}


### PR DESCRIPTION
### Description
To show the buttons on staging we need to pass in the staging url to the application, adding this to pass that in

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
