### PR TITLE
Fix java logger naming and keywords.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/oidc/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/oidc/IdcsProfileAdapter.java
@@ -31,7 +31,7 @@ import repository.UserRepository;
  * profile.
  */
 public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
-  public static final Logger LOG = LoggerFactory.getLogger(IdcsProfileAdapter.class);
+  public static final Logger logger = LoggerFactory.getLogger(IdcsProfileAdapter.class);
 
   public IdcsProfileAdapter(
       OidcConfiguration configuration,
@@ -109,12 +109,12 @@ public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
     // own modified resource retriever which has access to the required token.
 
     if (((OidcCredentials) cred).getAccessToken() == null) {
-      LOG.debug("No access token in the credentials.");
+      logger.debug("No access token in the credentials.");
       return;
     }
 
     if (this.configuration.getResourceRetriever() instanceof CachedResourceRetriever) {
-      LOG.debug("Already have jwk cached.");
+      logger.debug("Already have jwk cached.");
       return;
     }
 
@@ -127,7 +127,7 @@ public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
                   .retrieveResource(jwkSetUri.toURL()));
       this.configuration.setResourceRetriever(new CachedResourceRetriever(configuration, jwkCache));
     } catch (IOException | NullPointerException e) {
-      LOG.error("Failed to fetch JWK", e);
+      logger.error("Failed to fetch JWK", e);
     }
   }
 
@@ -146,7 +146,7 @@ public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
         headers = new HashMap<>();
       }
       String authHeader = ((OidcCredentials) cred).getAccessToken().toAuthorizationHeader();
-      LOG.debug("Auth header in the resource retriever: {}", authHeader);
+      logger.debug("Auth header in the resource retriever: {}", authHeader);
       headers.put("Authorization", List.of(authHeader));
       return headers;
     }
@@ -163,14 +163,14 @@ public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
 
     @Override
     public Resource retrieveResource(URL url) throws IOException {
-      LOG.debug("Attempting to fetch {}", url.toString());
+      logger.debug("Attempting to fetch {}", url.toString());
       try {
         if (resources.containsKey(url.toURI())) {
-          LOG.debug("Cached: {}", url.toString());
+          logger.debug("Cached: {}", url.toString());
           return resources.get(url.toURI());
         }
       } catch (URISyntaxException e) {
-        LOG.debug("failed to convert to URI", e);
+        logger.debug("failed to convert to URI", e);
       }
       return super.retrieveResource(url);
     }

--- a/universal-application-tool-0.0.1/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -35,7 +35,7 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
 
-  private static Logger LOG = LoggerFactory.getLogger(OidcCiviFormProfileAdapter.class);
+  private static final Logger logger = LoggerFactory.getLogger(OidcCiviFormProfileAdapter.class);
 
   public OidcCiviFormProfileAdapter(
       OidcConfiguration configuration,
@@ -79,12 +79,12 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     Optional<UserProfile> oidcProfile = super.create(cred, context, sessionStore);
 
     if (oidcProfile.isEmpty()) {
-      LOG.warn("Didn't get a valid profile back from OIDC.");
+      logger.warn("Didn't get a valid profile back from OIDC.");
       return Optional.empty();
     }
 
     if (!(oidcProfile.get() instanceof OidcProfile)) {
-      LOG.warn(
+      logger.warn(
           "Got a profile from OIDC callback but it wasn't an OIDC profile: %s",
           oidcProfile.get().getClass().getName());
       return Optional.empty();
@@ -128,7 +128,7 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
 
     // Now merge in the information sent to us by the OIDC server.
     if (existingProfile.isEmpty()) {
-      LOG.debug("Found no existing profile in session cookie.");
+      logger.debug("Found no existing profile in session cookie.");
       return Optional.of(civiformProfileFromOidcProfile(profile));
     } else {
       return Optional.of(mergeCiviFormProfile(existingProfile.get(), profile));

--- a/universal-application-tool-0.0.1/app/controllers/SupportController.java
+++ b/universal-application-tool-0.0.1/app/controllers/SupportController.java
@@ -11,7 +11,7 @@ import play.mvc.Result;
 import views.support.UnconfirmedIdcsEmailBugView;
 
 public class SupportController extends Controller {
-  private static Logger LOG = LoggerFactory.getLogger(SupportController.class);
+  private static final Logger logger = LoggerFactory.getLogger(SupportController.class);
 
   private final UnconfirmedIdcsEmailBugView unconfirmedIdcsEmailBugView;
 
@@ -21,7 +21,7 @@ public class SupportController extends Controller {
   }
 
   public Result handleUnconfirmedIdcsEmail(Http.Request request) {
-    LOG.info("UnconfirmedIdcsEmail-Support-Page: " + request.remoteAddress());
+    logger.info("UnconfirmedIdcsEmail-Support-Page: " + request.remoteAddress());
 
     return ok(unconfirmedIdcsEmailBugView.render());
   }

--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -29,7 +29,7 @@ public class ApplicationRepository {
   private final UserRepository userRepository;
   private final Database database;
   private final DatabaseExecutionContext executionContext;
-  private static final Logger LOG = LoggerFactory.getLogger(ApplicationRepository.class);
+  private static final Logger logger = LoggerFactory.getLogger(ApplicationRepository.class);
 
   @Inject
   public ApplicationRepository(
@@ -124,7 +124,7 @@ public class ApplicationRepository {
         .thenApplyAsync(application -> Optional.of(application))
         .exceptionally(
             exception -> {
-              LOG.error(exception.toString());
+              logger.error(exception.toString());
               exception.printStackTrace();
               return Optional.empty();
             });

--- a/universal-application-tool-0.0.1/app/repository/VersionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/VersionRepository.java
@@ -36,8 +36,8 @@ import services.program.predicate.PredicateExpressionNode;
 /** A repository object for dealing with versioning of questions and programs. */
 public class VersionRepository {
 
+  private static final Logger logger = LoggerFactory.getLogger(VersionRepository.class);
   private final Database database;
-  private final Logger LOG = LoggerFactory.getLogger(VersionRepository.class);
   private final ProgramRepository programRepository;
 
   @Inject
@@ -202,11 +202,11 @@ public class VersionRepository {
     ProgramDefinition.Builder updatedDefinition =
         draftProgram.getProgramDefinition().toBuilder().setBlockDefinitions(ImmutableList.of());
     for (BlockDefinition block : draftProgram.getProgramDefinition().blockDefinitions()) {
-      LOG.trace("Updating screen (block) {}.", block.id());
+      logger.trace("Updating screen (block) {}.", block.id());
       updatedDefinition.addBlockDefinition(updateQuestionVersions(draftProgram.id, block));
     }
     draftProgram = new Program(updatedDefinition.build());
-    LOG.trace("Submitting update.");
+    logger.trace("Submitting update.");
     database.update(draftProgram);
     draftProgram.refresh();
   }
@@ -237,7 +237,7 @@ public class VersionRepository {
     // Update questions contained in this block.
     for (ProgramQuestionDefinition question : block.programQuestionDefinitions()) {
       Optional<Question> updatedQuestion = getLatestVersionOfQuestion(question.id());
-      LOG.trace(
+      logger.trace(
           "Updating question ID {} to new ID {}.", question.id(), updatedQuestion.orElseThrow().id);
       updatedBlock.addQuestion(
           question.loadCompletely(

--- a/universal-application-tool-0.0.1/app/services/cloud/aws/SimpleEmail.java
+++ b/universal-application-tool-0.0.1/app/services/cloud/aws/SimpleEmail.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.services.ses.model.SesException;
 @Singleton
 public class SimpleEmail {
   public static final String AWS_SES_SENDER_CONF_PATH = "aws.ses.sender";
-  private static final Logger LOG = LoggerFactory.getLogger(SimpleEmail.class);
+  private static final Logger logger = LoggerFactory.getLogger(SimpleEmail.class);
 
   private final String sender;
   private final Client client;
@@ -75,7 +75,7 @@ public class SimpleEmail {
           SendEmailRequest.builder().destination(destination).message(msg).source(sender).build();
       client.get().sendEmail(emailRequest);
     } catch (SesException e) {
-      LOG.error(e.toString());
+      logger.error(e.toString());
       e.printStackTrace();
     }
   }

--- a/universal-application-tool-0.0.1/app/views/components/TextFormatter.java
+++ b/universal-application-tool-0.0.1/app/views/components/TextFormatter.java
@@ -38,7 +38,7 @@ import views.style.Styles;
  * </ul>
  */
 public class TextFormatter {
-  private static final Logger LOG = LoggerFactory.getLogger(TextFormatter.class);
+  private static final Logger logger = LoggerFactory.getLogger(TextFormatter.class);
 
   private static final String ACCORDION_CONTENT = ">";
   private static final String ACCORDION_HEADER = "### ";
@@ -55,7 +55,7 @@ public class TextFormatter {
         // is more likely to be part of the surrounding text, so we strip.
         url = Url.create(StringUtils.stripEnd(url.getOriginalUrl(), ".?!,:;"));
       } catch (MalformedURLException e) {
-        LOG.error(
+        logger.error(
             String.format(
                 "Failed to parse URL %s after stripping trailing punctuation",
                 url.getOriginalUrl()));
@@ -64,7 +64,7 @@ public class TextFormatter {
       int index = content.indexOf(url.getOriginalUrl());
       // Find where this URL is in the text.
       if (index == -1) {
-        LOG.error(
+        logger.error(
             String.format(
                 "Detected URL %s not present in actual content, %s.",
                 url.getOriginalUrl(), content));


### PR DESCRIPTION
Make all java loggers be private static final and use lowercase naming as they are not immutable objects per the style guide.

Fixes #2012 

