### PR TITLE
Fix dev dump and restore scripts

### DIFF
--- a/bin/dev-restore-db
+++ b/bin/dev-restore-db
@@ -33,8 +33,9 @@ readonly DUMP_FILE="project/${1}"
 readonly TRUNCATE_DB_CMD="/usr/bin/psql -h db -U postgres -c '${TRUNCATE_SQL}' postgres"
 
 # command for invoking pg_restore with the dev database
-readonly PG_RESTORE_CMD="/usr/bin/pg_restore -h db -U postgres -d postgres"\
-  " < ${DUMP_FILE}"
+
+readonly PG_RESTORE_CMD="/usr/bin/pg_restore -h db -U \
+  postgres -d postgres < ${DUMP_FILE}"
 
 readonly CMD="${TRUNCATE_DB_CMD} && ${PG_RESTORE_CMD}"
 

--- a/bin/dump-dev-program-config
+++ b/bin/dump-dev-program-config
@@ -21,4 +21,4 @@ docker run --rm -it \
     -t versions \
     -t versions_programs \
     -t versions_questions \
-    postgres > /project/dev_db.dump"
+    postgres > /project/dev_programs.dump"

--- a/bin/dump-dev-program-config
+++ b/bin/dump-dev-program-config
@@ -7,17 +7,18 @@ source bin/lib.sh
 docker::set_network_name_dev
 
 docker run --rm -it \
+  -v "$(pwd):/project" \
   -e "PGPASSWORD=example" \
   --network "${DOCKER_NETWORK_NAME}" \
   postgres:12.5 \
-  /usr/bin/pg_dump \
-  -w \
-  -Fc \
-  -h db \
-  -U postgres \
-  -t programs \
-  -t questions \
-  -t versions \
-  -t versions_programs \
-  -t versions_questions \
-  postgres > dev_programs.dump
+  /bin/bash -c "pg_dump \
+    -w \
+    -Fc \
+    -h db \
+    -U postgres \
+    -t programs \
+    -t questions \
+    -t versions \
+    -t versions_programs \
+    -t versions_questions \
+    postgres > /project/dev_db.dump"


### PR DESCRIPTION
The dump script appeared to work but actually generates a corrupted binary archive, I think because docker might be doing something to stdout output. This change fixes that by mounting the project directory into the docker image and writing the archive file in there instead of from the output from docker.

The line continuation in the restore script was wrong.