### PR TITLE
Enable manually triggering CI workflow

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,5 +1,7 @@
 name: Probe and Deploy
 on:
+  # Setting this enables manually triggering workflow in the GitHub UI
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/direct-deploy.yaml
+++ b/.github/workflows/direct-deploy.yaml
@@ -1,5 +1,7 @@
 name: Dangerously deploy prod
 on:
+  # Setting this enables manually triggering workflow in the GitHub UI
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -3,6 +3,9 @@ name: ci
 on:
   push:
     branches: main
+
+  # Setting this enables manually triggering workflow in the GitHub UI
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch: {}
 
 # Two probers running at once can break each other.

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches: main
+  workflow_dispatch: {}
 
 # Two probers running at once can break each other.
 concurrency:


### PR DESCRIPTION
Allows manually triggering the CI workflow from the GitHub web UI. See https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow