### PR TITLE
Validate deployment variable definitions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -89,6 +89,14 @@ jobs:
         run: while ! docker run --network host appropriate/curl -v -s --retry-max-time 180 --retry-connrefused http://localhost:9000/ ; do sleep 5; done
         timeout-minutes: 3
 
+  validate_deployment_variable_definitions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out pr branch
+        uses: actions/checkout@v2
+      - name: Run deployment variable definition validation test
+        run: python3 cloud/shared/validate_variable_definitions_test.py
+
   cloudformation:
     runs-on: ubuntu-18.04 # for older version of awscli.
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,6 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate_deployment_variable_definitions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out pr branch
+        uses: actions/checkout@v2
+      - name: Run deployment variable definition validation test
+        run: python3 cloud/shared/validate_variable_definitions_test.py
+
   build_container:
     runs-on: ubuntu-18.04 # for older version of awscli.
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ backend_vars
 **.tfvars
 !*example.auto.tfvars
 terraform.tfstate**
+*.pyc

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -42,6 +42,10 @@ class ValidateVariableDefinitions():
         if not isinstance(variable_definition.get("secret", None), bool):
             errors.append("Missing 'secret' field.")
 
+        if not isinstance(variable_definition.get("type", None), str):
+            errors.append("Missing 'type' field.")
+            return errors
+
         type_specific_validators = {
             "float": self.validate_float_definition_type,
             "integer": self.validate_integer_definition_type,
@@ -49,7 +53,7 @@ class ValidateVariableDefinitions():
             "enum": self.validate_enum_definition_type,
         }
 
-        validator = type_specific_validators[variable_definition["type"]]
+        validator = type_specific_validators.get(variable_definition["type"], None)
 
         if validator:
             validator(variable_definition, errors)

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -1,7 +1,18 @@
 import os
-import glob
 import json
 
+# Loads all configuration variable definition files and validates each
+# definition for correctness. Exercised by the accompanying test file
+# which is run for every pull request.
+#
+# Requires that:
+#     - Each variable definition file is referenced in
+#       def load_repo_variable_definitions_files():
+#
+#     - All variables have, at minimum, 'type', 'required', and 'secret' fields
+#
+#     - Variable definitions may include additional configuration based on their
+#       type.
 class ValidateVariableDefinitions():
     def __init__(self, variable_definitions = {}):
         self.variable_definitions = variable_definitions
@@ -10,7 +21,11 @@ class ValidateVariableDefinitions():
         self.variable_definitions = {}
         cwd = os.getcwd()
 
-        definition_file_paths = glob.glob(cwd + '/cloud/**/variable_definitions.json', recursive=True)
+        # As more variable definition files are added for each cloud provider,
+        # add their paths here.
+        definition_file_paths = [
+            cwd + '/cloud/shared/variable_definitions.json'
+        ]
 
         for path in definition_file_paths:
             with open(path, 'r') as file:

--- a/cloud/shared/validate_variable_definitions.py
+++ b/cloud/shared/validate_variable_definitions.py
@@ -1,0 +1,72 @@
+import os
+import glob
+import json
+
+class ValidateVariableDefinitions():
+    def __init__(self, variable_definitions = {}):
+        self.variable_definitions = variable_definitions
+
+    def load_repo_variable_definitions_files(self):
+        self.variable_definitions = {}
+        cwd = os.getcwd()
+
+        definition_file_paths = glob.glob(cwd + '/cloud/**/variable_definitions.json', recursive=True)
+
+        for path in definition_file_paths:
+            with open(path, 'r') as file:
+                definitions = json.loads(file.read())
+
+                for name, definition in definitions.items():
+                    if name in self.variable_definitions:
+                        raise RuntimeError(f"Duplicate variable name: {name} at {path}")
+
+                    self.variable_definitions[name] = definition
+
+    def get_validation_errors(self):
+        all_errors = {}
+
+        for name, definition in self.variable_definitions.items():
+            definition_errors = self.validate(definition)
+
+            if len(definition_errors) > 0:
+                all_errors[name] = definition_errors
+
+        return all_errors
+
+    def validate(self, variable_definition):
+        errors = []
+
+        if not isinstance(variable_definition.get("required", None), bool):
+            errors.append("Missing 'required' field.")
+
+        if not isinstance(variable_definition.get("secret", None), bool):
+            errors.append("Missing 'secret' field.")
+
+        type_specific_validators = {
+            "float": self.validate_float_definition_type,
+            "integer": self.validate_integer_definition_type,
+            "string": self.validate_string_definition_type,
+            "enum": self.validate_enum_definition_type,
+        }
+
+        validator = type_specific_validators[variable_definition["type"]]
+
+        if validator:
+            validator(variable_definition, errors)
+        else:
+            errors.append("Unknown or missing 'type' field.")
+
+        return errors
+
+    def validate_float_definition_type(self, variable_definition, errors):
+        pass
+
+    def validate_integer_definition_type(self, variable_definition, errors):
+        pass
+
+    def validate_string_definition_type(self, variable_definition, errors):
+        pass
+
+    def validate_enum_definition_type(self, variable_definition, errors):
+        if not isinstance(variable_definition.get("values", None), list):
+            errors.append("Missing 'values' field for enum.")

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -11,7 +11,7 @@ class TestValidateVariableDefinitions(unittest.TestCase):
         self.assertEqual(errors, {})
 
     def test_get_validation_errors_float_no_errors(self):
-        enum = {
+        defs = {
             "FOO": {
                 "required": True,
                 "secret": False,
@@ -19,12 +19,12 @@ class TestValidateVariableDefinitions(unittest.TestCase):
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, {})
 
     def test_get_validation_errors_integer_no_errors(self):
-        enum = {
+        defs = {
             "FOO": {
                 "required": True,
                 "secret": False,
@@ -32,12 +32,12 @@ class TestValidateVariableDefinitions(unittest.TestCase):
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, {})
 
     def test_get_validation_errors_string_no_errors(self):
-        enum = {
+        defs = {
             "FOO": {
                 "required": True,
                 "secret": False,
@@ -45,48 +45,48 @@ class TestValidateVariableDefinitions(unittest.TestCase):
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, {})
 
     def test_get_validation_errors_string_missing_secret(self):
-        enum = {
+        defs = {
             "FOO": {
                 "required": True,
                 "type": "string"
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, { "FOO": ["Missing 'secret' field."] })
 
     def test_get_validation_errors_string_missing_type(self):
-        enum = {
+        defs = {
             "FOO": {
                 "required": True,
                 "secret": False
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, { "FOO": ["Missing 'type' field."] })
 
     def test_get_validation_errors_string_missing_required(self):
-        enum = {
+        defs = {
             "FOO": {
                 "secret": False,
                 "type": "string"
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, { "FOO": ["Missing 'required' field."] })
 
     def test_get_validation_errors_enum_no_errors(self):
-        enum = {
+        defs = {
             "CIVIFORM_CLOUD_PROVIDER": {
                 "required": True,
                 "secret": False,
@@ -95,12 +95,12 @@ class TestValidateVariableDefinitions(unittest.TestCase):
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         self.assertEqual(errors, {})
 
     def test_get_validation_errors_enum_missing_values(self):
-        enum = {
+        defs = {
             "CIVIFORM_CLOUD_PROVIDER": {
                 "required": True,
                 "secret": False,
@@ -108,7 +108,7 @@ class TestValidateVariableDefinitions(unittest.TestCase):
             }
         }
 
-        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+        errors = ValidateVariableDefinitions(defs).get_validation_errors()
 
         expected_errors = {
             "CIVIFORM_CLOUD_PROVIDER": ["Missing 'values' field for enum."]

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -61,6 +61,18 @@ class TestValidateVariableDefinitions(unittest.TestCase):
 
         self.assertEqual(errors, { "FOO": ["Missing 'secret' field."] })
 
+    def test_get_validation_errors_string_missing_type(self):
+        enum = {
+            "FOO": {
+                "required": True,
+                "secret": False
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, { "FOO": ["Missing 'type' field."] })
+
     def test_get_validation_errors_string_missing_required(self):
         enum = {
             "FOO": {

--- a/cloud/shared/validate_variable_definitions_test.py
+++ b/cloud/shared/validate_variable_definitions_test.py
@@ -1,0 +1,108 @@
+import unittest
+
+from validate_variable_definitions import ValidateVariableDefinitions
+
+class TestValidateVariableDefinitions(unittest.TestCase):
+    def test_validate_all_variable_definitions(self):
+        validator = ValidateVariableDefinitions()
+        validator.load_repo_variable_definitions_files()
+        errors = validator.get_validation_errors()
+
+        self.assertEqual(errors, {})
+
+    def test_get_validation_errors_float_no_errors(self):
+        enum = {
+            "FOO": {
+                "required": True,
+                "secret": False,
+                "type": "float"
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, {})
+
+    def test_get_validation_errors_integer_no_errors(self):
+        enum = {
+            "FOO": {
+                "required": True,
+                "secret": False,
+                "type": "integer"
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, {})
+
+    def test_get_validation_errors_string_no_errors(self):
+        enum = {
+            "FOO": {
+                "required": True,
+                "secret": False,
+                "type": "string"
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, {})
+
+    def test_get_validation_errors_string_missing_secret(self):
+        enum = {
+            "FOO": {
+                "required": True,
+                "type": "string"
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, { "FOO": ["Missing 'secret' field."] })
+
+    def test_get_validation_errors_string_missing_required(self):
+        enum = {
+            "FOO": {
+                "secret": False,
+                "type": "string"
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, { "FOO": ["Missing 'required' field."] })
+
+    def test_get_validation_errors_enum_no_errors(self):
+        enum = {
+            "CIVIFORM_CLOUD_PROVIDER": {
+                "required": True,
+                "secret": False,
+                "type": "enum",
+                "values": ["gcp", "azure", "aws"]
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        self.assertEqual(errors, {})
+
+    def test_get_validation_errors_enum_missing_values(self):
+        enum = {
+            "CIVIFORM_CLOUD_PROVIDER": {
+                "required": True,
+                "secret": False,
+                "type": "enum"
+            }
+        }
+
+        errors = ValidateVariableDefinitions(enum).get_validation_errors()
+
+        expected_errors = {
+            "CIVIFORM_CLOUD_PROVIDER": ["Missing 'values' field for enum."]
+        }
+
+        self.assertEqual(errors, expected_errors)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -1,0 +1,8 @@
+{
+  "CIVIFORM_CLOUD_PROVIDER": {
+    "required": true,
+    "secret": false,
+    "type": "enum",
+    "values": ["gcp", "azure", "aws"]
+  }
+}


### PR DESCRIPTION
Adds a CI check that runs for each PR and `main` merge to ensure that each deployment variable definition:

1. uses a unique name
2. has the required fields for its type