### PR TITLE
Fix bug in testFailedProfileMerge for incorrect setup

### DIFF
--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -78,11 +78,12 @@ public class ProfileMergeTest extends ResetPostgres {
   }
 
   @Test
-  public void testFailedProfileMerge() {
+  public void testProfileMerge_fails_emailsDoNotMatch() {
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
+
     OidcProfile conflictingProfile = new OidcProfile();
-    oidcProfile.addAttribute("user_emailid", "bar@example.com");
+    conflictingProfile.addAttribute("user_emailid", "bar@example.com");
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);


### PR DESCRIPTION
Test data wasn't setting the correct object, though it indirectly had the correct intent I believe.

Renamed to allow for more tests later.
