### PR TITLE
Specify specific openjdk11 image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-slim
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
 
 # sbt
 


### PR DESCRIPTION
A [recent change to openjdk11](https://bugs.openjdk.java.net/browse/JDK-8278221?jql=project%20%3D%20JDK%20AND%20fixVersion%20%3D%2013-pool) changed some behavior related to "." in directory names. It now throws an exception if it finds one.

I attempted to fix this by removing the "."s from the java app directory name [see PR](https://bugs.openjdk.java.net/browse/JDK-8278221?jql=project%20%3D%20JDK%20AND%20fixVersion%20%3D%2013-pool) but that did not apparently do the trick.

For now this fix specifies the version of openjdk we'd been using successfully. Eventually we'll need to figure out how to upgrade but this unblocks CI for the time being.