### PR TITLE
Upgrade deps: sbt and play-ebean

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,9 +15,7 @@ jobs:
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
-      - name: sbt clean
-        run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform clean
+        run: docker build -t civiform ./
       - name: Run tests
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform test
 
@@ -31,7 +29,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -56,7 +54,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -81,7 +79,7 @@ jobs:
       - name: Build prod container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -f prod.Dockerfile -t civiform:prod ./
       - name: Build the stack
         env:
           SECRET_KEY: notarealsecret

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform ./
+        run: DOCKER_BUILDKIT=1 docker build -t civiform ./
       - name: Run tests
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform test
 
@@ -29,7 +29,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform ./
+        run: DOCKER_BUILDKIT=1 docker build -t civiform ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -54,7 +54,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform ./
+        run: DOCKER_BUILDKIT=1 docker build -t civiform ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,10 +10,12 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
-        run: DOCKER_BUILDKIT=1 docker build -t civiform ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Run tests
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform test
 
@@ -22,10 +24,12 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: DOCKER_BUILDKIT=1 docker build -t civiform ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -45,10 +49,12 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: DOCKER_BUILDKIT=1 docker build -t civiform ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -68,10 +74,12 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build prod container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f prod.Dockerfile -t civiform:prod ./
+        run: docker build -f prod.Dockerfile -t civiform:prod --cache-from docker.io/civiform/civiform:latest ./
       - name: Build the stack
         env:
           SECRET_KEY: notarealsecret

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build test container
         env:
           DOCKER_BUILDKIT: 1
@@ -24,8 +22,6 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
@@ -49,8 +45,6 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
@@ -74,8 +68,6 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build prod container
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,8 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+      - name: sbt clean
+        run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform clean
       - name: Run tests
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock civiform test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,21 +20,12 @@ RUN apk add --no-cache git openssh
 # Install node.js
 RUN apk add --update npm
 
-# Copy play project and compile it.
-# This will download all the ivy2 and sbt dependencies and install them
-# in the container /root directory, which saves time on future runs,
-# even if the dependencies change slightly.
-
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME universal-application-tool-0.0.1
 
-COPY ${PROJECT_NAME}/build.sbt ${PROJECT_HOME}/${PROJECT_NAME}/
-COPY ${PROJECT_NAME}/project ${PROJECT_HOME}/${PROJECT_NAME}/project
-RUN cd $PROJECT_HOME/$PROJECT_NAME && sbt update
-
 COPY ${PROJECT_NAME} ${PROJECT_HOME}/${PROJECT_NAME}
-RUN cd $PROJECT_HOME/$PROJECT_NAME && sbt reload compile
-ADD entrypoint.sh /entrypoint.sh
+
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN set -o pipefail && \
     apk update && \
     apk add --no-cache --update bash wget npm git openssh && \
     mkdir -p "${SBT_HOME}" && \
-    wget -qO - --no-check-certificate "${SBT_URL}" | \
-    tar xz -C "${INSTALL_DIR}" && \
+    wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt ${SBT_VERSION}\n" >> /root/.built
 
 ENV PROJECT_HOME /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
 
 # sbt
 
-ENV SBT_VERSION 1.3.13
+ENV SBT_VERSION 1.6.1
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,27 @@
 FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
 
-# sbt
-
-ENV SBT_VERSION 1.6.2
+ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
-ENV PATH ${PATH}:${SBT_HOME}/bin
+ENV PATH "${PATH}:${SBT_HOME}/bin"
+ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz"
 
-RUN apk update
-
-# Install sbt
-RUN apk add --no-cache --update bash wget && mkdir -p "$SBT_HOME" && \
-    wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
-    echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
-
-# Install git
-RUN apk add --no-cache git openssh
-
-# Install node.js
-RUN apk add --update npm
+RUN set -o pipefail && \
+    apk update && \
+    apk add --no-cache --update bash wget npm git openssh && \
+    mkdir -p "${SBT_HOME}" && \
+    wget -qO - --no-check-certificate "${SBT_URL}" | \
+    tar xz -C "${INSTALL_DIR}" && \
+    echo -ne "- with sbt ${SBT_VERSION}\n" >> /root/.built
 
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME universal-application-tool-0.0.1
 
-COPY ${PROJECT_NAME} ${PROJECT_HOME}/${PROJECT_NAME}
+COPY "${PROJECT_NAME}" "${PROJECT_HOME}/${PROJECT_NAME}"
 
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 9000
-WORKDIR $PROJECT_HOME/$PROJECT_NAME
+WORKDIR "${PROJECT_HOME}/${PROJECT_NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
 
 # sbt
 
-ENV SBT_VERSION 1.6.1
+ENV SBT_VERSION 1.6.2
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 START_TIME=$(date +%s)
-DEADLINE=$(($START_TIME + 200))
+DEADLINE=$(($START_TIME + 500))
 SERVER_URL="http://civiform:9000"
 
 echo "Polling to check server start"

--- a/formatter.Dockerfile
+++ b/formatter.Dockerfile
@@ -1,9 +1,13 @@
 FROM adoptopenjdk/openjdk11:alpine-slim
-RUN apk update
-RUN apk add --no-cache --update bash wget
-RUN wget https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar -O /fmt.jar
-RUN apk add --update npm
+
+ENV JAVA_FORMATTER_URL "https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar"
+
+RUN apk update && \
+    apk add --no-cache --update bash wget npm
+
 RUN npm install -g typescript prettier @typescript-eslint/parser @typescript-eslint/eslint-plugin
+RUN wget $JAVA_FORMATTER_URL -O /fmt.jar
+
 COPY .prettierrc.js /.prettierrc.js
 COPY .prettierignore /.prettierignore
 

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -2,7 +2,7 @@ FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage1
 
 # sbt
 
-ENV SBT_VERSION 1.3.13
+ENV SBT_VERSION 1.6.1
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,35 +1,24 @@
 FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage1
 
-# sbt
-
-ENV SBT_VERSION 1.6.2
+ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
-ENV PATH ${PATH}:${SBT_HOME}/bin
+ENV PATH "${PATH}:${SBT_HOME}/bin"
+ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz"
 
-RUN apk update
-
-# Install sbt
-RUN apk add --no-cache --update bash wget && mkdir -p "$SBT_HOME" && \
-    wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
+RUN set -o pipefail && \
+    apk update && \
+    apk add --no-cache --update bash wget npm git openssh && \
+    mkdir -p "$SBT_HOME" && \
+    wget -qO - --no-check-certificate "${SBT_URL}" | \
+    tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
-
-# Install git
-RUN apk add --no-cache git openssh
-
-# Install node.js
-RUN apk add --update npm
-
-# Copy play project and compile it.
-# This will download all the ivy2 and sbt dependencies and install them
-# in the container /root directory, which saves time on future runs,
-# even if the dependencies change slightly.
 
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME universal-application-tool-0.0.1
 
-COPY ${PROJECT_NAME} ${PROJECT_HOME}/${PROJECT_NAME}
-RUN cd $PROJECT_HOME/$PROJECT_NAME && \
+COPY "${PROJECT_NAME}" "${PROJECT_HOME}/${PROJECT_NAME}"
+RUN cd "${PROJECT_HOME}/${PROJECT_NAME}" && \
     npm install && \
     sbt update && \
     sbt dist
@@ -38,7 +27,6 @@ RUN cd $PROJECT_HOME/$PROJECT_NAME && \
 # we built with sbt dist.
 FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage2
 COPY --from=stage1 /usr/src/universal-application-tool-0.0.1/target/universal/universal-application-tool-0.0.1.zip /civiform.zip
-RUN apk add bash nodejs npm
-RUN unzip /civiform.zip; chmod +x /universal-application-tool-0.0.1/bin/universal-application-tool
 
+RUN unzip /civiform.zip; chmod +x /universal-application-tool-0.0.1/bin/universal-application-tool
 CMD ["/universal-application-tool-0.0.1/bin/universal-application-tool", "-Dconfig.file=/universal-application-tool-0.0.1/conf/application.conf"]

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -29,6 +29,10 @@ ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME universal-application-tool-0.0.1
 
 COPY ${PROJECT_NAME} ${PROJECT_HOME}/${PROJECT_NAME}
+RUN cd $PROJECT_HOME/$PROJECT_NAME && \
+    npm install && \
+    sbt update && \
+    sbt dist
 
 # This is a common trick to shrink container sizes.  we just throw away all that build stuff and use only the jars
 # we built with sbt dist.

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -28,13 +28,7 @@ RUN apk add --update npm
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME universal-application-tool-0.0.1
 
-COPY ${PROJECT_NAME}/build.sbt ${PROJECT_HOME}/${PROJECT_NAME}/
-COPY ${PROJECT_NAME}/project ${PROJECT_HOME}/${PROJECT_NAME}/project
-RUN cd $PROJECT_HOME/$PROJECT_NAME && sbt update
-
 COPY ${PROJECT_NAME} ${PROJECT_HOME}/${PROJECT_NAME}
-RUN cd $PROJECT_HOME/$PROJECT_NAME && npm install && \
-    sbt dist
 
 # This is a common trick to shrink container sizes.  we just throw away all that build stuff and use only the jars
 # we built with sbt dist.

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -2,7 +2,7 @@ FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage1
 
 # sbt
 
-ENV SBT_VERSION 1.6.1
+ENV SBT_VERSION 1.6.2
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -10,8 +10,7 @@ RUN set -o pipefail && \
     apk update && \
     apk add --no-cache --update bash wget npm git openssh && \
     mkdir -p "$SBT_HOME" && \
-    wget -qO - --no-check-certificate "${SBT_URL}" | \
-    tar xz -C "${INSTALL_DIR}" && \
+    wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
 
 ENV PROJECT_HOME /usr/src
@@ -27,6 +26,8 @@ RUN cd "${PROJECT_HOME}/${PROJECT_NAME}" && \
 # we built with sbt dist.
 FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim AS stage2
 COPY --from=stage1 /usr/src/universal-application-tool-0.0.1/target/universal/universal-application-tool-0.0.1.zip /civiform.zip
+
+RUN apk add bash
 
 RUN unzip /civiform.zip; chmod +x /universal-application-tool-0.0.1/bin/universal-application-tool
 CMD ["/universal-application-tool-0.0.1/bin/universal-application-tool", "-Dconfig.file=/universal-application-tool-0.0.1/conf/application.conf"]

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -6,8 +6,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import forms.BlockForm;
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
+import io.ebean.DB;
+import io.ebean.Database;
 import java.util.Locale;
 import java.util.Optional;
 import models.DisplayMode;
@@ -15,7 +15,6 @@ import models.LifecycleStage;
 import models.Models;
 import models.Version;
 import play.Environment;
-import play.db.ebean.EbeanConfig;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.LocalizedStrings;
@@ -45,21 +44,20 @@ import views.dev.DatabaseSeedView;
 public class DatabaseSeedController extends DevController {
 
   private final DatabaseSeedView view;
-  private final EbeanServer ebeanServer;
+  private final Database database;
   private final QuestionService questionService;
   private final ProgramService programService;
 
   @Inject
   public DatabaseSeedController(
       DatabaseSeedView view,
-      EbeanConfig ebeanConfig,
       QuestionService questionService,
       ProgramService programService,
       Environment environment,
       Config configuration) {
     super(environment, configuration);
     this.view = checkNotNull(view);
-    this.ebeanServer = Ebean.getServer(checkNotNull(ebeanConfig).defaultServer());
+    this.database = DB.getDefault();
     this.questionService = checkNotNull(questionService);
     this.programService = checkNotNull(programService);
   }
@@ -278,7 +276,7 @@ public class DatabaseSeedController extends DevController {
   }
 
   private void resetTables() {
-    Models.truncate(ebeanServer);
+    Models.truncate(database);
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
     newActiveVersion.save();
   }

--- a/universal-application-tool-0.0.1/app/models/Application.java
+++ b/universal-application-tool-0.0.1/app/models/Application.java
@@ -1,7 +1,7 @@
 package models;
 
-import io.ebean.annotation.CreatedTimestamp;
 import io.ebean.annotation.DbJson;
+import io.ebean.annotation.WhenCreated;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
@@ -32,7 +32,7 @@ public class Application extends BaseModel {
 
   @Constraints.Required private LifecycleStage lifecycleStage;
 
-  @CreatedTimestamp private Instant createTime;
+  @WhenCreated private Instant createTime;
 
   @Constraints.Required @DbJson private String object;
 

--- a/universal-application-tool-0.0.1/app/models/EbeanServerConfigStartup.java
+++ b/universal-application-tool-0.0.1/app/models/EbeanServerConfigStartup.java
@@ -3,7 +3,7 @@ package models;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import io.ebean.config.ServerConfig;
+import io.ebean.config.DatabaseConfig;
 import io.ebean.event.ServerConfigStartup;
 
 /**
@@ -14,9 +14,9 @@ import io.ebean.event.ServerConfigStartup;
 public class EbeanServerConfigStartup implements ServerConfigStartup {
 
   @Override
-  public void onStart(ServerConfig serverConfig) {
+  public void onStart(DatabaseConfig databaseConfig) {
     ObjectMapper mapper =
         new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
-    serverConfig.setObjectMapper(mapper);
+    databaseConfig.setObjectMapper(mapper);
   }
 }

--- a/universal-application-tool-0.0.1/app/models/EbeanServerConfigStartup.java
+++ b/universal-application-tool-0.0.1/app/models/EbeanServerConfigStartup.java
@@ -1,6 +1,7 @@
 package models;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.ebean.config.DatabaseConfig;
@@ -17,6 +18,7 @@ public class EbeanServerConfigStartup implements ServerConfigStartup {
   public void onStart(DatabaseConfig databaseConfig) {
     ObjectMapper mapper =
         new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     databaseConfig.setObjectMapper(mapper);
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Models.java
+++ b/universal-application-tool-0.0.1/app/models/Models.java
@@ -1,7 +1,7 @@
 package models;
 
 import com.google.common.collect.ImmutableList;
-import io.ebean.EbeanServer;
+import io.ebean.Database;
 
 /**
  * This is just a global constant of the list of models we have so we can truncate them in tests.
@@ -19,7 +19,7 @@ public class Models {
           Version.class);
 
   /** Get the complete list of ebean models to truncate. */
-  public static void truncate(EbeanServer ebeanServer) {
-    ebeanServer.truncate(MODELS.toArray(new Class[0]));
+  public static void truncate(Database database) {
+    database.truncate(MODELS.toArray(new Class[0]));
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Version.java
+++ b/universal-application-tool-0.0.1/app/models/Version.java
@@ -2,7 +2,7 @@ package models;
 
 import com.google.common.collect.ImmutableList;
 import io.ebean.annotation.DbArray;
-import io.ebean.annotation.UpdatedTimestamp;
+import io.ebean.annotation.WhenModified;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +50,7 @@ public class Version extends BaseModel {
    */
   @DbArray private List<String> tombstonedProgramNames = new ArrayList<>();
 
-  @UpdatedTimestamp private Instant submitTime;
+  @WhenModified private Instant submitTime;
 
   public Version() {
     this(LifecycleStage.DRAFT);

--- a/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ProgramRepository.java
@@ -5,8 +5,8 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
+import io.ebean.DB;
+import io.ebean.Database;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import java.util.List;
@@ -19,7 +19,6 @@ import models.Account;
 import models.LifecycleStage;
 import models.Program;
 import models.Version;
-import play.db.ebean.EbeanConfig;
 import services.program.ProgramNotFoundException;
 
 /**
@@ -28,35 +27,32 @@ import services.program.ProgramNotFoundException;
  */
 public class ProgramRepository {
 
-  private final EbeanServer ebeanServer;
+  private final Database database;
   private final DatabaseExecutionContext executionContext;
   private final Provider<VersionRepository> versionRepository;
 
   @Inject
   public ProgramRepository(
-      EbeanConfig ebeanConfig,
-      DatabaseExecutionContext executionContext,
-      Provider<VersionRepository> versionRepository) {
-    this.ebeanServer = Ebean.getServer(checkNotNull(ebeanConfig).defaultServer());
+      DatabaseExecutionContext executionContext, Provider<VersionRepository> versionRepository) {
+    this.database = DB.getDefault();
     this.executionContext = checkNotNull(executionContext);
     this.versionRepository = checkNotNull(versionRepository);
   }
 
   public CompletionStage<Optional<Program>> lookupProgram(long id) {
     return supplyAsync(
-        () -> ebeanServer.find(Program.class).where().eq("id", id).findOneOrEmpty(),
-        executionContext);
+        () -> database.find(Program.class).where().eq("id", id).findOneOrEmpty(), executionContext);
   }
 
   public Program insertProgramSync(Program program) {
     program.id = null;
-    ebeanServer.insert(program);
+    database.insert(program);
     program.refresh();
     return program;
   }
 
   public Program updateProgramSync(Program program) {
-    ebeanServer.update(program);
+    database.update(program);
     return program;
   }
 
@@ -75,7 +71,7 @@ public class ProgramRepository {
     } else {
       // Inside a question update, this will be a savepoint rather than a
       // full transaction.  Otherwise it will be creating a new transaction.
-      Transaction transaction = ebeanServer.beginTransaction(TxScope.required());
+      Transaction transaction = database.beginTransaction(TxScope.required());
       try {
         // Program -> builder -> back to program in order to clear any metadata stored
         // in the program (for example, version information).
@@ -114,7 +110,7 @@ public class ProgramRepository {
       } finally {
         // This may come after a prior call to `transaction.end` in the event of a
         // precondition failure - this is okay, since it a double-call to `end` on
-        // a particular transaction.  Only double calls to ebeanServer.endTransaction
+        // a particular transaction.  Only double calls to database.endTransaction
         // must be avoided.
         transaction.end();
       }
@@ -124,15 +120,14 @@ public class ProgramRepository {
   public CompletableFuture<Program> getForSlug(String slug) {
     return supplyAsync(
         () -> {
-          for (Program program :
-              ebeanServer.find(Program.class).where().isNull("slug").findList()) {
+          for (Program program : database.find(Program.class).where().isNull("slug").findList()) {
             program.getSlug();
             program.save();
           }
           ImmutableList<Program> activePrograms =
               versionRepository.get().getActiveVersion().getPrograms();
           List<Program> programsMatchingSlug =
-              ebeanServer.find(Program.class).where().eq("slug", slug).findList();
+              database.find(Program.class).where().eq("slug", slug).findList();
           Optional<Program> programMaybe =
               activePrograms.stream()
                   .filter(activeProgram -> programsMatchingSlug.contains(activeProgram))
@@ -147,12 +142,12 @@ public class ProgramRepository {
 
   public ImmutableList<Account> getProgramAdministrators(String programName) {
     return ImmutableList.copyOf(
-        ebeanServer.find(Account.class).where().arrayContains("admin_of", programName).findList());
+        database.find(Account.class).where().arrayContains("admin_of", programName).findList());
   }
 
   public ImmutableList<Account> getProgramAdministrators(long programId)
       throws ProgramNotFoundException {
-    Optional<Program> program = ebeanServer.find(Program.class).setId(programId).findOneOrEmpty();
+    Optional<Program> program = database.find(Program.class).setId(programId).findOneOrEmpty();
     if (program.isEmpty()) {
       throw new ProgramNotFoundException(programId);
     }
@@ -160,12 +155,12 @@ public class ProgramRepository {
   }
 
   public ImmutableList<Program> getAllProgramVersions(long programId) {
-    return ebeanServer
+    return database
         .find(Program.class)
         .where()
         .eq(
             "name",
-            ebeanServer.find(Program.class).setId(programId).select("name").findSingleAttribute())
+            database.find(Program.class).setId(programId).select("name").findSingleAttribute())
         .findList()
         .stream()
         .collect(ImmutableList.toImmutableList());

--- a/universal-application-tool-0.0.1/app/repository/StoredFileRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/StoredFileRepository.java
@@ -3,14 +3,13 @@ package repository;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
+import io.ebean.DB;
+import io.ebean.Database;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.StoredFile;
-import play.db.ebean.EbeanConfig;
 
 /**
  * StoredFileRepository performs complicated operations on {@link StoredFile} that involve
@@ -18,24 +17,24 @@ import play.db.ebean.EbeanConfig;
  */
 public class StoredFileRepository {
 
-  private final EbeanServer ebeanServer;
+  private final Database database;
   private final DatabaseExecutionContext executionContext;
 
   @Inject
-  public StoredFileRepository(EbeanConfig ebeanConfig, DatabaseExecutionContext executionContext) {
-    this.ebeanServer = Ebean.getServer(checkNotNull(ebeanConfig).defaultServer());
+  public StoredFileRepository(DatabaseExecutionContext executionContext) {
+    this.database = DB.getDefault();
     this.executionContext = checkNotNull(executionContext);
   }
 
   /** Return all files in a set. */
   public CompletionStage<Set<StoredFile>> list() {
-    return supplyAsync(() -> ebeanServer.find(StoredFile.class).findSet(), executionContext);
+    return supplyAsync(() -> database.find(StoredFile.class).findSet(), executionContext);
   }
 
   public CompletionStage<Optional<StoredFile>> lookupFile(Long id) {
     return supplyAsync(
         () -> {
-          StoredFile file = ebeanServer.find(StoredFile.class).setId(id).findOne();
+          StoredFile file = database.find(StoredFile.class).setId(id).findOne();
           if (file == null) {
             return Optional.empty();
           }
@@ -47,7 +46,7 @@ public class StoredFileRepository {
   public CompletionStage<Long> insert(StoredFile file) {
     return supplyAsync(
         () -> {
-          ebeanServer.insert(file);
+          database.insert(file);
           return file.id;
         },
         executionContext);

--- a/universal-application-tool-0.0.1/app/services/applicant/JsonPathProvider.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/JsonPathProvider.java
@@ -1,6 +1,7 @@
 package services.applicant;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.jayway.jsonpath.Configuration;
@@ -34,6 +35,7 @@ public class JsonPathProvider {
   private static Configuration generateConfiguration() {
     ObjectMapper mapper =
         new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
     return Configuration.builder()
         .jsonProvider(new JacksonJsonProvider(mapper))

--- a/universal-application-tool-0.0.1/app/services/cloud/aws/SignedS3UploadRequest.java
+++ b/universal-application-tool-0.0.1/app/services/cloud/aws/SignedS3UploadRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.auto.value.AutoValue;
@@ -274,6 +275,10 @@ public abstract class SignedS3UploadRequest implements StorageUploadRequest {
   abstract static class UploadPolicy {
     private static final ObjectMapper mapper =
         new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+
+    static {
+      mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
 
     static Builder builder() {
       return new AutoValue_SignedS3UploadRequest_UploadPolicy.Builder();

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableSet;
@@ -67,6 +68,10 @@ public abstract class QuestionDefinition {
   public abstract static class ValidationPredicates {
     protected static final ObjectMapper mapper =
         new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+
+    static {
+      mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
 
     public String serializeAsString() {
       try {

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
   .settings(
     name := """universal-application-tool""",
     version := "0.0.1",
-    scalaVersion := "2.13.1",
+    scalaVersion := "2.13.8",
     maintainer := "uat-public-contact@google.com",
     libraryDependencies ++= Seq(
       guice,

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -95,8 +95,6 @@ lazy val root = (project in file("."))
       "-implicit:class",
       "-Werror"
     ),
-    // Allow circular dependencies between Scala and Java
-    Compile / compileOrder := CompileOrder.ScalaThenJava,
     // Make verbose tests
     Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     // Use test config for tests

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -92,7 +92,8 @@ lazy val root = (project in file("."))
       // Turn off the AutoValueSubclassLeaked error since the generated
       // code contains it - we can't control that.
       "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF",
-      "-implicit:class"
+      "-implicit:class",
+      "-Werror"
     ),
     // Make verbose tests
     Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -96,7 +96,7 @@ lazy val root = (project in file("."))
       "-Werror"
     ),
     // Allow circular dependencies between Scala and Java
-    Compile / compileOrder := CompileOrder.Mixed,
+    Compile / compileOrder := CompileOrder.ScalaThenJava,
     // Make verbose tests
     Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     // Use test config for tests

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -95,6 +95,8 @@ lazy val root = (project in file("."))
       "-implicit:class",
       "-Werror"
     ),
+    // Allow circular dependencies between Scala and Java
+    Compile / compileOrder := CompileOrder.Mixed,
     // Make verbose tests
     Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     // Use test config for tests

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
   .settings(
     name := """universal-application-tool""",
     version := "0.0.1",
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.1",
     maintainer := "uat-public-contact@google.com",
     libraryDependencies ++= Seq(
       guice,

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -92,8 +92,7 @@ lazy val root = (project in file("."))
       // Turn off the AutoValueSubclassLeaked error since the generated
       // code contains it - we can't control that.
       "-Xplugin:ErrorProne -Xep:AutoValueSubclassLeaked:OFF",
-      "-implicit:class",
-      "-Werror"
+      "-implicit:class"
     ),
     // Make verbose tests
     Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),

--- a/universal-application-tool-0.0.1/project/build.properties
+++ b/universal-application-tool-0.0.1/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.6.1

--- a/universal-application-tool-0.0.1/project/build.properties
+++ b/universal-application-tool-0.0.1/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.6.2

--- a/universal-application-tool-0.0.1/project/plugins.sbt
+++ b/universal-application-tool-0.0.1/project/plugins.sbt
@@ -1,6 +1,6 @@
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "6.0.0")
+addSbtPlugin("com.typesafe.play" % "sbt-play-ebean" % "6.2.0-RC4")
 addSbtPlugin("name.de-vries" % "sbt-typescript" % "2.6.2")
 
 // Dependency tree plugin. To use, open an sbt shell and run dependencyBrowseTree

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -8,8 +8,8 @@ import static org.fluentlenium.core.filter.FilterConstructor.withText;
 import static play.test.Helpers.fakeApplication;
 
 import controllers.routes;
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
+import io.ebean.DB;
+import io.ebean.Database;
 import java.util.Optional;
 import models.LifecycleStage;
 import models.Models;
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.openqa.selenium.By;
 import play.Application;
 import play.api.mvc.Call;
-import play.db.ebean.EbeanConfig;
 import play.test.WithBrowser;
 import services.question.types.QuestionType;
 import support.TestConstants;
@@ -39,9 +38,8 @@ public class BaseBrowserTest extends WithBrowser {
 
   @Before
   public void resetTables() {
-    EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
-    EbeanServer server = Ebean.getServer(config.defaultServer());
-    Models.truncate(server);
+    Database database = DB.getDefault();
+    Models.truncate(database);
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
     newActiveVersion.save();
   }

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -3,8 +3,8 @@ package repository;
 import static play.test.Helpers.fakeApplication;
 
 import akka.stream.Materializer;
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
+import io.ebean.DB;
+import io.ebean.Database;
 import models.LifecycleStage;
 import models.Models;
 import models.Version;
@@ -57,8 +57,8 @@ public class WithPostgresContainer {
   @Before
   public void resetTables() {
     EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
-    EbeanServer server = Ebean.getServer(config.defaultServer());
-    Models.truncate(server);
+    Database database = DB.getDefault();
+    Models.truncate(database);
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);
     newActiveVersion.save();
   }

--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import play.Application;
-import play.db.ebean.EbeanConfig;
 import play.test.Helpers;
 import support.ProgramBuilder;
 import support.ResourceCreator;
@@ -56,7 +55,6 @@ public class WithPostgresContainer {
 
   @Before
   public void resetTables() {
-    EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
     Database database = DB.getDefault();
     Models.truncate(database);
     Version newActiveVersion = new Version(LifecycleStage.ACTIVE);

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -1,7 +1,7 @@
 package support;
 
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
+import io.ebean.DB;
+import io.ebean.Database;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
@@ -11,7 +11,6 @@ import models.Models;
 import models.Program;
 import models.Question;
 import models.TrustedIntermediaryGroup;
-import play.db.ebean.EbeanConfig;
 import play.inject.Injector;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -19,15 +18,15 @@ import services.question.types.TextQuestionDefinition;
 
 public class ResourceCreator {
 
-  private final EbeanServer ebeanServer;
+  private final Database database;
 
   public ResourceCreator(Injector injector) {
-    this.ebeanServer = Ebean.getServer(injector.instanceOf(EbeanConfig.class).defaultServer());
+    this.database = DB.getDefault();
     ProgramBuilder.setInjector(injector);
   }
 
   public void truncateTables() {
-    Models.truncate(ebeanServer);
+    Models.truncate(database);
   }
 
   public Question insertQuestion(String name) {


### PR DESCRIPTION
Upgrades:

- [x] sbt (the project's build tool) upgraded 1.3.13 -> 1.6.2
- [x] play-ebean (the plugin that integrates ebean into Play) upgraded 6.0.0 -> 6.2.0-RC4
- [x] ebean (the project's ORM) upgraded 11.45.1 -> 12.8.1 (implicitly via [play-ebean](https://github.com/playframework/play-ebean#releases))

SBT versions higher than 1.3.13 (current project version) are not compatible with play-ebean 6.0.0 (current project version) so these need to be upgraded together.

outstanding issues:

- [x] fix the ebean deprecation warnings
- [x] fix compile loop problem

closes https://github.com/seattle-uat/civiform/issues/1942
