### PR TITLE
Add startup poll of the server to initiate lazy load of compiled resources.

### DIFF
--- a/bin/run-dev
+++ b/bin/run-dev
@@ -54,6 +54,13 @@ docker-compose --profile "${cloud_provider}" \
 # Wait until the emulator is running.
 "bin/${emulator}/wait"
 
+# Once the server starts through the subsequent 'up' the webserver will lazily compile a lot of resources upon first
+# load. This will instigates that happening so the server is fully usable for the user.
+for i in {1..24}; do
+  curl --output /dev/null --silent --fail http://localhost:9000/script-startup-load && break
+  sleep 5
+done &
+
 # start everything else
 docker-compose \
   -f docker-compose.yml \


### PR DESCRIPTION
Add a startup poll of the server to initiate lazy load of compiled resources.

This is purely to aid developer velocity.