### PR TITLE
Update permissions and expand README for keyvault

### DIFF
--- a/cloud/azure/main.tf
+++ b/cloud/azure/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     random = {}
   }
-  backend "azurerm" {}
+  # backend "azurerm" {}
   required_version = ">= 0.14.9"
 }
 

--- a/cloud/azure/main.tf
+++ b/cloud/azure/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     random = {}
   }
-  # backend "azurerm" {}
+  backend "azurerm" {}
   required_version = ">= 0.14.9"
 }
 

--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -57,7 +57,7 @@ resource "azurerm_storage_account_network_rules" "files_storage_rules" {
 
 data "azurerm_key_vault" "civiform_key_vault" {
   name                = var.key_vault_name
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = var.key_vault_resource_group
 }
 
 data "azurerm_key_vault_secret" "postgres_password" {
@@ -146,7 +146,6 @@ resource "azurerm_app_service" "civiform_app" {
   identity {
     type = "SystemAssigned"
   }
-
 }
 
 resource "azurerm_app_service_virtual_network_swift_connection" "appservice_vnet_connection" {
@@ -283,6 +282,12 @@ resource "azurerm_private_endpoint" "endpoint" {
 resource "azurerm_role_assignment" "storage_blob_delegator" {
   scope                = azurerm_storage_account.files_storage_account.id
   role_definition_name = "Storage Blob Delegator"
+  principal_id         = azurerm_app_service.civiform_app.identity.0.principal_id
+}
+
+resource "azurerm_role_assignment" "key_vault_secrets_user" {
+  scope                = data.azurerm_key_vault.civiform_key_vault.id
+  role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_app_service.civiform_app.identity.0.principal_id
 }
 

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -49,11 +49,6 @@ variable "bastion_address_prefixes" {
   ]
 }
 
-variable "app_secret_key" {
-  type        = string
-  description = "Secret Key For the app"
-}
-
 variable "app_sku" {
   type        = map(string)
   description = "SKU tier/size/capacity information"
@@ -129,4 +124,8 @@ variable "custom_hostname" {
 variable "key_vault_name" {
   type        = string
   description = "Name of key vault where secrets are stored."
+}
+
+variable "key_vault_resource_group" {
+  type    = string
 }

--- a/cloud/deploys/dev_azure/main.tf
+++ b/cloud/deploys/dev_azure/main.tf
@@ -17,14 +17,15 @@ module "app" {
   source               = "../../azure/modules/app"
   resource_group_name  = var.resource_group_name
   postgres_admin_login = var.postgres_admin_login
-  key_vault_name       = var.key_vault_name
   postgres_sku_name    = "GP_Gen5_2"
 
   docker_username        = var.docker_username
   docker_repository_name = var.docker_repository_name
 
+  key_vault_name = var.key_vault_name
+  key_vault_resource_group = var.key_vault_resource_group
+
   application_name = var.application_name
-  app_secret_key   = var.app_secret_key
   ses_sender_email = var.sender_email_address
   custom_hostname  = ""
   staging_hostname = ""

--- a/cloud/deploys/dev_azure/main.tf
+++ b/cloud/deploys/dev_azure/main.tf
@@ -22,7 +22,7 @@ module "app" {
   docker_username        = var.docker_username
   docker_repository_name = var.docker_repository_name
 
-  key_vault_name = var.key_vault_name
+  key_vault_name           = var.key_vault_name
   key_vault_resource_group = var.key_vault_resource_group
 
   application_name = var.application_name

--- a/cloud/deploys/dev_azure/variables.tf
+++ b/cloud/deploys/dev_azure/variables.tf
@@ -39,10 +39,10 @@ variable "resource_group_name" {
 }
 
 variable "key_vault_name" {
-  type = string
+  type        = string
   description = "Name of key vault where secrets are stored."
 }
 
 variable "key_vault_resource_group" {
-  type    = string
+  type = string
 }

--- a/cloud/deploys/dev_azure/variables.tf
+++ b/cloud/deploys/dev_azure/variables.tf
@@ -18,11 +18,6 @@ variable "application_name" {
   description = "Azure Web App Name"
 }
 
-variable "key_vault_name" {
-  type        = string
-  description = "name of the keyvault"
-}
-
 variable "app_secret_key" {
   type        = string
   description = "Secret Key For the app"
@@ -41,4 +36,13 @@ variable "sender_email_address" {
 
 variable "resource_group_name" {
   type = string
+}
+
+variable "key_vault_name" {
+  type = string
+  description = "Name of key vault where secrets are stored."
+}
+
+variable "key_vault_resource_group" {
+  type    = string
 }

--- a/cloud/deploys/staging_azure/README.md
+++ b/cloud/deploys/staging_azure/README.md
@@ -94,11 +94,18 @@ portal the resource group name is 'tfstate' and the storage_account_name is
 Before applying the Terraform configuration, you'll need to make sure that Azure Key Vault is
 properly configured to store the `postgres-password` and `app-secret-key` secrets. To do this, run the command `az keyvault list` to list all the key vaults in your project. Find the key vault that stores the secrets for Civiform. Then run `az keyvault secret list --vault-name=[your vault name]`. The `postgres-password` and `app-secret-key` secrets should be listed.
 
-If the secrets are not listed, you'll need to [create a key vault](https://docs.microsoft.com/en-us/azure/key-vault/general/quick-create-cli) if you haven't already. Then set the secrets:
+If the secrets are not listed, you'll need to [create a key vault](https://docs.microsoft.com/en-us/azure/key-vault/general/quick-create-cli) if you haven't already. Make a note of the resource group that is used. Next, run 
+```
+az keyvault update --name=[your keyvault name] --enable-rbac-authorization
+```
+This allows you to grant the App Service Managed Identity permission to access the key vault.
+
+Next, [grant yourself the Key Vault Secrets Officer role in the Azure portal](https://docs.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#key-vault-scope-role-assignment)
+Then set the secrets:
 
 ```
 az keyvault secret set --name postgres-password --vault-name [key vault name] --value [password]
 az keyvault secret set --name app-secret-key --vault-name [key vault name] --value [secret key]
 ```
 
-Then, in order to use the Key Vault as a data source in Terraform, set the `key_vault_name` variable in your `auto.tfvars` file to the name of the key vault.
+Then, in order to use the Key Vault as a data source in Terraform, set the `key_vault_name` variable in your `auto.tfvars` file to the name of the key vault and the `key_vault_resource_group` to the resource group the key vault is in.

--- a/cloud/deploys/staging_azure/main.tf
+++ b/cloud/deploys/staging_azure/main.tf
@@ -15,19 +15,20 @@ terraform {
 }
 
 module "app" {
-  source = "../../azure/modules/app"
-  postgres_admin_login    = var.postgres_admin_login
-  
+  source               = "../../azure/modules/app"
+  postgres_admin_login = var.postgres_admin_login
+
   # note that we must use GP tier
-  postgres_sku_name       = "GP_Gen5_2"
+  postgres_sku_name = "GP_Gen5_2"
 
   docker_username        = var.docker_username
   docker_repository_name = var.docker_repository_name
 
   key_vault_name = var.key_vault_name
+  key_vault_resource_group = var.key_vault_resource_group
 
   application_name = var.application_name
-  
+
   ses_sender_email = var.sender_email_address
   custom_hostname  = var.custom_hostname
 }

--- a/cloud/deploys/staging_azure/variables.tf
+++ b/cloud/deploys/staging_azure/variables.tf
@@ -19,8 +19,13 @@ variable "application_name" {
 }
 
 variable "key_vault_name" {
-  type = string
-  description = "Name of key vault where app secrets are stored."
+  type        = string
+  description = "Name of key vault where secrets are stored."
+}
+
+variable "key_vault_resource_group" {
+  type        = string
+  description = "Resource group that key vault is in."
 }
 
 variable "aws_region" {


### PR DESCRIPTION
Fixes permissions and expands README for setting up keyvault integration. The biggest change was creating the key vault in a separate resource group, since in a real deployment, it will be set up before the terraform-managed resources.
