### PR TITLE
Update Azure terraform code for compatibility with v3 azurerm provider

### DIFF
--- a/cloud/azure/modules/app/main.tf
+++ b/cloud/azure/modules/app/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_storage_account" "files_storage_account" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
-  allow_blob_public_access = false
+  allow_nested_items_to_be_public = false
 }
 
 data "azurerm_key_vault_secret" "adfs_client_id" {

--- a/cloud/azure/templates/azure_saml_ses/main.tf
+++ b/cloud/azure/templates/azure_saml_ses/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azurerm = {
       source  = "azurerm"
-      version = ">=2.99"
+      version = "3.0.2"
     }
     random = {}
   }

--- a/cloud/deploys/dev_azure/main.tf
+++ b/cloud/deploys/dev_azure/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azurerm = {
       source  = "azurerm"
-      version = ">=2.99"
+      version = "3.0.2"
     }
     random = {}
   }


### PR DESCRIPTION
Also pinning the provider version and letting renovatebot manage it so we won't get unexpected changes like this again.
https://github.com/hashicorp/terraform-provider-azurerm/blob/4bea503e4bce5978f9b822fb9eb32b45de70d89f/website/docs/guides/3.0-upgrade-guide.html.markdown