### PR TITLE
Scaffolding for deployment command delegation

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -3,7 +3,9 @@
 # This file loads shared code for most shell scripts. All scripts
 # in the base bin/ directory should begin by sourcing it.
 
-pushd $(git rev-parse --show-toplevel) > /dev/null
+if [[ "${KEEP_ORIGINAL_PWD}" != "true" ]]; then
+  pushd $(git rev-parse --show-toplevel) > /dev/null
+fi
 
 set -e
 set +x

--- a/cloud/azure/bin/deploy
+++ b/cloud/azure/bin/deploy
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+KEEP_ORIGINAL_PWD=true source "${PROJECT_BASE_DIR}/bin/lib.sh"
+source "${PROJECT_BASE_DIR}/cloud/shared/bin/lib.sh"
+source "${PROJECT_BASE_DIR}/cloud/azure/bin/lib.sh"

--- a/cloud/azure/bin/deploy
+++ b/cloud/azure/bin/deploy
@@ -3,3 +3,5 @@
 KEEP_ORIGINAL_PWD=true source "${PROJECT_BASE_DIR}/bin/lib.sh"
 source "${PROJECT_BASE_DIR}/cloud/shared/bin/lib.sh"
 source "${PROJECT_BASE_DIR}/cloud/azure/bin/lib.sh"
+
+# TODO: implement actual Azure deployment logic

--- a/cloud/azure/bin/lib.sh
+++ b/cloud/azure/bin/lib.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/cloud/shared/bin/deploy
+++ b/cloud/shared/bin/deploy
@@ -1,4 +1,8 @@
 #! /usr/bin/env bash
 
+set -e
+
 export PROJECT_BASE_DIR="$(realpath "$(dirname "${BASH_SOURCE}")/../../../")"
-exec "${PROJECT_BASE_DIR}/cloud/azure/bin/deploy" "$@"
+"${PROJECT_BASE_DIR}/cloud/shared/bin/validate_cloud_provider"
+
+exec "${PROJECT_BASE_DIR}/cloud/${CLOUD_PROVIDER}/bin/deploy" "$@"

--- a/cloud/shared/bin/deploy
+++ b/cloud/shared/bin/deploy
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+export PROJECT_BASE_DIR="$(realpath "$(dirname "${BASH_SOURCE}")/../../../")"
+exec "${PROJECT_BASE_DIR}/cloud/azure/bin/deploy" "$@"

--- a/cloud/shared/bin/lib.sh
+++ b/cloud/shared/bin/lib.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/cloud/shared/bin/validate_cloud_provider
+++ b/cloud/shared/bin/validate_cloud_provider
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+readonly VALID_CLOUD_PROVIDERS=(azure)
+
+if [[ "${CLOUD_PROVIDER}" = "" ]]; then
+  >&2 echo "Must specify CLOUD_PROVIDER configuration variable."
+  exit 1
+fi
+
+if [[ ! " ${VALID_CLOUD_PROVIDERS[*]} " =~ " ${CLOUD_PROVIDER} " ]]; then
+  >&2 echo "'${CLOUD_PROVIDER}' is not a valid cloud provider."
+  exit 1
+fi


### PR DESCRIPTION
Puts the pieces in place to delegate deployment commands from the deployment repo to executables in the main repo and ensures the delegated command has access to shell script library code. See also https://github.com/civiform/civiform-deploy/pull/2

The order of operations for a command run from the deployment repo is:

1. load the deployment repo's shell library code
1. load the deployment repo's civiform configuratoin
1. resolve the git revision for the main repo the command should run in
1. exec the `cloud/shared` version of the command in the main repo
1. resolve the cloud provider (report an error if the cloud provider is invalid or missing)
1. exec the provider-specific version of the command in the main repo
1. load the shell library code in bin/lib.sh
1. load the cloud provider-specific shell library code 
1. perform the command