### PR TITLE
Fix for Azure deploy script

### DIFF
--- a/cloud/shared/bin/lib.sh
+++ b/cloud/shared/bin/lib.sh
@@ -6,9 +6,8 @@ set -o pipefail
 export TF_VAR_FILENAME="setup.auto.tfvars"
 export BACKEND_VARS_FILENAME="backend_vars"
 
-readonly CLOUD_LIB_DIR="${BASH_SOURCE%/*}/lib"
-
 if [[ "${SOURCED_CLOUD_LIB}" != "true" ]]; then
+  readonly CLOUD_LIB_DIR="${BASH_SOURCE%/*}/lib"
   source "bin/lib/out.sh"
   source "${CLOUD_LIB_DIR}/health.sh"
   source "${CLOUD_LIB_DIR}/log.sh"


### PR DESCRIPTION
### Description
I was getting an error message ```cloud/shared/bin/lib.sh: line 9: CLOUD_LIB_DIR: readonly variable``` when I tried to run the Azure deploy command. This is potentially a fix 
