### PR TITLE
Ignore updates to Java version used in Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "ignoreDeps": ["bellsoft/liberica-openjdk-alpine", "adoptopenjdk/openjdk11"],
   "packageRules": [
     {
       "groupName": "autovalue", 


### PR DESCRIPTION
Ignore updates to Java images being used in Dockerfiles until Play framework supports later Java versions.
See: https://github.com/seattle-uat/civiform/issues/2156