### PR TITLE
Correctly set next ID for MultiOptionQuestionForm

### DIFF
--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -143,27 +143,31 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
       predicateBuilder.setMaxChoicesAllowed(getMaxChoicesAllowed());
     }
 
-    ImmutableList.Builder<QuestionOption> questionOptions = ImmutableList.builder();
+    ImmutableList.Builder<QuestionOption> questionOptionsBuilder = ImmutableList.builder();
     Preconditions.checkState(
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
 
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
-      questionOptions.add(
+      questionOptionsBuilder.add(
           QuestionOption.create(
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
     }
+    setNextAvailableId(options.size());
     for (int i = 0; i < newOptions.size(); i++) {
-      questionOptions.add(
+      questionOptionsBuilder.add(
           QuestionOption.create(
               nextAvailableId.orElse(0L) + i,
               options.size() + i,
               LocalizedStrings.withDefaultValue(newOptions.get(i))));
     }
+    ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
+
+    setNextAvailableId(questionOptions.size());
 
     return super.getBuilder()
-        .setQuestionOptions(questionOptions.build())
+        .setQuestionOptions(questionOptions)
         .setValidationPredicates(predicateBuilder.build());
   }
 

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -22,7 +22,10 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   private List<String> options;
   // Options added to the list during the edit.
   private List<String> newOptions;
+  // The IDs of each option are not expected to be in any particular order.
   private List<Long> optionIds;
+  // This value is the max existing ID + 1. The max ID will not necessarily be the last one in the
+  // optionIds list,we do not store options by order of their IDs.
   private OptionalLong nextAvailableId;
   private OptionalInt minChoicesRequired;
   private OptionalInt maxChoicesAllowed;
@@ -148,7 +151,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
 
-    if (this.optionIds.size() > 0) {
+    if (!optionIds.isEmpty()) {
       setNextAvailableId(this.optionIds.get(0) + 1);
     }
 
@@ -157,6 +160,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
       questionOptionsBuilder.add(
           QuestionOption.create(
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
+      // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
+      // the largest ID in the list and accurately set the next largest.
       if (optionIds.get(i) > nextAvailableId.orElse(0L)) {
         setNextAvailableId(optionIds.get(i) + 1);
       }

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -162,7 +162,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
       // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
       // the largest ID in the list and accurately set the next largest.
-      if (optionIds.get(i) > nextAvailableId.orElse(0L)) {
+      if (optionIds.get(i) == nextAvailableId.orElse(0L)) {
         setNextAvailableId(optionIds.get(i) + 1);
       }
     }

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -14,7 +14,9 @@ import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 
-/** Superclass for all forms for updating a multi-option question. */
+/**
+ * Superclass for all forms for updating a multi-option question.
+ */
 public abstract class MultiOptionQuestionForm extends QuestionForm {
 
   // Caution: This must be a mutable list type, or else Play's form binding cannot add elements to
@@ -64,9 +66,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.nextAvailableId =
             OptionalLong.of(
                 qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
-                        .mapToLong(LocalizedQuestionOption::id)
-                        .max()
-                        .getAsLong()
+                    .mapToLong(LocalizedQuestionOption::id)
+                    .max()
+                    .getAsLong()
                     + 1);
       }
     } catch (TranslationNotFoundException e) {
@@ -165,12 +167,13 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     setNextAvailableId(maxId + 1);
 
     for (int i = 0; i < newOptions.size(); i++) {
-      questionOptionsBuilder.add(
-          QuestionOption.create(
-              nextAvailableId.getAsLong() + i,
-              options.size() + i,
-              LocalizedStrings.withDefaultValue(newOptions.get(i))));
-      optionIds.add(nextAvailableId.getAsLong() + i);
+      QuestionOption newQuestionOption = QuestionOption.create(
+          nextAvailableId.getAsLong() + i,
+          options.size() + i,
+          LocalizedStrings.withDefaultValue(newOptions.get(i)));
+
+      questionOptionsBuilder.add(newQuestionOption);
+      optionIds.add(newQuestionOption.id());
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
 

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -165,7 +165,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
     // the largest ID in the list and accurately set the next largest.
     Long maxId = optionIds.stream().max(Long::compareTo).orElse(0L);
-    setNextAvailableId(maxId);
+    setNextAvailableId(maxId + 1);
 
     for (int i = 0; i < newOptions.size(); i++) {
       questionOptionsBuilder.add(

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -151,10 +151,6 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
 
-    if (!optionIds.isEmpty()) {
-      setNextAvailableId(this.optionIds.get(0) + 1);
-    }
-
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       questionOptionsBuilder.add(
@@ -162,7 +158,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
       // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
       // the largest ID in the list and accurately set the next largest.
-      if (optionIds.get(i) == nextAvailableId.orElse(0L)) {
+      if (optionIds.get(i) >= nextAvailableId.orElse(0L)) {
         setNextAvailableId(optionIds.get(i) + 1);
       }
     }

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -14,9 +14,7 @@ import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 
-/**
- * Superclass for all forms for updating a multi-option question.
- */
+/** Superclass for all forms for updating a multi-option question. */
 public abstract class MultiOptionQuestionForm extends QuestionForm {
 
   // Caution: This must be a mutable list type, or else Play's form binding cannot add elements to
@@ -66,9 +64,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.nextAvailableId =
             OptionalLong.of(
                 qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
-                    .mapToLong(LocalizedQuestionOption::id)
-                    .max()
-                    .getAsLong()
+                        .mapToLong(LocalizedQuestionOption::id)
+                        .max()
+                        .getAsLong()
                     + 1);
       }
     } catch (TranslationNotFoundException e) {
@@ -167,13 +165,11 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     setNextAvailableId(maxId + 1);
 
     for (int i = 0; i < newOptions.size(); i++) {
-      QuestionOption newQuestionOption = QuestionOption.create(
-          nextAvailableId.getAsLong() + i,
-          options.size() + i,
-          LocalizedStrings.withDefaultValue(newOptions.get(i)));
-
-      questionOptionsBuilder.add(newQuestionOption);
-      optionIds.add(newQuestionOption.id());
+      questionOptionsBuilder.add(
+          QuestionOption.create(
+              nextAvailableId.getAsLong() + i,
+              options.size() + i,
+              LocalizedStrings.withDefaultValue(newOptions.get(i))));
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
 

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -173,7 +173,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
     // Sets the next available ID as the previous ID + the size of new options, since each new
     // option ID is assigned in order.
-    setNextAvailableId(nextAvailableId.orElse(0L) + newOptions.size());
+    setNextAvailableId(nextAvailableId.orElse(0L) + newOptions.size() + 1L);
 
     return super.getBuilder()
         .setQuestionOptions(questionOptions)

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -148,13 +148,20 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
 
+    if (this.optionIds.size() > 0) {
+      setNextAvailableId(this.optionIds.get(0) + 1);
+    }
+
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       questionOptionsBuilder.add(
           QuestionOption.create(
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
+      if (optionIds.get(i) > nextAvailableId.orElse(0L)) {
+        setNextAvailableId(optionIds.get(i) + 1);
+      }
     }
-    setNextAvailableId(options.size());
+
     for (int i = 0; i < newOptions.size(); i++) {
       questionOptionsBuilder.add(
           QuestionOption.create(
@@ -164,7 +171,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
 
-    setNextAvailableId(questionOptions.size());
+    // Sets the next available ID as the previous ID + the size of new options, since each new
+    // option ID is assigned in order.
+    setNextAvailableId(nextAvailableId.orElse(0L) + newOptions.size());
 
     return super.getBuilder()
         .setQuestionOptions(questionOptions)

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -178,7 +178,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
     // Sets the next available ID as the previous ID + the size of new options, since each new
     // option ID is assigned in order.
-    setNextAvailableId(nextAvailableId.orElse(0L) + newOptions.size() + 1L);
+    setNextAvailableId(nextAvailableId.orElse(0L) + newOptions.size());
 
     return super.getBuilder()
         .setQuestionOptions(questionOptions)

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -14,8 +14,11 @@ import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 
-/** Superclass for all forms for updating a multi-option question. */
+/**
+ * Superclass for all forms for updating a multi-option question.
+ */
 public abstract class MultiOptionQuestionForm extends QuestionForm {
+
   // Caution: This must be a mutable list type, or else Play's form binding cannot add elements to
   // the list. This means the constructors MUST set this field to a mutable List type, NOT
   // ImmutableList.
@@ -63,9 +66,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.nextAvailableId =
             OptionalLong.of(
                 qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
-                        .mapToLong(LocalizedQuestionOption::id)
-                        .max()
-                        .getAsLong()
+                    .mapToLong(LocalizedQuestionOption::id)
+                    .max()
+                    .getAsLong()
                     + 1);
       }
     } catch (TranslationNotFoundException e) {
@@ -77,8 +80,16 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     return this.options;
   }
 
+  public void setOptions(List<String> options) {
+    this.options = options;
+  }
+
   public List<String> getNewOptions() {
     return this.newOptions;
+  }
+
+  public void setNewOptions(List<String> options) {
+    this.newOptions = options;
   }
 
   public List<Long> getOptionIds() {
@@ -87,14 +98,6 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
   public void setOptionIds(List<Long> optionIds) {
     this.optionIds = optionIds;
-  }
-
-  public void setNewOptions(List<String> options) {
-    this.newOptions = options;
-  }
-
-  public void setOptions(List<String> options) {
-    this.options = options;
   }
 
   public OptionalInt getMinChoicesRequired() {
@@ -151,10 +154,6 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
 
-    if (this.optionIds.size() > 0) {
-      setNextAvailableId(this.optionIds.get(0) + 1);
-    }
-
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       questionOptionsBuilder.add(
@@ -170,7 +169,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     for (int i = 0; i < newOptions.size(); i++) {
       questionOptionsBuilder.add(
           QuestionOption.create(
-              nextAvailableId.orElse(0L) + i,
+              nextAvailableId.getAsLong() + i,
               options.size() + i,
               LocalizedStrings.withDefaultValue(newOptions.get(i))));
     }

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -25,7 +25,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   // The IDs of each option are not expected to be in any particular order.
   private List<Long> optionIds;
   // This value is the max existing ID + 1. The max ID will not necessarily be the last one in the
-  // optionIds list,we do not store options by order of their IDs.
+  // optionIds list, we do not store options by order of their IDs.
   private OptionalLong nextAvailableId;
   private OptionalInt minChoicesRequired;
   private OptionalInt maxChoicesAllowed;
@@ -160,12 +160,12 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
       questionOptionsBuilder.add(
           QuestionOption.create(
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
-      // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
-      // the largest ID in the list and accurately set the next largest.
-      if (optionIds.get(i) == nextAvailableId.orElse(0L)) {
-        setNextAvailableId(optionIds.get(i) + 1);
-      }
     }
+
+    // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
+    // the largest ID in the list and accurately set the next largest.
+    Long maxId = optionIds.stream().max(Long::compareTo).orElse(0L);
+    setNextAvailableId(maxId);
 
     for (int i = 0; i < newOptions.size(); i++) {
       questionOptionsBuilder.add(
@@ -178,7 +178,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
     // Sets the next available ID as the previous ID + the size of new options, since each new
     // option ID is assigned in order.
-    setNextAvailableId(nextAvailableId.orElse(0L) + newOptions.size());
+    setNextAvailableId(nextAvailableId.getAsLong() + newOptions.size());
 
     return super.getBuilder()
         .setQuestionOptions(questionOptions)

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -170,6 +170,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               nextAvailableId.getAsLong() + i,
               options.size() + i,
               LocalizedStrings.withDefaultValue(newOptions.get(i))));
+      optionIds.add(nextAvailableId.getAsLong() + i);
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
 

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -151,6 +151,10 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionIds.size() == this.options.size(),
         "Option ids and options are not the same size.");
 
+    if (this.optionIds.size() > 0) {
+      setNextAvailableId(this.optionIds.get(0) + 1);
+    }
+
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       questionOptionsBuilder.add(
@@ -158,7 +162,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               optionIds.get(i), i, LocalizedStrings.withDefaultValue(options.get(i))));
       // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
       // the largest ID in the list and accurately set the next largest.
-      if (optionIds.get(i) >= nextAvailableId.orElse(0L)) {
+      if (optionIds.get(i) == nextAvailableId.orElse(0L)) {
         setNextAvailableId(optionIds.get(i) + 1);
       }
     }

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -161,7 +161,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
 
     // The IDs are not guaranteed to be in any type of order, so doing this ensures that we find
     // the largest ID in the list and accurately set the next largest.
-    Long maxId = optionIds.stream().max(Long::compareTo).orElse(0L);
+    Long maxId = optionIds.stream().max(Long::compareTo).orElse(-1L);
     setNextAvailableId(maxId + 1);
 
     for (int i = 0; i < newOptions.size(); i++) {

--- a/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/MultiOptionQuestionForm.java
@@ -14,9 +14,7 @@ import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 
-/**
- * Superclass for all forms for updating a multi-option question.
- */
+/** Superclass for all forms for updating a multi-option question. */
 public abstract class MultiOptionQuestionForm extends QuestionForm {
 
   // Caution: This must be a mutable list type, or else Play's form binding cannot add elements to
@@ -66,9 +64,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.nextAvailableId =
             OptionalLong.of(
                 qd.getOptionsForLocale(LocalizedStrings.DEFAULT_LOCALE).stream()
-                    .mapToLong(LocalizedQuestionOption::id)
-                    .max()
-                    .getAsLong()
+                        .mapToLong(LocalizedQuestionOption::id)
+                        .max()
+                        .getAsLong()
                     + 1);
       }
     } catch (TranslationNotFoundException e) {

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -266,7 +266,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 QuestionOption.create(
                     4L, LocalizedStrings.of(Locale.US, "coffee", Locale.FRENCH, "café"))));
     // We can only update draft questions, so save this in the DRAFT version.
-    Question question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+    testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
 
     ArrayList<String> newOptions = new ArrayList<>();
     newOptions.add("cookie");

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -10,7 +10,6 @@ import static play.test.Helpers.contentAsString;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import forms.DropdownQuestionForm;
-import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -252,9 +251,9 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   public void update_setsIdsAsExpected() {
     DropdownQuestionDefinition definition =
         new DropdownQuestionDefinition(
-            "applicant ice cream",
-            Optional.empty(),
-            "Select your favorite ice cream flavor",
+            /* name= */ "applicant ice cream",
+            /* enumeratorId= */ Optional.empty(),
+            /* description= */ "Select your favorite ice cream flavor",
             LocalizedStrings.of(Locale.US, "Ice cream?", Locale.FRENCH, "crème glacée?"),
             LocalizedStrings.of(Locale.US, "help", Locale.FRENCH, "aider"),
             ImmutableList.of(
@@ -269,13 +268,8 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     // We can only update draft questions, so save this in the DRAFT version.
     testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
 
-    ArrayList<String> newOptions = new ArrayList<>();
-    newOptions.add("cookie");
-    newOptions.add("mint");
-    newOptions.add("pistachio");
-
     DropdownQuestionForm questionForm = new DropdownQuestionForm(definition);
-    questionForm.setNewOptions(newOptions);
+    questionForm.setNewOptions(ImmutableList.of("cookie", "mint", "pistachio"));
 
     questionForm.getBuilder();
 

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -272,6 +272,9 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
     questionForm.getBuilder();
 
+    assertThat(questionForm.getOptionIds().get(4)).isEqualTo(5L);
+    assertThat(questionForm.getOptionIds().get(5)).isEqualTo(6L);
+    assertThat(questionForm.getOptionIds().get(6)).isEqualTo(7L);
     assertThat(questionForm.getNextAvailableId()).isPresent();
     assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(8L);
   }

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableMap;
 import forms.DropdownQuestionForm;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.OptionalLong;
 import models.LifecycleStage;
 import models.Question;
 import org.junit.Before;
@@ -274,7 +273,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     questionForm.getBuilder();
 
     assertThat(questionForm.getNextAvailableId()).isPresent();
-    assertThat(questionForm.getNextAvailableId()).isEqualTo(OptionalLong.of(8));
+    assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(8L);
   }
 
   @Test
@@ -339,6 +338,13 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             QuestionOption.create(5, 2, LocalizedStrings.withDefaultValue("lavender")));
     assertThat(((MultiOptionQuestionDefinition) found.getQuestionDefinition()).getOptions())
         .isEqualTo(expectedOptions);
+
+    DropdownQuestionForm questionForm =
+        new DropdownQuestionForm((DropdownQuestionDefinition) definition);
+    questionForm.getBuilder();
+
+    assertThat(questionForm.getNextAvailableId()).isPresent();
+    assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(6L);
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -26,6 +26,7 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
 import services.question.types.DropdownQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import views.html.helper.CSRF;
 

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -13,6 +13,7 @@ import forms.DropdownQuestionForm;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import models.LifecycleStage;
 import models.Question;
 import org.junit.Before;
@@ -279,7 +280,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     questionForm.getBuilder();
 
     assertThat(questionForm.getNextAvailableId()).isPresent();
-    assertThat(questionForm.getNextAvailableId()).isEqualTo(8L);
+    assertThat(questionForm.getNextAvailableId()).isEqualTo(OptionalLong.of(8));
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -344,7 +344,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     questionForm.getBuilder();
 
     assertThat(questionForm.getNextAvailableId()).isPresent();
-    assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(6L);
+    assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(5L);
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminQuestionControllerTest.java
@@ -247,7 +247,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void update_setsIdsAsExpected() {
+  public void update_setsIdsAsExpected() throws Exception {
     DropdownQuestionDefinition definition =
         new DropdownQuestionDefinition(
             /* name= */ "applicant ice cream",
@@ -270,13 +270,14 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     DropdownQuestionForm questionForm = new DropdownQuestionForm(definition);
     questionForm.setNewOptions(ImmutableList.of("cookie", "mint", "pistachio"));
 
-    questionForm.getBuilder();
+    DropdownQuestionForm newQuestionForm =
+        new DropdownQuestionForm((DropdownQuestionDefinition) questionForm.getBuilder().build());
 
-    assertThat(questionForm.getOptionIds().get(4)).isEqualTo(5L);
-    assertThat(questionForm.getOptionIds().get(5)).isEqualTo(6L);
-    assertThat(questionForm.getOptionIds().get(6)).isEqualTo(7L);
-    assertThat(questionForm.getNextAvailableId()).isPresent();
-    assertThat(questionForm.getNextAvailableId().getAsLong()).isEqualTo(8L);
+    assertThat(newQuestionForm.getOptionIds().get(4)).isEqualTo(5L);
+    assertThat(newQuestionForm.getOptionIds().get(5)).isEqualTo(6L);
+    assertThat(newQuestionForm.getOptionIds().get(6)).isEqualTo(7L);
+    assertThat(newQuestionForm.getNextAvailableId()).isPresent();
+    assertThat(newQuestionForm.getNextAvailableId().getAsLong()).isEqualTo(8L);
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
@@ -91,5 +92,40 @@ public class MultiOptionQuestionFormTest {
     QuestionDefinition actual = builder.build();
 
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void getBuilder_setsNextIdCorrectly() throws Exception {
+    MultiOptionQuestionForm form = new DropdownQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionIds(ImmutableList.of(4L, 1L));
+
+    form.getBuilder();
+
+    assertThat(form.getNextAvailableId()).isEqualTo(OptionalLong.of(5L));
+  }
+
+  @Test
+  public void getBuilder_addNewOptions_setsNextIdCorrectly() throws Exception {
+    MultiOptionQuestionForm form = new DropdownQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionIds(ImmutableList.of(4L, 1L));
+    form.setNewOptions(ImmutableList.of("three", "four"));
+
+    form.getBuilder();
+
+    assertThat(form.getNextAvailableId()).isEqualTo(OptionalLong.of(7));
   }
 }

--- a/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/MultiOptionQuestionFormTest.java
@@ -95,7 +95,7 @@ public class MultiOptionQuestionFormTest {
   }
 
   @Test
-  public void getBuilder_setsNextIdCorrectly() throws Exception {
+  public void getBuilder_setsNextIdCorrectly_initialOptions() throws Exception {
     MultiOptionQuestionForm form = new DropdownQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
@@ -120,12 +120,13 @@ public class MultiOptionQuestionFormTest {
     form.setQuestionHelpText("help text");
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
+    // Add two existing options with IDs 1 and 2
     form.setOptions(ImmutableList.of("one", "two"));
-    form.setOptionIds(ImmutableList.of(4L, 1L));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
     form.setNewOptions(ImmutableList.of("three", "four"));
 
     form.getBuilder();
 
-    assertThat(form.getNextAvailableId()).isEqualTo(OptionalLong.of(7));
+    assertThat(form.getNextAvailableId()).isEqualTo(OptionalLong.of(5));
   }
 }


### PR DESCRIPTION
### Description
Issue #2013: After a CiviForm admin edits a question to have more options, whether that be adding options to a dropdown or a radio button, that selection is able to be chosen by the applicant initially but is not actually saved when the applicant goes to the review page or the admin exports the user data.

In MultiOptionQuestionForm, there's a field called "nextAvailableId". This field is set with "setNextAvailableId", which is never actually called. To fix this, I set the nextAvailableId every time the question options are updated. 

To test, I recreated the question linked in that bug. 

Here, I am picking Grandparent, which was added later on as the 4th option: 
![image](https://user-images.githubusercontent.com/93745541/157734682-73f4afac-cc37-47fa-84d9-3e6060e5cbe8.png)

I do the same with this edited radio button question:
![image](https://user-images.githubusercontent.com/93745541/157734808-fb50f909-cf32-4186-a6e0-8cb6ff65b17a.png)

As you can see here, Grandparent now shows up in both places instead of "Child", which was happening previously
![image](https://user-images.githubusercontent.com/93745541/157734972-12ed6f39-3d5e-4315-9f21-306f142047de.png)


### Issue(s)
Fixes #2013 
