### PR TITLE
Remove firewall for Azure Storage

### DIFF
--- a/cloud/azure/modules/app/locals.tf
+++ b/cloud/azure/modules/app/locals.tf
@@ -6,5 +6,5 @@ locals {
   generated_hostname    = "${var.application_name}-${random_pet.server.id}.azurewebsites.net"
 
   postgres_password_keyvault_id = "postgres-password"
-  app_secret_key_keyvault_id = "app-secret-key"
+  app_secret_key_keyvault_id    = "app-secret-key"
 }

--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -34,6 +34,8 @@ resource "azurerm_storage_account" "files_storage_account" {
 
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  allow_blob_public_access = false
 }
 data "azurerm_key_vault" "civiform_key_vault" {
   name                = var.key_vault_name

--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -35,26 +35,6 @@ resource "azurerm_storage_account" "files_storage_account" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
-
-data "http" "myip" {
-  url = "https://ipv4.icanhazip.com"
-}
-
-# adding the bypass/ip_rules is a workaround for azure's firewall settings
-# if we don't add this we can't add storage containers to this storage_account
-# there might be a type of account we can create to run the tf command through
-# instead of doing this ip_rules bypass
-resource "azurerm_storage_account_network_rules" "files_storage_rules" {
-  storage_account_id         = azurerm_storage_account.files_storage_account.id
-  default_action             = "Deny"
-  virtual_network_subnet_ids = [azurerm_subnet.storage_subnet.id]
-  bypass                     = ["AzureServices"]
-  ip_rules                   = [chomp(data.http.myip.body)]
-  private_link_access {
-    endpoint_resource_id = azurerm_app_service.civiform_app.id
-  }
-}
-
 data "azurerm_key_vault" "civiform_key_vault" {
   name                = var.key_vault_name
   resource_group_name = var.key_vault_resource_group

--- a/cloud/azure/modules/app/variables.tf
+++ b/cloud/azure/modules/app/variables.tf
@@ -127,5 +127,5 @@ variable "key_vault_name" {
 }
 
 variable "key_vault_resource_group" {
-  type    = string
+  type = string
 }


### PR DESCRIPTION
We recently discovered that this firewall prevents SAS URLs from working from any IP address that isn't explicitly allowlisted (like an end user's IP address) which is not what we want. We should secure our storage account using user permissions instead.
