### PR TITLE
WIP: Save OIDC iss/sub as Accounts.authority_id

### DIFF
--- a/universal-application-tool-0.0.1/test/auth/IdcsProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/IdcsProfileMergeTest.java
@@ -12,7 +12,7 @@ import org.pac4j.oidc.profile.OidcProfile;
 import repository.UserRepository;
 import repository.WithPostgresContainer;
 
-public class ProfileMergeTest extends WithPostgresContainer {
+public class IdcsProfileMergeTest extends WithPostgresContainer {
 
   private IdcsProfileAdapter profileAdapter;
   private ProfileFactory profileFactory;
@@ -38,18 +38,25 @@ public class ProfileMergeTest extends WithPostgresContainer {
   public void testProfileCreation() throws ExecutionException, InterruptedException {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
+    // authority_id values.
+    oidcProfile.addAttribute("iss", "issuer");
+    oidcProfile.setId("subject");
 
     CiviFormProfileData profileData = profileAdapter.civiformProfileFromOidcProfile(oidcProfile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
     assertThat(profile.getEmailAddress().get()).isEqualTo("foo@example.com");
+    assertThat(profile.getAuthorityId().get()).isEqualTo("iss: issuer sub: subject");
   }
 
   @Test
   public void testSuccessfulProfileMerge() {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
+    // authority_id values.
+    oidcProfile.addAttribute("iss", "issuer");
+    oidcProfile.setId("subject");
 
     CiviFormProfileData profileData = profileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 


### PR DESCRIPTION
### Description
Stores an Accounts.authority_id for OIDC accounts.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
