### PR TITLE
Revert "Update dependency bellsoft/liberica-openjdk-alpine to v11.0.14"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG PLATFORM="amd64"
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
 FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim as amd64
-FROM bellsoft/liberica-openjdk-alpine:11.0.14-9-aarch64 as arm64
+FROM bellsoft/liberica-openjdk-alpine:11.0.10-9-aarch64 as arm64
 
 FROM ${PLATFORM}
 


### PR DESCRIPTION
Reverts seattle-uat/civiform#2130

Going to need to revert this, since I started seeing this error. Rolling back the version fixes it:
```
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] com.typesafe
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java:6:1: cannot access com.typesafe.config
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] com.typesafe.config
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java:10:1: cannot access org.pac4j.core
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java:10:1: cannot access org.pac4j.core.client
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core.client
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java:11:1: cannot access org.pac4j.core.credentials
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core.credentials
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java:12:1: cannot access org.pac4j.core.util
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core.util
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/repository/VersionRepository.java:6:1: cannot access com.google.common.annotations
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] com.google.common.annotations
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java:3:1: cannot access org.pac4j.core.exception
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core.exception
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java:3:1: cannot access org.pac4j.core.exception.http
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core.exception.http
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/ProfileUtils.java:7:1: cannot access org.pac4j.core.context
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
civiform  | [error] org.pac4j.core.context
civiform  | [error] /usr/src/universal-application-tool-0.0.1/app/auth/ProfileUtils.java:8:1: cannot access org.pac4j.core.context.session
civiform  | [error]   ZIP file can't be opened as a file system because an entry has a '.' or '..' element in its name
```
