### PR TITLE
Include applicant ID in program CSV export

### DIFF
--- a/bin/sbt
+++ b/bin/sbt
@@ -10,5 +10,8 @@ bin/pull-image
 docker run -it --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 \
-  civiform \
+  -v ~/.coursier:/root/.coursier \
+  -v ~/.sbt:/root/.sbt \
+  -v ~/.ivy:/root/.ivy2 \
+  civiform-dev \
   $@

--- a/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
+++ b/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
@@ -79,10 +79,13 @@ public class CsvExporter {
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     for (Column column : getColumns()) {
       switch (column.columnType()) {
-        case APPLICANT:
+        case APPLICANT_ANSWER:
           printer.print(getValueFromAnswerMap(column, answerMap));
           break;
-        case ID:
+        case APPLICANT_ID:
+          printer.print(application.getApplicant().id);
+          break;
+        case APPLICATION_ID:
           printer.print(application.id);
           break;
         case LANGUAGE:

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -227,8 +227,13 @@ public class ExporterService {
     ImmutableList.Builder<Column> columnsBuilder = new ImmutableList.Builder<>();
 
     // Default columns
-    columnsBuilder.add(Column.builder().setHeader("Applicant ID").setColumnType(ColumnType.APPLICANT_ID).build());
-    columnsBuilder.add(Column.builder().setHeader("Application ID").setColumnType(ColumnType.APPLICATION_ID).build());
+    columnsBuilder.add(
+        Column.builder().setHeader("Applicant ID").setColumnType(ColumnType.APPLICANT_ID).build());
+    columnsBuilder.add(
+        Column.builder()
+            .setHeader("Application ID")
+            .setColumnType(ColumnType.APPLICATION_ID)
+            .build());
     columnsBuilder.add(
         Column.builder()
             .setHeader("Applicant language")

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -225,8 +225,10 @@ public class ExporterService {
    */
   private CsvExportConfig generateDefaultCsvConfig(ImmutableList<AnswerData> answerDataList) {
     ImmutableList.Builder<Column> columnsBuilder = new ImmutableList.Builder<>();
-    // First add the ID, submit time, and submitter email columns.
-    columnsBuilder.add(Column.builder().setHeader("ID").setColumnType(ColumnType.ID).build());
+
+    // Default columns
+    columnsBuilder.add(Column.builder().setHeader("Applicant ID").setColumnType(ColumnType.APPLICANT_ID).build());
+    columnsBuilder.add(Column.builder().setHeader("Application ID").setColumnType(ColumnType.APPLICATION_ID).build());
     columnsBuilder.add(
         Column.builder()
             .setHeader("Applicant language")
@@ -250,7 +252,7 @@ public class ExporterService {
             Column.builder()
                 .setHeader(pathToHeader(path))
                 .setJsonPath(path)
-                .setColumnType(ColumnType.APPLICANT)
+                .setColumnType(ColumnType.APPLICANT_ANSWER)
                 .build());
       }
     }
@@ -366,7 +368,7 @@ public class ExporterService {
                   .setColumnType(
                       tagType == QuestionTag.DEMOGRAPHIC_PII
                           ? ColumnType.APPLICANT_OPAQUE
-                          : ColumnType.APPLICANT)
+                          : ColumnType.APPLICANT_ANSWER)
                   .build());
         }
       }

--- a/universal-application-tool-0.0.1/app/services/program/ColumnType.java
+++ b/universal-application-tool-0.0.1/app/services/program/ColumnType.java
@@ -4,8 +4,9 @@ package services.program;
  * Defines types of columns that will be handled differently in {@link services.export.CsvExporter}.
  */
 public enum ColumnType {
-  APPLICANT,
-  ID,
+  APPLICANT_ANSWER,
+  APPLICANT_ID,
+  APPLICATION_ID,
   LANGUAGE,
   SUBMIT_TIME,
   SUBMITTER_EMAIL,

--- a/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
@@ -66,7 +66,7 @@ public class CsvExporterTest extends WithPostgresContainer {
                     Column.builder()
                         .setHeader(ExporterService.pathToHeader(path))
                         .setJsonPath(path)
-                        .setColumnType(ColumnType.APPLICANT)
+                        .setColumnType(ColumnType.APPLICANT_ANSWER)
                         .build()));
     return csvExportConfigBuilder.build();
   }
@@ -381,7 +381,8 @@ public class CsvExporterTest extends WithPostgresContainer {
     assertThat(parser.getHeaderMap())
         .containsExactlyEntriesOf(
             ImmutableMap.<String, Integer>builder()
-                .put("ID", id++)
+                .put("Applicant ID", id++)
+                .put("Application ID", id++)
                 .put("Applicant language", id++)
                 .put("Submit time", id++)
                 .put("Submitted by", id++)


### PR DESCRIPTION
- [x] include applicant ID as a default column in program CSV export
- [x] mount sbt cache directories in sbt docker container for faster builds
- [x] rename a few enums for clarity

column type enum renaming:

`APPLICANT` -> `APPLICANT_ANSWER`
`ID` -> `APPLICATION_ID`

and added a new column type of `APPLICANT_ID`

fixes https://github.com/seattle-uat/civiform/issues/1735