### PR TITLE
fix key_vault::has-secret funtion to grep stderr

### DIFF
--- a/cloud/azure/bin/lib/key_vault.sh
+++ b/cloud/azure/bin/lib/key_vault.sh
@@ -115,7 +115,7 @@ function key_vault::has_secret() {
     --vault-name "${1}" \
     --name "${2}" \
     --query value \
-    -o tsv)"
+    -o tsv 2>&1 >/dev/null)"
   
   echo "${SECRET_RESULT}" | grep -q -v "SecretNotFound"
 }


### PR DESCRIPTION
This function wasn't working because we were searching stdout while the string we were targeting is logged to stderr.
