### PR TITLE
Set content type for azure file uploads so downloads have a file extension

### DIFF
--- a/universal-application-tool-0.0.1/app/assets/javascripts/azure_upload.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/azure_upload.ts
@@ -30,12 +30,19 @@ class AzureUploadController {
     // window["azblob"] was used because the TS compiler complained about using
     // window.azblob.
     const azblob = window['azblob']
+
     if (uploadContainer == null) {
       throw new Error('Attempted to upload to null container')
     }
     const azureUploadProps = this.getAzureUploadProps(uploadContainer)
 
     const redirectUrl = new URL(azureUploadProps.successActionRedirect)
+
+    const options = {
+      blobHTTPHeaders: {
+        blobContentType: azureUploadProps.file.type,
+      },
+    }
 
     const blockBlobUrl = azblob.BlockBlobURL.fromBlobURL(
       new azblob.BlobURL(
@@ -48,7 +55,8 @@ class AzureUploadController {
       .uploadBrowserDataToBlockBlob(
         azblob.Aborter.none,
         azureUploadProps.file,
-        blockBlobUrl
+        blockBlobUrl,
+        options
       )
       .then((resp, err) => {
         if (err) {

--- a/universal-application-tool-0.0.1/app/services/cloud/azure/BlobStorage.java
+++ b/universal-application-tool-0.0.1/app/services/cloud/azure/BlobStorage.java
@@ -135,7 +135,7 @@ public class BlobStorage implements StorageClient {
                           // and passed along, more info on the headers:
                           // https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
                           .setAllowedHeaders(
-                              "content-type,x-ms-blob-type,x-ms-client-request-id,x-ms-version")
+                              "content-type,x-ms-blob-type,x-ms-client-request-id,x-ms-version,x-ms-blob-content-type")
                           .setAllowedMethods("GET,PUT,OPTIONS")
                           .setMaxAgeInSeconds(500)));
       blobServiceClient.setProperties(properties);


### PR DESCRIPTION
### Description
Previously, azure file uploads didn't have a content type set so extensions were lost. For whatever reason, Azure SDK defaults to MIME type "application/octet-stream". This PR sets the MIME type to preserve extensions. 

Issue was found in bug bash, not sure if there is an issue number.



### Issue(s)
Fixes #2101
