### PR TITLE
Fix display of long names and single names

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -93,8 +93,11 @@ public class ApplicantData {
   public String getApplicantName() {
     try {
       String firstName = readString(WellKnownPaths.APPLICANT_FIRST_NAME).get();
-      String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
-      return String.format("%s, %s", lastName, firstName);
+      if(hasPath(WellKnownPaths.APPLICANT_LAST_NAME)) {
+        String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
+        return String.format("%s, %s", lastName, firstName);
+      }
+      return firstName;
     } catch (NoSuchElementException e) {
       logger.error("Application {} does not include an applicant name.");
       return "<Anonymous Applicant>";

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -93,7 +93,7 @@ public class ApplicantData {
   public String getApplicantName() {
     try {
       String firstName = readString(WellKnownPaths.APPLICANT_FIRST_NAME).get();
-      if(hasPath(WellKnownPaths.APPLICANT_LAST_NAME)) {
+      if (hasPath(WellKnownPaths.APPLICANT_LAST_NAME)) {
         String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
         return String.format("%s, %s", lastName, firstName);
       }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -93,11 +93,8 @@ public class ApplicantData {
   public String getApplicantName() {
     try {
       String firstName = readString(WellKnownPaths.APPLICANT_FIRST_NAME).get();
-      if(hasPath(WellKnownPaths.APPLICANT_LAST_NAME)) {
-        String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
-        return String.format("%s, %s", lastName, firstName);
-      }
-      return firstName;
+      String lastName = readString(WellKnownPaths.APPLICANT_LAST_NAME).get();
+      return String.format("%s, %s", lastName, firstName);
     } catch (NoSuchElementException e) {
       logger.error("Application {} does not include an applicant name.");
       return "<Anonymous Applicant>";

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -717,7 +717,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     String name = subject.getName(applicant.id).toCompletableFuture().join();
     assertThat(name).isEqualTo("World, Hello");
   }
-  
+
   @Test
   public void getName_applicantWithThreeNames() {
     Applicant applicant = resourceCreator.insertApplicant();
@@ -735,7 +735,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     String name = subject.getName(applicant.id).toCompletableFuture().join();
     assertThat(name).isEqualTo("First Second Third Fourth");
   }
-  
+
   @Test
   public void getName_applicantWithOneName() {
     Applicant applicant = resourceCreator.insertApplicant();
@@ -744,7 +744,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     String name = subject.getName(applicant.id).toCompletableFuture().join();
     assertThat(name).isEqualTo("Mononymous");
   }
-  
+
   @Test
   public void getEmail_invalidApplicantId_doesNotFail() {
     subject.getEmail(9999L).toCompletableFuture().join();

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -717,7 +717,34 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
     String name = subject.getName(applicant.id).toCompletableFuture().join();
     assertThat(name).isEqualTo("World, Hello");
   }
+  
+  @Test
+  public void getName_applicantWithThreeNames() {
+    Applicant applicant = resourceCreator.insertApplicant();
+    applicant.getApplicantData().setUserName("First Middle Last");
+    applicant.save();
+    String name = subject.getName(applicant.id).toCompletableFuture().join();
+    assertThat(name).isEqualTo("Last, First");
+  }
 
+  @Test
+  public void getName_applicantWithManyNames() {
+    Applicant applicant = resourceCreator.insertApplicant();
+    applicant.getApplicantData().setUserName("First Second Third Fourth");
+    applicant.save();
+    String name = subject.getName(applicant.id).toCompletableFuture().join();
+    assertThat(name).isEqualTo("First Second Third Fourth");
+  }
+  
+  @Test
+  public void getName_applicantWithOneName() {
+    Applicant applicant = resourceCreator.insertApplicant();
+    applicant.getApplicantData().setUserName("Mononymous");
+    applicant.save();
+    String name = subject.getName(applicant.id).toCompletableFuture().join();
+    assertThat(name).isEqualTo("Mononymous");
+  }
+  
   @Test
   public void getEmail_invalidApplicantId_doesNotFail() {
     subject.getEmail(9999L).toCompletableFuture().join();


### PR DESCRIPTION
### Description
In the case of the applicant having at least four names or just one name, simply the first name (display name) is returned as-is instead of "Anonymous Applicant." 
Added additional unit tests to correspond to the four cases of the setUserName() method: getApplicantName() returns "Name" if the display name has 1 name (0 spaces), "Last, First" for 1 space (2 names), "Last, First" for 2 spaces (3 names), and "First Second Third Fourth [...]" for 3+  spaces (4+ names).

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2000 
