### PR TITLE
Add aria attributes for applicant form UI

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -299,6 +299,7 @@ class ValidationController {
     const addressQuestions = Array.from(
       document.querySelectorAll(ValidationController.ADDRESS_QUESTION_CLASS)
     )
+
     for (const question of addressQuestions) {
       // validate address line 1 not empty.
       const addressLine1 = <HTMLInputElement>(
@@ -365,6 +366,7 @@ class ValidationController {
       const isValid = emptyOptional || hasValidPresentInputs
       allValid = allValid && isValid
     }
+
     return allValid
   }
 

--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -275,11 +275,13 @@ class ValidationController {
     const filledInputs = Array.from(question.querySelectorAll('input')).filter(
       (input) => input.value !== ''
     )
+
     if (isOptional && filledInputs.length === 0) {
       return
     }
 
     const errorDiv = question.querySelector(fieldName + '-error')
+
     if (errorDiv) {
       errorDiv.classList.toggle('hidden', isValid)
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -76,6 +76,10 @@ public class ApplicantQuestion {
     return programQuestionDefinition.optional();
   }
 
+  public boolean isRequired() {
+    return !isOptional();
+  }
+
   /**
    * Return true if this question is answered or a skipped optional question in the program
    * specified. Questions can only be skipped and left unanswered if they are optional.

--- a/universal-application-tool-0.0.1/app/views/HtmlAttributes.java
+++ b/universal-application-tool-0.0.1/app/views/HtmlAttributes.java
@@ -1,0 +1,8 @@
+package views;
+
+public final class HtmlAttributes {
+  public static final String ARIA_DESCRIBEDBY = "aria-describedby";
+  public static final String ARIA_ERRORMESSAGE = "aria-errormessage";
+  public static final String ARIA_INVALID = "aria-invalid";
+  public static final String ARIA_REQUIRED = "aria-required";
+}

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -88,9 +88,6 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
               params.messages()));
     }
 
-    // Add question validation scripts.
-    bundle.addFooterScripts(layout.viewUtils.makeLocalJsTag("validation"));
-
     return layout.renderWithNav(
         params.request(), params.applicantName(), params.messages(), bundle);
   }

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -5,6 +5,7 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.textarea;
+import static views.HtmlAttributes.*;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -55,6 +56,10 @@ public class FieldWithLabel {
   protected boolean checked = false;
   protected boolean disabled = false;
   protected boolean isCurrency = false;
+  protected String errorMessageHtmlId = "";
+  protected String describedByHtmlId = "";
+  protected boolean isInvalid = false;
+  protected boolean isRequired = false;
   protected ImmutableList.Builder<String> referenceClassesBuilder = ImmutableList.builder();
 
   public FieldWithLabel(Tag fieldTag) {
@@ -133,7 +138,27 @@ public class FieldWithLabel {
     return this;
   }
 
-  FieldWithLabel setIsCurrency() {
+  public FieldWithLabel setErrorMessageHtmlId(String errorMessageHtmlId) {
+    this.errorMessageHtmlId = errorMessageHtmlId;
+    return this;
+  }
+
+  public FieldWithLabel setDescribedByHtmlId(String describedByHtmlId) {
+    this.describedByHtmlId = describedByHtmlId;
+    return this;
+  }
+
+  public FieldWithLabel setIsInvalid(boolean isInvalid) {
+    this.isInvalid = isInvalid;
+    return this;
+  }
+
+  public FieldWithLabel setIsRequired(boolean isRequired) {
+    this.isRequired = isRequired;
+    return this;
+  }
+
+  public FieldWithLabel setIsCurrency() {
     this.isCurrency = true;
     // There is no HTML currency input so we identify these with a custom attribute.
     this.setAttribute("currency");
@@ -293,6 +318,10 @@ public class FieldWithLabel {
             StyleUtils.joinStyles(
                 BaseStyles.INPUT, hasFieldErrors ? BaseStyles.FORM_FIELD_ERROR_BORDER_COLOR : ""))
         .withId(this.id)
+        .condAttr(isRequired, ARIA_REQUIRED, "true")
+        .condAttr(!errorMessageHtmlId.isEmpty(), ARIA_ERRORMESSAGE, errorMessageHtmlId)
+        .condAttr(!describedByHtmlId.isEmpty(), ARIA_DESCRIBEDBY, describedByHtmlId)
+        .attr(ARIA_INVALID, isInvalid)
         .withName(this.fieldName)
         .condAttr(this.disabled, Attr.DISABLED, "true")
         .withCondPlaceholder(!Strings.isNullOrEmpty(this.placeholderText), this.placeholderText)

--- a/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/FieldWithLabel.java
@@ -8,12 +8,13 @@ import static j2html.TagCreator.textarea;
 import static views.HtmlAttributes.*;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import j2html.TagCreator;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -60,7 +61,7 @@ public class FieldWithLabel {
   protected String describedByHtmlId = "";
   protected boolean isInvalid = false;
   protected boolean isRequired = false;
-  protected ImmutableList.Builder<String> referenceClassesBuilder = ImmutableList.builder();
+  protected ArrayList<String> referenceClasses = new ArrayList<>();
 
   public FieldWithLabel(Tag fieldTag) {
     this.fieldTag = checkNotNull(fieldTag);
@@ -108,7 +109,7 @@ public class FieldWithLabel {
 
   /** Add a reference class from {@link views.style.ReferenceClasses} to this element. */
   public FieldWithLabel addReferenceClass(String referenceClass) {
-    referenceClassesBuilder.add(referenceClass);
+    referenceClasses.add(referenceClass);
     return this;
   }
 
@@ -343,7 +344,7 @@ public class FieldWithLabel {
             labelTag,
             div(fieldTag, buildFieldErrorsTag()).withClasses(Styles.FLEX, Styles.FLEX_COL))
         .withClasses(
-            StyleUtils.joinStyles(referenceClassesBuilder.build().toArray(new String[0])),
+            StyleUtils.joinStyles(referenceClasses.toArray(new String[0])),
             BaseStyles.FORM_FIELD_MARGIN_BOTTOM);
   }
 
@@ -358,7 +359,7 @@ public class FieldWithLabel {
 
     return label()
         .withClasses(
-            StyleUtils.joinStyles(referenceClassesBuilder.build().toArray(new String[0])),
+            StyleUtils.joinStyles(referenceClasses.toArray(new String[0])),
             BaseStyles.CHECKBOX_LABEL,
             BaseStyles.FORM_FIELD_MARGIN_BOTTOM,
             labelText.isEmpty() ? Styles.W_MIN : "")
@@ -369,7 +370,8 @@ public class FieldWithLabel {
 
   private Tag buildFieldErrorsTag() {
     String[] referenceClasses =
-        referenceClassesBuilder.build().stream().map(ref -> ref + "-error").toArray(String[]::new);
+        this.referenceClasses.stream().map(ref -> ref + "-error").toArray(String[]::new);
+
     return div(each(fieldErrors, error -> div(error.getMessage(messages))))
         .withClasses(
             StyleUtils.joinStyles(referenceClasses),

--- a/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
@@ -2,6 +2,7 @@ package views.components;
 
 import static j2html.TagCreator.option;
 import static j2html.TagCreator.select;
+import static views.HtmlAttributes.ARIA_REQUIRED;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -92,6 +93,8 @@ public class SelectWithLabel extends FieldWithLabel {
       placeholder.attr(Attr.SELECTED);
     }
     ((ContainerTag) fieldTag).with(placeholder);
+
+    fieldTag.condAttr(isRequired, ARIA_REQUIRED, "true");
 
     // Either set the options to be custom options or create options from the (text, value) pairs.
     if (!this.customOptions.isEmpty()) {

--- a/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
+++ b/universal-application-tool-0.0.1/app/views/components/SelectWithLabel.java
@@ -22,7 +22,7 @@ public class SelectWithLabel extends FieldWithLabel {
 
   @Override
   public SelectWithLabel addReferenceClass(String referenceClass) {
-    referenceClassesBuilder.add(referenceClass);
+    referenceClasses.add(referenceClass);
     return this;
   }
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
@@ -41,6 +41,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
                     .setFieldErrors(messages, addressQuestion.getStreetErrorMessage())
                     .showFieldErrors(!addressQuestion.getStreetErrors().isEmpty())
                     .addReferenceClass(ReferenceClasses.ADDRESS_STREET_1)
+                    .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+                    .setDescribedByHtmlId(questionHelpTextHtmlId())
+                    .setIsInvalid(isInvalid())
                     .getContainer(),
                 /** Second line of address entry: Address line 2 AKA apartment, unit, etc. */
                 FieldWithLabel.input()
@@ -62,6 +65,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
                             .addReferenceClass(ReferenceClasses.ADDRESS_CITY)
                             .setFieldErrors(messages, addressQuestion.getCityErrorMessage())
                             .showFieldErrors(!addressQuestion.getCityErrors().isEmpty())
+                            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+                            .setDescribedByHtmlId(questionHelpTextHtmlId())
+                            .setIsInvalid(isInvalid())
                             .getContainer(),
                         FieldWithLabel.input()
                             .setFieldName(addressQuestion.getStatePath().toString())
@@ -70,6 +76,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
                             .setFieldErrors(messages, addressQuestion.getStateErrorMessage())
                             .showFieldErrors(!addressQuestion.getStateErrors().isEmpty())
                             .addReferenceClass(ReferenceClasses.ADDRESS_STATE)
+                            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+                            .setDescribedByHtmlId(questionHelpTextHtmlId())
+                            .setIsInvalid(isInvalid())
                             .getContainer(),
                         FieldWithLabel.input()
                             .setFieldName(addressQuestion.getZipPath().toString())
@@ -79,6 +88,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
                             .setFieldErrors(messages, addressQuestion.getZipErrorMessage())
                             .showFieldErrors(!addressQuestion.getZipErrors().isEmpty())
                             .addReferenceClass(ReferenceClasses.ADDRESS_ZIP)
+                            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+                            .setDescribedByHtmlId(questionHelpTextHtmlId())
+                            .setIsInvalid(isInvalid())
                             .getContainer()));
 
     return renderInternal(messages, addressQuestionFormContent);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -1,8 +1,7 @@
 package views.questiontypes;
 
-import static j2html.TagCreator.div;
-import static j2html.TagCreator.input;
-import static j2html.TagCreator.label;
+import static j2html.TagCreator.*;
+import static views.HtmlAttributes.*;
 
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
@@ -32,8 +31,11 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
   public Tag render(ApplicantQuestionRendererParams params) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
+    // If there is only one checkbox and the question is required then the checkbox is required.
+    boolean markRequired = multiOptionQuestion.getOptions().size() == 1 && question.isRequired();
+
     Tag checkboxQuestionFormContent =
-        div()
+        fieldset()
             // Hidden input that's always selected to allow for clearing mutli-select data.
             .with(
                 input()
@@ -50,13 +52,17 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
                             renderCheckboxOption(
                                 multiOptionQuestion.getSelectionPathAsArray(),
                                 option,
-                                multiOptionQuestion.optionIsSelected(option))));
+                                multiOptionQuestion.optionIsSelected(option),
+                                markRequired)));
 
     return renderInternal(params.messages(), checkboxQuestionFormContent);
   }
 
   private Tag renderCheckboxOption(
-      String selectionPath, LocalizedQuestionOption option, boolean isSelected) {
+      String selectionPath,
+      LocalizedQuestionOption option,
+      boolean isSelected,
+      boolean isRequired) {
     String id = "checkbox-" + question.getContextualizedPath() + "-" + option.id();
     ContainerTag labelTag =
         label()
@@ -71,6 +77,9 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
                     .withName(selectionPath)
                     .withValue(String.valueOf(option.id()))
                     .condAttr(isSelected, Attr.CHECKED, "")
+                    .condAttr(isRequired, ARIA_REQUIRED, "true")
+                    .attr(ARIA_ERRORMESSAGE, questionErrorMessageHtmlId())
+                    .attr(ARIA_DESCRIBEDBY, questionHelpTextHtmlId())
                     .withClasses(
                         StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.CHECKBOX)))
             .withText(option.optionText());

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -36,6 +36,7 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRenderer {
                 params.messages(),
                 ImmutableSet.of(
                     ValidationErrorMessage.create(MessageKey.CURRENCY_VALIDATION_MISFORMATTED)))
+            .setDescribedByHtmlId(questionHelpTextHtmlId())
             .showFieldErrors(false);
     if (currencyQuestion.getValue().isPresent()) {
       currencyField.setValue(currencyQuestion.getValue().get());

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -59,6 +59,6 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRenderer {
     Tag currencyQuestionFormContent =
         div().withClasses(Styles.FLEX).with(dollarSign).with(currencyField.getContainer());
 
-    return renderInternal(params.messages(), currencyQuestionFormContent, false);
+    return renderInternal(params.messages(), currencyQuestionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
@@ -39,6 +39,6 @@ public class DateQuestionRenderer extends ApplicantQuestionRenderer {
     }
     Tag dateQuestionFormContent = dateField.getContainer();
 
-    return renderInternal(params.messages(), dateQuestionFormContent, false);
+    return renderInternal(params.messages(), dateQuestionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
@@ -26,8 +26,13 @@ public class DateQuestionRenderer extends ApplicantQuestionRenderer {
 
     FieldWithLabel dateField =
         FieldWithLabel.date()
+            .setDescribedByHtmlId(questionHelpTextHtmlId())
+            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+            .setIsInvalid(isInvalid())
+            .setIsRequired(question.isRequired())
             .setFieldName(dateQuestion.getDatePath().toString())
-            .setScreenReaderText(question.getQuestionText());
+            .setScreenReaderText(question.getQuestionText())
+            .setDescribedByHtmlId(questionHelpTextHtmlId());
     if (dateQuestion.getDateValue().isPresent()) {
       Optional<String> value = dateQuestion.getDateValue().map(LocalDate::toString);
       dateField.setValue(value);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -43,6 +43,12 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
                             option -> String.valueOf(option.id()))));
     select.setScreenReaderText(question.getQuestionText());
 
+    select
+        .setDescribedByHtmlId(questionHelpTextHtmlId())
+        .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+        .setIsInvalid(isInvalid())
+        .setIsRequired(question.isRequired());
+
     if (singleSelectQuestion.getSelectedOptionId().isPresent()) {
       select.setValue(String.valueOf(singleSelectQuestion.getSelectedOptionId().get()));
     }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
@@ -34,6 +34,6 @@ public class EmailQuestionRenderer extends ApplicantQuestionRenderer {
             .setIsRequired(question.isRequired())
             .getContainer();
 
-    return renderInternal(params.messages(), questionFormContent, false);
+    return renderInternal(params.messages(), questionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
@@ -28,6 +28,10 @@ public class EmailQuestionRenderer extends ApplicantQuestionRenderer {
             .setValue(emailQuestion.getEmailValue().orElse(""))
             .setFieldErrors(params.messages(), emailQuestion.getQuestionErrors())
             .setScreenReaderText(question.getQuestionText())
+            .setDescribedByHtmlId(questionHelpTextHtmlId())
+            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+            .setIsInvalid(isInvalid())
+            .setIsRequired(question.isRequired())
             .getContainer();
 
     return renderInternal(params.messages(), questionFormContent, false);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -91,7 +91,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
                         ApplicantStyles.BUTTON_ENUMERATOR_ADD_ENTITY,
                         StyleUtils.disabled(Styles.BG_GRAY_200, Styles.TEXT_GRAY_400)));
 
-    return renderInternal(messages, enumeratorQuestionFormContent, false);
+    return renderInternal(messages, enumeratorQuestionFormContent);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
@@ -33,6 +33,6 @@ public class IdQuestionRenderer extends ApplicantQuestionRenderer {
             .setIsRequired(question.isRequired())
             .getContainer();
 
-    return renderInternal(params.messages(), questionFormContent, false);
+    return renderInternal(params.messages(), questionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
@@ -27,6 +27,10 @@ public class IdQuestionRenderer extends ApplicantQuestionRenderer {
             .setValue(idQuestion.getIdValue().orElse(""))
             .setFieldErrors(params.messages(), idQuestion.getQuestionErrors())
             .setScreenReaderText(question.getQuestionText())
+            .setDescribedByHtmlId(questionHelpTextHtmlId())
+            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+            .setIsInvalid(isInvalid())
+            .setIsRequired(question.isRequired())
             .getContainer();
 
     return renderInternal(params.messages(), questionFormContent, false);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
@@ -37,6 +37,9 @@ public class NameQuestionRenderer extends ApplicantQuestionRenderer {
                     .setFieldErrors(messages, nameQuestion.getFirstNameErrorMessage())
                     .showFieldErrors(!nameQuestion.getFirstNameErrors().isEmpty())
                     .addReferenceClass(ReferenceClasses.NAME_FIRST)
+                    .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+                    .setDescribedByHtmlId(questionHelpTextHtmlId())
+                    .setIsInvalid(isInvalid())
                     .getContainer())
             .with(
                 FieldWithLabel.input()
@@ -53,6 +56,9 @@ public class NameQuestionRenderer extends ApplicantQuestionRenderer {
                     .setFieldErrors(messages, nameQuestion.getLastNameErrorMessage())
                     .showFieldErrors(!nameQuestion.getLastNameErrors().isEmpty())
                     .addReferenceClass(ReferenceClasses.NAME_LAST)
+                    .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+                    .setDescribedByHtmlId(questionHelpTextHtmlId())
+                    .setIsInvalid(isInvalid())
                     .getContainer());
 
     return renderInternal(messages, nameQuestionFormContent);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
@@ -51,6 +51,6 @@ public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
 
     Tag numberQuestionFormContent = div().with(numberField.getContainer());
 
-    return renderInternal(params.messages(), numberQuestionFormContent, false);
+    return renderInternal(params.messages(), numberQuestionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
@@ -33,6 +33,10 @@ public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
             .setScreenReaderText(question.getQuestionText())
             .setMin(numberQuestion.getQuestionDefinition().getMin())
             .setMax(numberQuestion.getQuestionDefinition().getMax())
+            .setDescribedByHtmlId(questionHelpTextHtmlId())
+            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+            .setIsInvalid(isInvalid())
+            .setIsRequired(question.isRequired())
             .setFieldErrors(
                 params.messages(),
                 ImmutableSet.of(

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -1,8 +1,7 @@
 package views.questiontypes;
 
-import static j2html.TagCreator.div;
-import static j2html.TagCreator.input;
-import static j2html.TagCreator.label;
+import static j2html.TagCreator.*;
+import static views.HtmlAttributes.*;
 
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
@@ -33,7 +32,8 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
     Tag radioQuestionFormContent =
-        div()
+        fieldset()
+            .condAttr(question.isRequired(), ARIA_REQUIRED, "true")
             .with(
                 singleOptionQuestion.getOptions().stream()
                     .sorted(Comparator.comparing(LocalizedQuestionOption::order))
@@ -63,6 +63,8 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
                     .withType("radio")
                     .withName(selectionPath)
                     .withValue(String.valueOf(option.id()))
+                    .attr(ARIA_DESCRIBEDBY, questionHelpTextHtmlId())
+                    .attr(ARIA_ERRORMESSAGE, questionErrorMessageHtmlId())
                     .condAttr(checked, Attr.CHECKED, "")
                     .withClasses(
                         StyleUtils.joinStyles(ReferenceClasses.RADIO_INPUT, BaseStyles.RADIO)))

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -27,6 +27,10 @@ public class TextQuestionRenderer extends ApplicantQuestionRenderer {
             .setValue(textQuestion.getTextValue().orElse(""))
             .setFieldErrors(params.messages(), textQuestion.getQuestionErrors())
             .setScreenReaderText(question.getQuestionText())
+            .setDescribedByHtmlId(questionHelpTextHtmlId())
+            .setErrorMessageHtmlId(questionErrorMessageHtmlId())
+            .setIsInvalid(isInvalid())
+            .setIsRequired(question.isRequired())
             .getContainer();
 
     return renderInternal(params.messages(), questionFormContent, false);

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -33,6 +33,6 @@ public class TextQuestionRenderer extends ApplicantQuestionRenderer {
             .setIsRequired(question.isRequired())
             .getContainer();
 
-    return renderInternal(params.messages(), questionFormContent, false);
+    return renderInternal(params.messages(), questionFormContent);
   }
 }

--- a/universal-application-tool-0.0.1/test/views/questiontypes/RadioButtonQuestionRendererTest.java
+++ b/universal-application-tool-0.0.1/test/views/questiontypes/RadioButtonQuestionRendererTest.java
@@ -76,7 +76,8 @@ public class RadioButtonQuestionRendererTest {
     assertThat(result.render())
         .contains(
             "<input id=\"peanut_butter\" type=\"radio\""
-                + " name=\"applicant.favorite_ice_cream.selection\""
-                + " value=\"2\" checked=\"\"");
+                + " name=\"applicant.favorite_ice_cream.selection\" value=\"2\""
+                + " aria-describedby=\"applicant.favorite_ice_cream-help-text\""
+                + " aria-errormessage=\"applicant.favorite_ice_cream-error\" checked=\"\"");
   }
 }


### PR DESCRIPTION
- [ ] form inputs use `aria-describedby` to reference questions help text
- [ ] required inputs are marked `aria-required`
- [ ] form inputs with invalid contents or missing non-optional contents are marked as `aria-invalid`
- [ ] form inputs with invalid contents or missing non-optional contents reference error messages with `aria-errormessage`
