### PR TITLE
Add accounts.authority_id to serve as a new unique account identifier.

### DIFF
--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -22,7 +22,7 @@ import services.program.ProgramDefinition;
  * {@code Account} record for them.
  *
  * <p>emailAddress serves as the unchanging unique identifier for accounts though it is not
- * gauranteed to not change in authentication protocols like OIDC. When #1793 is resolved though
+ * guaranteed to not change in authentication protocols like OIDC. When #1793 is resolved though
  * authorityId will serve that purpose.
  *
  * <p>Note that residents have a single {@code Account} and a single {@code Applicant} record,

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -21,6 +21,9 @@ import services.program.ProgramDefinition;
  * <p>When a user logs in for the first time either using SSO or as a guest, CiviForm creates an
  * {@code Account} record for them.
  *
+ * emailAddress serves as the unchanging unique identifier for accounts. When #1793 is resolved
+ * though authorityId will serve that purpose.
+ *
  * <p>Note that residents have a single {@code Account} and a single {@code Applicant} record,
  * despite the one to many relationship. This is technical debt that stems from earlier reasoning
  * about the approach wherein we expected we'd need to create multiple versions of the resident's
@@ -45,6 +48,7 @@ public class Account extends BaseModel {
   // This must be a mutable collection so we can add to the list later.
   @DbArray private List<String> adminOf = new ArrayList<>();
 
+  private String authorityId;
   private String emailAddress;
 
   public ImmutableList<Long> ownedApplicantIds() {
@@ -61,6 +65,14 @@ public class Account extends BaseModel {
 
   public void setApplicants(List<Applicant> applicants) {
     this.applicants = applicants;
+  }
+
+  public void setAuthorityId(String authorityId) {
+    this.authorityId = authorityId;
+  }
+
+  public String getAuthorityId() {
+    return this.authorityId;
   }
 
   public void setEmailAddress(String emailAddress) {

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -21,8 +21,9 @@ import services.program.ProgramDefinition;
  * <p>When a user logs in for the first time either using SSO or as a guest, CiviForm creates an
  * {@code Account} record for them.
  *
- * emailAddress serves as the unchanging unique identifier for accounts. When #1793 is resolved
- * though authorityId will serve that purpose.
+ * emailAddress serves as the unchanging unique identifier for accounts though it is not gauranteed
+ * to change in authentication providers. When #1793 is resolved though authorityId will serve that
+ * purpose.
  *
  * <p>Note that residents have a single {@code Account} and a single {@code Applicant} record,
  * despite the one to many relationship. This is technical debt that stems from earlier reasoning

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -21,9 +21,9 @@ import services.program.ProgramDefinition;
  * <p>When a user logs in for the first time either using SSO or as a guest, CiviForm creates an
  * {@code Account} record for them.
  *
- * emailAddress serves as the unchanging unique identifier for accounts though it is not gauranteed
- * to change in authentication providers. When #1793 is resolved though authorityId will serve that
- * purpose.
+ * <p>emailAddress serves as the unchanging unique identifier for accounts though it is not
+ * gauranteed to change in authentication providers. When #1793 is resolved though authorityId will
+ * serve that purpose.
  *
  * <p>Note that residents have a single {@code Account} and a single {@code Applicant} record,
  * despite the one to many relationship. This is technical debt that stems from earlier reasoning

--- a/universal-application-tool-0.0.1/app/models/Account.java
+++ b/universal-application-tool-0.0.1/app/models/Account.java
@@ -22,8 +22,8 @@ import services.program.ProgramDefinition;
  * {@code Account} record for them.
  *
  * <p>emailAddress serves as the unchanging unique identifier for accounts though it is not
- * gauranteed to change in authentication providers. When #1793 is resolved though authorityId will
- * serve that purpose.
+ * gauranteed to not change in authentication protocols like OIDC. When #1793 is resolved though
+ * authorityId will serve that purpose.
  *
  * <p>Note that residents have a single {@code Account} and a single {@code Applicant} record,
  * despite the one to many relationship. This is technical debt that stems from earlier reasoning

--- a/universal-application-tool-0.0.1/conf/evolutions/default/36.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/36.sql
@@ -1,6 +1,6 @@
 # --- Add a new unique identifier for accounts based on the authentication systems unique ID semantics.
 # --- Until we fully migrate from email_address to the new authority_id as the unique account ID both will identify
-# --- accounts, first with authority_id if present, then eamil_address..
+# --- accounts, first with authority_id if present, then email_address.
 
 # --- !Ups
 alter table accounts add authority_id varchar;

--- a/universal-application-tool-0.0.1/conf/evolutions/default/36.sql
+++ b/universal-application-tool-0.0.1/conf/evolutions/default/36.sql
@@ -1,0 +1,7 @@
+# --- Add a new unique identifier for accounts based on the authentication systems unique ID semantics.
+# --- Until we fully migrate from email_address to the new authority_id as the unique account ID both will identify
+# --- accounts, first with authority_id if present, then eamil_address..
+
+# --- !Ups
+alter table accounts add authority_id varchar;
+alter table accounts add unique (authority_id);


### PR DESCRIPTION
### Description
Adds a new authority_id field to Accounts to serve as a unique ID. Email is not unique in OIDC but that has been assumed and relied on.

Part of addressing #1793 