### PR TITLE
adding the http logs config

### DIFF
--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -143,6 +143,15 @@ resource "azurerm_app_service" "civiform_app" {
   identity {
     type = "SystemAssigned"
   }
+
+  logs {
+    http_logs {
+      file_system {
+        retention_in_days = 1
+        retention_in_mb   = 35
+      }
+    }
+  }
 }
 
 resource "azurerm_app_service_virtual_network_swift_connection" "appservice_vnet_connection" {


### PR DESCRIPTION
### Description
Currently our terraform configs don't send http logs from the app so this configures the http logs to be correctly generated (otherwise we only generate logs on start up failures)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
