### PR TITLE
Blocks are complete in program if they have no questions

### DIFF
--- a/browser-test/src/application_review.test.ts
+++ b/browser-test/src/application_review.test.ts
@@ -59,6 +59,7 @@ describe('normal application flow', () => {
 
     const programName = 'a shiny new program'
     await adminPrograms.addProgram(programName)
+
     await adminPrograms.editProgramBlock(programName, 'block description', [
       'date-q',
       'address-q',
@@ -84,6 +85,10 @@ describe('normal application flow', () => {
       'second-static-q',
       'monthly-income-q',
     ])
+
+    // Intentionally add an empty block to ensure that empty blocks do not
+    // prevent applicants from being able to submit applications.
+    await adminPrograms.addProgramBlock(programName, 'empty block')
 
     await adminPrograms.gotoAdminProgramsPage()
     await adminPrograms.expectDraftProgram(programName)

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -205,8 +205,9 @@ public final class Block {
   }
 
   private boolean isCompleteInProgram() {
-    return getQuestions().size() == 0 || getQuestions().stream()
-        .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
+    return getQuestions().size() == 0
+        || getQuestions().stream()
+            .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -205,8 +205,8 @@ public final class Block {
   }
 
   private boolean isCompleteInProgram() {
-    return getQuestions().stream()
-        .anyMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
+    return getQuestions().size() == 0 || getQuestions().stream()
+        .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -205,11 +205,9 @@ public final class Block {
   }
 
   private boolean isCompleteInProgram() {
-    return getQuestions().stream()
-        .anyMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
-    //    return getQuestions().size() == 0
-    //            || getQuestions().stream()
-    //            .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
+        return getQuestions().size() == 0
+                || getQuestions().stream()
+                .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -205,9 +205,11 @@ public final class Block {
   }
 
   private boolean isCompleteInProgram() {
-    return getQuestions().size() == 0
-        || getQuestions().stream()
-            .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
+    return getQuestions().stream()
+        .anyMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
+    //    return getQuestions().size() == 0
+    //            || getQuestions().stream()
+    //            .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -205,9 +205,9 @@ public final class Block {
   }
 
   private boolean isCompleteInProgram() {
-        return getQuestions().size() == 0
-                || getQuestions().stream()
-                .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
+    return getQuestions().size() == 0
+        || getQuestions().stream()
+            .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -204,8 +204,14 @@ public final class Block {
     return isCompleteInProgram() && !hasErrors();
   }
 
+  /**
+   * A block is considered complete in a program if 1) It has no questions (this is a bit of a
+   * bugfix hack so that empty blocks the admin hasn't added content to don't prevent applicants
+   * from being able to submit their applications). OR 2) Each of its required questions is answered
+   * AND each of its optional questions is answered or intentionally skipped.
+   */
   private boolean isCompleteInProgram() {
-    return getQuestions().size() == 0
+    return getQuestions().isEmpty()
         || getQuestions().stream()
             .allMatch(question -> question.isAnsweredOrSkippedOptionalInProgram());
   }


### PR DESCRIPTION
To determine if an application is ok to submit or requires more answers from the applicant, we count the number of active blocks (i.e. blocks that are not hidden by predicate logic) and compare that with the number of active blocks that are completed (answered) or skipped if Optional. This caused a bug where blocks that have no questions would count towards the total of active but incomplete blocks, making it impossible to complete the application.

This change alters the logic for calculating block completion state to be true if the block has no questions.

Verified the updated test catches this bug:

![image](https://user-images.githubusercontent.com/473671/152893759-30d37eb6-ef38-45f8-b566-1dfa07f74722.png)

Fixes #1877