### PR TITLE
Allow empty beans in db seed view object mapper

### DIFF
--- a/universal-application-tool-0.0.1/app/views/dev/DatabaseSeedView.java
+++ b/universal-application-tool-0.0.1/app/views/dev/DatabaseSeedView.java
@@ -9,6 +9,7 @@ import static j2html.TagCreator.pre;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
 import controllers.dev.routes;
 import j2html.tags.ContainerTag;
@@ -36,6 +37,7 @@ public class DatabaseSeedView extends BaseHtmlView {
   public DatabaseSeedView(BaseHtmlLayout layout, ObjectMapper objectMapper) {
     this.layout = checkNotNull(layout);
     this.objectMapper = checkNotNull(objectMapper);
+    this.objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
   }
 
   public Content render(


### PR DESCRIPTION
The new version of play-ebean configures the object serializer to by default throw an exception if a bean is missing. Most of these were caught in https://github.com/seattle-uat/civiform/pull/1860 but this one got missed.

fixes https://github.com/seattle-uat/civiform/issues/1953