### PR TITLE
Don't include screens without questions in total block count

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -124,7 +124,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
   private ApplicantProgramSummaryView.Params.Builder generateParamsBuilder(
       ReadOnlyApplicantProgramService roApplicantProgramService) {
     ImmutableList<AnswerData> summaryData = roApplicantProgramService.getSummaryData();
-    int totalBlockCount = roApplicantProgramService.getAllActiveBlocks().size();
+    int totalBlockCount = roApplicantProgramService.getCompletableProgramsBlockCount();
     int completedBlockCount = roApplicantProgramService.getActiveAndCompletedInProgramBlockCount();
     String programTitle = roApplicantProgramService.getProgramTitle();
 

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -106,6 +106,10 @@ public final class Block {
     return blockDefinition.isFileUpload();
   }
 
+  public boolean hasQuestions() {
+    return getQuestions().size() > 0;
+  }
+
   public ImmutableList<ApplicantQuestion> getQuestions() {
     if (questionsMemo.isEmpty()) {
       this.questionsMemo =

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -40,6 +40,9 @@ public interface ReadOnlyApplicantProgramService {
    */
   int getActiveAndCompletedInProgramBlockCount();
 
+  /** The count of blocks that are active and have at least one question. */
+  int getCompletableProgramsBlockCount();
+
   /** Get the block with the given block ID */
   Optional<Block> getBlock(String blockId);
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -64,8 +64,14 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
   }
 
   @Override
+  public int getCompletableProgramsBlockCount() {
+    return getAllActiveBlocks().stream().filter(Block::hasQuestions).mapToInt(b -> 1).sum();
+  }
+
+  @Override
   public int getActiveAndCompletedInProgramBlockCount() {
     return getAllActiveBlocks().stream()
+        .filter(block -> block.hasQuestions())
         .filter(block -> block.isCompletedInProgramWithoutErrors())
         .mapToInt(b -> 1)
         .sum();

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -120,6 +120,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
       return fileUploadStrategy.renderFileUploadBlockSubmitForms(
           params, applicantQuestionRendererFactory);
     }
+
     String formAction =
         routes.ApplicantProgramBlocksController.update(
                 params.applicantId(), params.programId(), params.block().getId(), params.inReview())

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramSummaryView.java
@@ -45,7 +45,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
   }
 
   /**
-   * Renders a summary of all of the applicant's data for a specific application. Data includes:
+   * Renders a summary of all the applicant's data for a specific application. Data includes:
    *
    * <p>Program Id, Applicant Id - Needed for link context (submit & edit)
    *


### PR DESCRIPTION
To determine if an application is ok to submit or requires more answers from the applicant, we count the number of active blocks and compare that with the number of active and completed blocks. This caused a bug where blocks that have no questions would count towards the total of active but incomplete blocks, making it impossible to complete the application.

This change alters the logic for tallying completed blocks by not including blocks that have no questions in the tally.