### PR TITLE
Add option to build local docker image for ARM architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
+ARG PLATFORM="amd64"
+
+# The AdoptOpenJDK image fails to run on M1 Macs because it is incompatible with ARM architecture. This
+# workaround uses an aarch64 (arm64) image instead when an optional platform argument is set to arm64.
+# Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
+
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim as amd64
+FROM bellsoft/liberica-openjdk-alpine:11.0.10-9-aarch64 as arm64
+
+FROM ${PLATFORM}
 
 ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local


### PR DESCRIPTION
I recently discovered that our dev server doesn't run properly on M1 macs due to an incompatibility between the AdoptOpenJDK image we're using and the M1 Mac's ARM64 architecture. This workaround allows us to use an alternative base image by passing in a platform argument when building the image. M1 Mac users will need to use the `USE_LOCAL_CIVIFORM=1` environment variable, and build the local docker image using `docker build --build-arg PLATFORM=arm64 -t  civiform-dev .`. This info will be added to the wiki once the PR is merged. 
