### PR TITLE
Pin NPM version and use latest package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${
 
 RUN set -o pipefail && \
     apk update && \
+    apk add --upgrade apk-tools && \
+    apk upgrade --available && \
     apk add --no-cache --update bash wget npm git openssh && \
+    npm install -g npm@8.5.1 && \
     mkdir -p "${SBT_HOME}" && \
     wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt ${SBT_VERSION}\n" >> /root/.built

--- a/bin/dev-bash
+++ b/bin/dev-bash
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+# DOC: Open a bash shell in the dev environment container.
+
+source bin/lib.sh
+
+bin/pull-image
+
+docker run -it --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 \
+  -v ~/.coursier:/root/.coursier \
+  -v ~/.sbt:/root/.sbt \
+  -v ~/.ivy:/root/.ivy2 \
+  --entrypoint /bin/bash \
+  civiform-dev

--- a/bin/dev-bash
+++ b/bin/dev-bash
@@ -6,7 +6,9 @@ source bin/lib.sh
 
 bin/pull-image
 
-docker run -it --rm \
+docker run \
+  -it \
+  --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(pwd)/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 \
   -v ~/.coursier:/root/.coursier \

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -8,6 +8,8 @@ ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT
 
 RUN set -o pipefail && \
     apk update && \
+    apk add --upgrade apk-tools && \
+    apk upgrade --available && \
     apk add --no-cache --update bash wget npm git openssh && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
@@ -18,6 +20,7 @@ ENV PROJECT_NAME universal-application-tool-0.0.1
 
 COPY "${PROJECT_NAME}" "${PROJECT_HOME}/${PROJECT_NAME}"
 RUN cd "${PROJECT_HOME}/${PROJECT_NAME}" && \
+    npm install -g npm@8.5.1 && \
     npm install && \
     sbt update && \
     sbt dist

--- a/universal-application-tool-0.0.1/package-lock.json
+++ b/universal-application-tool-0.0.1/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "universal-application-tool-0.0.1",
       "version": "0.0.1",
       "license": "CC0-1.0",
       "devDependencies": {


### PR DESCRIPTION
- [x] pins NPM version to 8.5.1 which will stop the annoying package-lock.json diffs from constantly getting generated
- [x] upgrades the docker image packages at build time. this improves the security of the image
- [x] adds `bin/dev-bash` script for convenience of getting a bash shell running in a dev container