### PR TITLE
Add authority_id to SAML profile and use as primary identifier

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/saml/InvalidSamlProfileException.java
+++ b/universal-application-tool-0.0.1/app/auth/saml/InvalidSamlProfileException.java
@@ -1,8 +1,6 @@
 package auth.saml;
 
-/**
- * Raised when a SAML profile is valid.
- */
+/** Raised when a SAML profile is valid. */
 public class InvalidSamlProfileException extends RuntimeException {
 
   InvalidSamlProfileException(String message) {

--- a/universal-application-tool-0.0.1/app/auth/saml/InvalidSamlProfileException.java
+++ b/universal-application-tool-0.0.1/app/auth/saml/InvalidSamlProfileException.java
@@ -1,5 +1,8 @@
 package auth.saml;
 
+/**
+ * Raised when a SAML profile is valid.
+ */
 public class InvalidSamlProfileException extends RuntimeException {
 
   InvalidSamlProfileException(String message) {

--- a/universal-application-tool-0.0.1/app/auth/saml/InvalidSamlProfileException.java
+++ b/universal-application-tool-0.0.1/app/auth/saml/InvalidSamlProfileException.java
@@ -1,0 +1,8 @@
+package auth.saml;
+
+public class InvalidSamlProfileException extends RuntimeException {
+
+  InvalidSamlProfileException(String message) {
+    super(message);
+  }
+}

--- a/universal-application-tool-0.0.1/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -147,6 +147,12 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
 
   public CiviFormProfileData mergeCiviFormProfile(
       CiviFormProfile civiFormProfile, SAML2Profile saml2Profile) {
+    String authorityId =
+        getAuthorityId(saml2Profile)
+            .orElseThrow(
+                () -> new InvalidSamlProfileException("Unable to get authority ID from profile"));
+    civiFormProfile.setAuthorityId(authorityId).join();
+
     final String locale = saml2Profile.getAttribute("locale", String.class);
     final boolean hasLocale = !Strings.isNullOrEmpty(locale);
 
@@ -180,13 +186,6 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
           .toCompletableFuture()
           .join();
     }
-
-    String authorityId =
-        getAuthorityId(saml2Profile)
-            .orElseThrow(
-                () -> new InvalidSamlProfileException("Unable to get authority ID from profile"));
-    civiFormProfile.setAuthorityId(authorityId).join();
-
     String emailAddress = saml2Profile.getEmail();
     civiFormProfile.setEmailAddress(emailAddress).join();
 

--- a/universal-application-tool-0.0.1/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -181,8 +181,10 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
           .join();
     }
 
-    String authorityId = getAuthorityId(saml2Profile).orElseThrow(()
-        -> new InvalidSamlProfileException("Unable to get authority ID from profile"));
+    String authorityId =
+        getAuthorityId(saml2Profile)
+            .orElseThrow(
+                () -> new InvalidSamlProfileException("Unable to get authority ID from profile"));
     civiFormProfile.setAuthorityId(authorityId).join();
 
     String emailAddress = saml2Profile.getEmail();

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -73,6 +73,7 @@ public class ProfileMergeTest extends ResetPostgres {
     profile.setId(subject);
     profile.addAuthenticationAttribute("issuerId", issuer);
     profile.addAttribute(CommonProfileDefinition.EMAIL, email);
+    return profile;
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -125,9 +125,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThat(
-            idcsProfileAdapter
-                .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
-                .getEmail())
+        idcsProfileAdapter
+            .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
+            .getEmail())
         .isEqualTo("foo@example.com");
   }
 
@@ -143,9 +143,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-            () ->
-                idcsProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), newProfile))
+        () ->
+            idcsProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -161,9 +161,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-            () ->
-                idcsProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), newProfile))
+        () ->
+            idcsProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -179,9 +179,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-            () ->
-                idcsProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), newProfile))
+        () ->
+            idcsProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -194,9 +194,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-            () ->
-                idcsProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        () ->
+            idcsProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -210,9 +210,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-            () ->
-                idcsProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        () ->
+            idcsProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -226,9 +226,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-            () ->
-                idcsProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        () ->
+            idcsProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -242,7 +242,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
     assertThat(profile.getEmailAddress().get()).isEqualTo("foo@example.com");
-    assertThat(profile.getAuthorityId().get()).isEqualTo("iss: issuer sub: subject");
+    assertThat(profile.getAuthorityId().get()).isEqualTo("Issuer: issuer NameID: subject");
   }
 
   @Test
@@ -253,9 +253,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThat(
-            samlProfileAdapter
-                .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), saml2Profile)
-                .getEmail())
+        samlProfileAdapter
+            .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), saml2Profile)
+            .getEmail())
         .isEqualTo("foo@example.com");
   }
 
@@ -268,9 +268,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-            () ->
-                samlProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        () ->
+            samlProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -286,9 +286,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-            () ->
-                samlProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), newProfile))
+        () ->
+            samlProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidSamlProfileException.class);
   }
 
@@ -304,9 +304,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-            () ->
-                samlProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), newProfile))
+        () ->
+            samlProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidSamlProfileException.class);
   }
 
@@ -320,9 +320,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-            () ->
-                samlProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        () ->
+            samlProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), conflictingProfile))
         .isInstanceOf(CompletionException.class);
   }
 
@@ -336,9 +336,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-            () ->
-                samlProfileAdapter.mergeCiviFormProfile(
-                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        () ->
+            samlProfileAdapter.mergeCiviFormProfile(
+                profileFactory.wrapProfileData(profileData), conflictingProfile))
         .isInstanceOf(CompletionException.class);
   }
 }

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import auth.oidc.IdcsProfileAdapter;
 import auth.oidc.InvalidOidcProfileException;
+import auth.saml.InvalidSamlProfileException;
 import auth.saml.SamlCiviFormProfileAdapter;
 import io.ebean.DB;
 import io.ebean.Database;
@@ -65,6 +66,13 @@ public class ProfileMergeTest extends ResetPostgres {
     profile.addAttribute("iss", issuer);
     profile.setId(subject);
     return profile;
+  }
+
+  private SAML2Profile createSamlProfile(String email, String issuer, String subject) {
+    SAML2Profile profile = new SAML2Profile();
+    profile.setId(subject);
+    profile.addAuthenticationAttribute("issuerId", issuer);
+    profile.addAttribute(CommonProfileDefinition.EMAIL, email);
   }
 
   @Test
@@ -223,9 +231,8 @@ public class ProfileMergeTest extends ResetPostgres {
   }
 
   @Test
-  public void testSamlProfileCreation() throws ExecutionException, InterruptedException {
-    SAML2Profile saml2Profile = new SAML2Profile();
-    saml2Profile.addAttribute(CommonProfileDefinition.EMAIL, "foo@example.com");
+  public void testSamlProfileCreation() throws Exception {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
@@ -233,12 +240,12 @@ public class ProfileMergeTest extends ResetPostgres {
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
     assertThat(profile.getEmailAddress().get()).isEqualTo("foo@example.com");
+    assertThat(profile.getAuthorityId().get()).isEqualTo("iss: issuer sub: subject");
   }
 
   @Test
-  public void testSuccessfulSamlProfileMerge() {
-    SAML2Profile saml2Profile = new SAML2Profile();
-    saml2Profile.addAttribute(CommonProfileDefinition.EMAIL, "foo@example.com");
+  public void testProfileMerge_saml_succeeds() {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
@@ -251,11 +258,9 @@ public class ProfileMergeTest extends ResetPostgres {
   }
 
   @Test
-  public void testFailedSamlProfileMerge() {
-    SAML2Profile saml2Profile = new SAML2Profile();
-    saml2Profile.addAttribute(CommonProfileDefinition.EMAIL, "foo@example.com");
-    SAML2Profile conflictingProfile = new SAML2Profile();
-    conflictingProfile.addAttribute(CommonProfileDefinition.EMAIL, "bar@example.com");
+  public void testProfileMerge_saml_fails_differentEmails() {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
+    SAML2Profile conflictingProfile = createSamlProfile("bar@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
@@ -265,5 +270,73 @@ public class ProfileMergeTest extends ResetPostgres {
                 samlProfileAdapter.mergeCiviFormProfile(
                     profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
+  }
+
+  @Test
+  public void testProfileMerge_saml_fails_noSubject() {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
+
+    SAML2Profile newProfile = new SAML2Profile();
+    newProfile.addAttribute(CommonProfileDefinition.EMAIL, "foo@example.com");
+    newProfile.addAuthenticationAttribute("issuerId", "issuer");
+
+    CiviFormProfileData profileData =
+        samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
+
+    assertThatThrownBy(
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
+        .isInstanceOf(InvalidSamlProfileException.class);
+  }
+
+  @Test
+  public void testProfileMerge_saml_fails_noIssuer() {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
+
+    SAML2Profile newProfile = new SAML2Profile();
+    newProfile.addAttribute(CommonProfileDefinition.EMAIL, "foo@example.com");
+    newProfile.setId("subject");
+
+    CiviFormProfileData profileData =
+        samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
+
+    assertThatThrownBy(
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
+        .isInstanceOf(InvalidSamlProfileException.class);
+  }
+
+  @Test
+  public void testProfileMerge_saml_fails_differentAuthoritySubject() {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
+    SAML2Profile conflictingProfile =
+        createSamlProfile("foo@example.com", "issuer", "a different subject");
+
+    CiviFormProfileData profileData =
+        samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
+
+    assertThatThrownBy(
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        .isInstanceOf(InvalidSamlProfileException.class);
+  }
+
+  @Test
+  public void testProfileMerge_saml_fails_differentAuthorityIssuer() {
+    SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
+    SAML2Profile conflictingProfile =
+        createSamlProfile("foo@example.com", "a different issuer", "subject");
+
+    CiviFormProfileData profileData =
+        samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
+
+    assertThatThrownBy(
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        .isInstanceOf(InvalidSamlProfileException.class);
   }
 }

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -322,7 +322,7 @@ public class ProfileMergeTest extends ResetPostgres {
             () ->
                 samlProfileAdapter.mergeCiviFormProfile(
                     profileFactory.wrapProfileData(profileData), conflictingProfile))
-        .isInstanceOf(InvalidSamlProfileException.class);
+        .isInstanceOf(ProfileMergeConflictException.class);
   }
 
   @Test
@@ -338,6 +338,6 @@ public class ProfileMergeTest extends ResetPostgres {
             () ->
                 samlProfileAdapter.mergeCiviFormProfile(
                     profileFactory.wrapProfileData(profileData), conflictingProfile))
-        .isInstanceOf(InvalidSamlProfileException.class);
+        .isInstanceOf(ProfileMergeConflictException.class);
   }
 }

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -125,9 +125,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThat(
-        idcsProfileAdapter
-            .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
-            .getEmail())
+            idcsProfileAdapter
+                .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
+                .getEmail())
         .isEqualTo("foo@example.com");
   }
 
@@ -143,9 +143,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-        () ->
-            idcsProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), newProfile))
+            () ->
+                idcsProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -161,9 +161,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-        () ->
-            idcsProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), newProfile))
+            () ->
+                idcsProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -179,9 +179,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-        () ->
-            idcsProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), newProfile))
+            () ->
+                idcsProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidOidcProfileException.class);
   }
 
@@ -194,9 +194,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-        () ->
-            idcsProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), conflictingProfile))
+            () ->
+                idcsProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -210,9 +210,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-        () ->
-            idcsProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), conflictingProfile))
+            () ->
+                idcsProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -226,9 +226,9 @@ public class ProfileMergeTest extends ResetPostgres {
         idcsProfileAdapter.civiformProfileFromOidcProfile(oidcProfile);
 
     assertThatThrownBy(
-        () ->
-            idcsProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), conflictingProfile))
+            () ->
+                idcsProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -253,9 +253,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThat(
-        samlProfileAdapter
-            .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), saml2Profile)
-            .getEmail())
+            samlProfileAdapter
+                .mergeCiviFormProfile(profileFactory.wrapProfileData(profileData), saml2Profile)
+                .getEmail())
         .isEqualTo("foo@example.com");
   }
 
@@ -268,9 +268,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-        () ->
-            samlProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), conflictingProfile))
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
         .hasCauseInstanceOf(ProfileMergeConflictException.class);
   }
 
@@ -286,9 +286,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-        () ->
-            samlProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), newProfile))
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidSamlProfileException.class);
   }
 
@@ -304,9 +304,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-        () ->
-            samlProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), newProfile))
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), newProfile))
         .isInstanceOf(InvalidSamlProfileException.class);
   }
 
@@ -320,9 +320,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-        () ->
-            samlProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), conflictingProfile))
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
         .isInstanceOf(CompletionException.class);
   }
 
@@ -336,9 +336,9 @@ public class ProfileMergeTest extends ResetPostgres {
         samlProfileAdapter.civiformProfileFromSamlProfile(saml2Profile);
 
     assertThatThrownBy(
-        () ->
-            samlProfileAdapter.mergeCiviFormProfile(
-                profileFactory.wrapProfileData(profileData), conflictingProfile))
+            () ->
+                samlProfileAdapter.mergeCiviFormProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
         .isInstanceOf(CompletionException.class);
   }
 }

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -9,6 +9,7 @@ import auth.saml.InvalidSamlProfileException;
 import auth.saml.SamlCiviFormProfileAdapter;
 import io.ebean.DB;
 import io.ebean.Database;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import javax.inject.Provider;
 import models.Account;
@@ -322,7 +323,7 @@ public class ProfileMergeTest extends ResetPostgres {
             () ->
                 samlProfileAdapter.mergeCiviFormProfile(
                     profileFactory.wrapProfileData(profileData), conflictingProfile))
-        .isInstanceOf(ProfileMergeConflictException.class);
+        .isInstanceOf(CompletionException.class);
   }
 
   @Test
@@ -338,6 +339,6 @@ public class ProfileMergeTest extends ResetPostgres {
             () ->
                 samlProfileAdapter.mergeCiviFormProfile(
                     profileFactory.wrapProfileData(profileData), conflictingProfile))
-        .isInstanceOf(ProfileMergeConflictException.class);
+        .isInstanceOf(CompletionException.class);
   }
 }


### PR DESCRIPTION
### Description
SamlCiviFormProfileAdapter looks up users based on their authority_id now. This ID is built by combining the subject and issuer ID.

### Checklist
- [ X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

