### PR TITLE
Store database password and app secret key in Azure Key Vault

### DIFF
--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -4,4 +4,7 @@ locals {
   # and record set configured.
   postgres_private_link = azurerm_private_endpoint.endpoint.private_dns_zone_configs[0].record_sets[0].fqdn
   generated_hostname    = "${var.application_name}-${random_pet.server.id}.azurewebsites.net"
+
+  postgres_password_secret_name = "postgres-password"
+  app_key_secret_name = "app-secret-key"
 }

--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -5,6 +5,6 @@ locals {
   postgres_private_link = azurerm_private_endpoint.endpoint.private_dns_zone_configs[0].record_sets[0].fqdn
   generated_hostname    = "${var.application_name}-${random_pet.server.id}.azurewebsites.net"
 
-  postgres_password_secret_name = "postgres-password"
-  app_key_secret_name = "app-secret-key"
+  postgres_password_keyvault_id = "postgres-password"
+  app_secret_key_keyvault_id = "app-secret-key"
 }

--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -61,12 +61,12 @@ data "azurerm_key_vault" "civiform_key_vault" {
 }
 
 data "azurerm_key_vault_secret" "postgres_password" {
-  name         = local.postgres_password_secret_name
+  name         = local.postgres_password_keyvault_id
   key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
 }
 
 data "azurerm_key_vault_secret" "app_secret_key" {
-  name         = local.app_key_secret_name
+  name         = local.app_secret_key_keyvault_id
   key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
 }
 

--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -55,6 +55,21 @@ resource "azurerm_storage_account_network_rules" "files_storage_rules" {
   }
 }
 
+data "azurerm_key_vault" "civiform_key_vault" {
+  name                = var.key_vault_name
+  resource_group_name = azurerm_resource_group.rg
+}
+
+data "azurerm_key_vault_secret" "postgres_password" {
+  name         = local.postgres_password_secret_name
+  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
+}
+
+data "azurerm_key_vault_secret" "app_secret_key" {
+  name         = local.app_key_secret_name
+  key_vault_id = data.azurerm_key_vault.civiform_key_vault.id
+}
+
 resource "azurerm_storage_container" "files_container" {
   name                  = "files"
   storage_account_name  = azurerm_storage_account.files_storage_account.name
@@ -106,7 +121,7 @@ resource "azurerm_app_service" "civiform_app" {
     DOCKER_REGISTRY_SERVER_URL = "https://index.docker.io"
 
     DB_USERNAME    = "${azurerm_postgresql_server.civiform.administrator_login}@${azurerm_postgresql_server.civiform.name}"
-    DB_PASSWORD    = azurerm_postgresql_server.civiform.administrator_login_password
+    DB_PASSWORD    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.postgres_password.id})"
     DB_JDBC_STRING = "jdbc:postgresql://${local.postgres_private_link}:5432/postgres?ssl=true&sslmode=require"
 
     STORAGE_SERVICE_NAME = "azure-blob"
@@ -118,7 +133,7 @@ resource "azurerm_app_service" "civiform_app" {
     AZURE_STORAGE_ACCOUNT_CONTAINER = azurerm_storage_container.files_container.name
 
     AWS_SES_SENDER = var.ses_sender_email
-    SECRET_KEY     = var.app_secret_key
+    SECRET_KEY     = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.app_secret_key.id})"
   }
   # Configure Docker Image to load on start
   site_config {
@@ -198,7 +213,7 @@ resource "azurerm_postgresql_server" "civiform" {
   resource_group_name = azurerm_resource_group.rg.name
 
   administrator_login          = var.postgres_admin_login
-  administrator_login_password = var.postgres_admin_password
+  administrator_login_password = data.azurerm_key_vault_secret.postgres_password.value
 
   // fqdn civiform-db.postgres.database.azure.com
 

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -41,11 +41,6 @@ variable "subnet_address_prefixes" {
   ]
 }
 
-variable "app_secret_key" {
-  type        = string
-  description = "Secret Key For the app"
-}
-
 variable "app_sku" {
   type        = map(string)
   description = "SKU tier/size/capacity information"
@@ -64,11 +59,6 @@ variable "resource_group_name" {
 variable "postgres_admin_login" {
   type        = string
   description = "Postgres admin login"
-}
-
-variable "postgres_admin_password" {
-  type        = string
-  description = "Postgres admin password"
 }
 
 variable "postgres_sku_name" {
@@ -122,4 +112,8 @@ variable "staging_hostname" {
 variable "custom_hostname" {
   type        = string
   description = "custom hostname for the app to map the dns (used also for CORS)"
+}
+variable "key_vault_name" {
+  type = string
+  description = "Name of key vault where app secrets are stored."
 }

--- a/cloud/deploys/staging_azure/README.md
+++ b/cloud/deploys/staging_azure/README.md
@@ -89,3 +89,8 @@ storage account within that resource group. For example in the below azure
 portal the resource group name is 'tfstate' and the storage_account_name is 
 'tfstate7307'.
 ![Image of Azure portal showing where to find the storage_account_name](img/how_to_find_backend_vars.png?raw=true)
+
+# Manually Configure Key Vault before running Terraform
+Before applying the Terraform configuration, you'll need to make sure that Azure Key Vault is
+properly configured to store the `postgres-password` and `app-secret-key` secrets. Then, in order
+to use the Key Vault as a data source in Terraform, set the `key_vault_name` variable in your `auto.tfvars` file to the name of the key vault.

--- a/cloud/deploys/staging_azure/README.md
+++ b/cloud/deploys/staging_azure/README.md
@@ -92,5 +92,13 @@ portal the resource group name is 'tfstate' and the storage_account_name is
 
 # Manually Configure Key Vault before running Terraform
 Before applying the Terraform configuration, you'll need to make sure that Azure Key Vault is
-properly configured to store the `postgres-password` and `app-secret-key` secrets. Then, in order
-to use the Key Vault as a data source in Terraform, set the `key_vault_name` variable in your `auto.tfvars` file to the name of the key vault.
+properly configured to store the `postgres-password` and `app-secret-key` secrets. To do this, run the command `az keyvault list` to list all the key vaults in your project. Find the key vault that stores the secrets for Civiform. Then run `az keyvault secret list --vault-name=[your vault name]`. The `postgres-password` and `app-secret-key` secrets should be listed.
+
+If the secrets are not listed, you'll need to [create a key vault](https://docs.microsoft.com/en-us/azure/key-vault/general/quick-create-cli) if you haven't already. Then set the secrets:
+
+```
+az keyvault secret set --name postgres-password --vault-name [key vault name] --value [password]
+az keyvault secret set --name app-secret-key --vault-name [key vault name] --value [secret key]
+```
+
+Then, in order to use the Key Vault as a data source in Terraform, set the `key_vault_name` variable in your `auto.tfvars` file to the name of the key vault.

--- a/cloud/deploys/staging_azure/main.tf
+++ b/cloud/deploys/staging_azure/main.tf
@@ -16,17 +16,18 @@ terraform {
 
 module "app" {
   source = "../../azure/modules/app"
-
   postgres_admin_login    = var.postgres_admin_login
-  postgres_admin_password = var.postgres_admin_password
+  
   # note that we must use GP tier
   postgres_sku_name       = "GP_Gen5_2"
 
   docker_username        = var.docker_username
   docker_repository_name = var.docker_repository_name
 
+  key_vault_name = var.key_vault_name
+
   application_name = var.application_name
-  app_secret_key   = var.app_secret_key
+  
   ses_sender_email = var.sender_email_address
   custom_hostname  = var.custom_hostname
 }

--- a/cloud/deploys/staging_azure/variables.tf
+++ b/cloud/deploys/staging_azure/variables.tf
@@ -18,14 +18,9 @@ variable "application_name" {
   description = "Azure Web App Name"
 }
 
-variable "postgres_admin_password" {
-  type        = string
-  description = "Postgres admin password"
-}
-
-variable "app_secret_key" {
-  type        = string
-  description = "Secret Key For the app"
+variable "key_vault_name" {
+  type = string
+  description = "Name of key vault where app secrets are stored."
 }
 
 variable "aws_region" {


### PR DESCRIPTION
### Description
Remove `postgres_admin_password` and `app_secret_key` variables and instead retrieve these values from Azure Key Vault

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1839 
