### PR TITLE
Add primary OIDC user lookup by Account.authority_id

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -5,6 +5,7 @@ import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
 import auth.Roles;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
@@ -119,12 +120,8 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
 
     OidcProfile profile = (OidcProfile) oidcProfile.get();
     // Check if we already have a profile in the database for the user returned to us by OIDC.
-    Optional<Applicant> existingApplicant =
-        applicantRepositoryProvider
-            .get()
-            .lookupApplicantByEmail(profile.getAttribute(emailAttributeName(), String.class))
-            .toCompletableFuture()
-            .join();
+    // Lookup on authority first.
+    Optional<Applicant> existingApplicant = getExistingApplicant(profile);
 
     // Now we have a three-way merge situation.  We might have
     // 1) an applicant in the database (`existingApplicant`),
@@ -160,6 +157,40 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     } else {
       return Optional.of(mergeCiviFormProfile(existingProfile.get(), profile));
     }
+  }
+
+  @VisibleForTesting
+  Optional<Applicant> getExistingApplicant(OidcProfile profile) {
+    // User keying changed in March 2022 and is reflected and managed here.
+    // Originally users were keyed on their email address, however this is not guaranteed to be a
+    // unique stable ID.
+    // In March 2022 the code base changed to using authority_id which is unique and stable per
+    // authentication provider.
+
+    Optional<String> authorityId = getAuthorityId(profile);
+    if (authorityId.isEmpty()) {
+      throw new InvalidOidcProfileException("Unable to get authority ID from profile.");
+    }
+    Optional<Applicant> applicantOpt =
+        applicantRepositoryProvider
+            .get()
+            .lookupApplicantByAuthorityId(authorityId.get())
+            .toCompletableFuture()
+            .join();
+    if (applicantOpt.isPresent()) {
+      logger.debug("Found user using authority ID: {}", authorityId);
+      return applicantOpt;
+    }
+
+    // For pre-existing deployments before April 2022, users will exist without an authority ID and
+    // will be keyed on their email.
+    String userEmail = profile.getAttribute(emailAttributeName(), String.class);
+    logger.debug("Looking up user using email {}", userEmail);
+    return applicantRepositoryProvider
+        .get()
+        .lookupApplicantByEmail(userEmail)
+        .toCompletableFuture()
+        .join();
   }
 
   protected abstract void possiblyModifyConfigBasedOnCred(Credentials cred);

--- a/universal-application-tool-0.0.1/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -120,7 +120,6 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
 
     OidcProfile profile = (OidcProfile) oidcProfile.get();
     // Check if we already have a profile in the database for the user returned to us by OIDC.
-    // Lookup on authority first.
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
 
     // Now we have a three-way merge situation.  We might have
@@ -167,14 +166,15 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     // In March 2022 the code base changed to using authority_id which is unique and stable per
     // authentication provider.
 
-    Optional<String> authorityId = getAuthorityId(profile);
-    if (authorityId.isEmpty()) {
-      throw new InvalidOidcProfileException("Unable to get authority ID from profile.");
-    }
+    String authorityId =
+        getAuthorityId(profile)
+            .orElseThrow(
+                () -> new InvalidOidcProfileException("Unable to get authority ID from profile."));
+
     Optional<Applicant> applicantOpt =
         applicantRepositoryProvider
             .get()
-            .lookupApplicantByAuthorityId(authorityId.get())
+            .lookupApplicantByAuthorityId(authorityId)
             .toCompletableFuture()
             .join();
     if (applicantOpt.isPresent()) {

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -110,6 +110,7 @@ public class UserRepository {
     }
     return database.find(Account.class).where().eq("email_address", emailAddress).findOneOrEmpty();
   }
+
   /**
    * Returns the most recent Applicant identified by Account, creating one if necessary.
    *
@@ -117,12 +118,13 @@ public class UserRepository {
    * we create one.
    */
   private Applicant getOrCreateApplicant(Account account) {
-    Optional<Applicant> applicantMaybe =
+    Optional<Applicant> applicantOpt =
         account.getApplicants().stream()
             .max(Comparator.comparing(compared -> compared.getWhenCreated()));
-    if (applicantMaybe.isPresent()) {
-      return applicantMaybe.get();
+    if (applicantOpt.isPresent()) {
+      return applicantOpt.get();
     }
+
     Applicant newApplicant = new Applicant().setAccount(account);
     newApplicant.save();
     return newApplicant;

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -97,37 +97,46 @@ public class UserRepository {
         executionContext.current());
   }
 
+  public Optional<Account> lookupAccountByAuthorityId(String authorityId) {
+    if (authorityId == null || authorityId.isEmpty()) {
+      return Optional.empty();
+    }
+    return database.find(Account.class).where().eq("authority_id", authorityId).findOneOrEmpty();
+  }
+
   public Optional<Account> lookupAccountByEmail(String emailAddress) {
     if (emailAddress == null || emailAddress.isEmpty()) {
       return Optional.empty();
     }
     return database.find(Account.class).where().eq("email_address", emailAddress).findOneOrEmpty();
   }
+  /**
+   * Returns the most recent Applicant identified by Account, creating one if necessary.
+   *
+   * <p>If no applicant exists, this is probably an account waiting for a trusted intermediary, so we
+   * create one.
+   */
+  private Applicant getOrCreateApplicant(Account account) {
+    Optional<Applicant> applicantMaybe =
+        account.getApplicants().stream()
+            .max(Comparator.comparing(compared -> compared.getWhenCreated()));
+    if (applicantMaybe.isPresent()) {
+      return applicantMaybe.get();
+    }
+    Applicant newApplicant = new Applicant().setAccount(account);
+    newApplicant.save();
+    return newApplicant;
+  }
+
+  public CompletionStage<Optional<Applicant>> lookupApplicantByAuthorityId(String authorityId) {
+    return supplyAsync(
+        () -> lookupAccountByAuthorityId(authorityId).map(this::getOrCreateApplicant),
+        executionContext);
+  }
 
   public CompletionStage<Optional<Applicant>> lookupApplicantByEmail(String emailAddress) {
     return supplyAsync(
-        () -> {
-          Optional<Account> accountMaybe = lookupAccountByEmail(emailAddress);
-          // Return the applicant which was most recently created.
-          // If no applicant exists, this is probably an account waiting for
-          // a trusted intermediary - create one.
-          if (accountMaybe.isEmpty()) {
-            return Optional.empty();
-          }
-          Optional<Applicant> applicantMaybe =
-              accountMaybe.flatMap(
-                  account ->
-                      account.getApplicants().stream()
-                          .max(Comparator.comparing(compared -> compared.getWhenCreated())));
-          if (applicantMaybe.isPresent()) {
-            return applicantMaybe;
-          }
-          Applicant newApplicant = new Applicant();
-          newApplicant.setAccount(accountMaybe.get());
-          newApplicant.save();
-          return Optional.of(newApplicant);
-        },
-        executionContext);
+        () -> lookupAccountByEmail(emailAddress).map(this::getOrCreateApplicant), executionContext);
   }
 
   public CompletionStage<Void> insertApplicant(Applicant applicant) {

--- a/universal-application-tool-0.0.1/app/repository/UserRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/UserRepository.java
@@ -113,8 +113,8 @@ public class UserRepository {
   /**
    * Returns the most recent Applicant identified by Account, creating one if necessary.
    *
-   * <p>If no applicant exists, this is probably an account waiting for a trusted intermediary, so we
-   * create one.
+   * <p>If no applicant exists, this is probably an account waiting for a trusted intermediary, so
+   * we create one.
    */
   private Applicant getOrCreateApplicant(Account account) {
     Optional<Applicant> applicantMaybe =

--- a/universal-application-tool-0.0.1/test/auth/oidc/OidcCiviFormProfileAdapterTest.java
+++ b/universal-application-tool-0.0.1/test/auth/oidc/OidcCiviFormProfileAdapterTest.java
@@ -1,0 +1,106 @@
+package auth.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import auth.ProfileFactory;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import javax.inject.Provider;
+import models.Account;
+import models.Applicant;
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.oidc.profile.OidcProfile;
+import repository.ResetPostgres;
+import repository.UserRepository;
+
+public class OidcCiviFormProfileAdapterTest extends ResetPostgres {
+  private static final String EMAIL = "foo@bar.com";
+  private static final String ISSUER = "issuer";
+  private static final String SUBJECT = "subject";
+  private static final String AUTHORITY_ID = "iss: issuer sub: subject";
+
+  private OidcCiviFormProfileAdapter oidcProfileAdapter;
+  private ProfileFactory profileFactory;
+
+  @Before
+  public void setup() {
+    UserRepository repository = instanceOf(UserRepository.class);
+    profileFactory = instanceOf(ProfileFactory.class);
+    oidcProfileAdapter =
+        // Just need some complete adaptor to access methods.
+        new IdcsProfileAdapter(
+            /* configuration= */ null,
+            /* client= */ null,
+            profileFactory,
+            new Provider<UserRepository>() {
+              @Override
+              public UserRepository get() {
+                return repository;
+              }
+            });
+  }
+
+  @Test
+  public void getExistingApplicant_succeeds_noAuthorityFallsBackToEmail() {
+    // When an existing account doesn't have an authority_id we still find it by email.
+
+    // Setup.
+    // Existing account doesn't have an authority.
+    resourceCreator
+        .insertAccount()
+        .setEmailAddress(EMAIL)
+        .setApplicants(ImmutableList.of(resourceCreator.insertApplicant()))
+        .save();
+
+    // Current OIDC info has an authority and email.
+    OidcProfile profile = new OidcProfile();
+    profile.addAttribute("user_emailid", EMAIL);
+    profile.addAttribute("iss", ISSUER);
+    profile.setId(SUBJECT);
+
+    // Execute.
+    Optional<Applicant> applicant = oidcProfileAdapter.getExistingApplicant(profile);
+
+    // Verify.
+    assertThat(applicant).isPresent();
+    Account account = applicant.get().getAccount();
+
+    assertThat(account.getEmailAddress()).isEqualTo(EMAIL);
+    // The existing account doesn't have an authority as it didn't before.
+    assertThat(account.getAuthorityId()).isNull();
+  }
+
+  @Test
+  public void getExistingApplicant_succeeds_sameAuthorityDifferentEmail() {
+    // Authority ID is the main key and returns the local account even with different other old keys
+    // like email.
+
+    // Setup.
+    final String otherEmail = "OTHER@EMAIL.com";
+    // Existing account has authority but some other email.
+    resourceCreator
+        .insertAccount()
+        .setEmailAddress(otherEmail)
+        .setAuthorityId(AUTHORITY_ID)
+        .setApplicants(ImmutableList.of(resourceCreator.insertApplicant()))
+        .save();
+
+    // Current OIDC info has an authority and email.
+    OidcProfile profile = new OidcProfile();
+    profile.addAttribute("user_emailid", EMAIL);
+    profile.addAttribute("iss", ISSUER);
+    profile.setId(SUBJECT);
+
+    // Execute.
+    Optional<Applicant> applicant = oidcProfileAdapter.getExistingApplicant(profile);
+
+    // Verify.
+    assertThat(applicant).isPresent();
+    Account account = applicant.get().getAccount();
+
+    // The email of the existing account is the pre-existing one, not a new profile one.
+    assertThat(account.getEmailAddress()).isEqualTo(otherEmail);
+    assertThat(account.getAuthorityId()).isEqualTo(AUTHORITY_ID);
+  }
+}

--- a/universal-application-tool-0.0.1/test/repository/UserRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/UserRepositoryTest.java
@@ -57,6 +57,27 @@ public class UserRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void lookupByAuthorityId() {
+    String email = "happy@test.com";
+    String authorityId = "I'm an authority ID";
+
+    new Account().setEmailAddress(email).setAuthorityId(authorityId).save();
+
+    assertThat(repo.lookupAccountByAuthorityId(authorityId).get().getEmailAddress())
+        .isEqualTo(email);
+  }
+
+  @Test
+  public void lookupByEmailAddress() {
+    String email = "happy@test.com";
+    String authorityId = "I'm an authority ID";
+
+    new Account().setEmailAddress(email).setAuthorityId(authorityId).save();
+
+    assertThat(repo.lookupAccountByEmail(email).get().getAuthorityId()).isEqualTo(authorityId);
+  }
+
+  @Test
   public void insertApplicant() {
     Applicant applicant = new Applicant();
     String path = "$.applicant.birthdate";


### PR DESCRIPTION
### Description
OidcCiviFormProfileAdapter looks up users based on their authority_id now, falling back to email in legacy situations where users don't have an authority_id.

The UserRepository.java lookup has a behavior of creating an Applicant if missing when an Account exists. This is copied forward for the lookup by Authority ID case.  The existing behavior is not well understood, but in theory if a TI lookup up a resident email and there's an Account but not Applicant, then the code thinks that should be corrected.  It's unclear how that situation would actually occur and may be WAI for an old design from what we actually have.  So in theory that correction flow may never happen, but doing it in both cases shouldn't be able to cause harm either.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1793 