### PR TITLE
Check if the keyvault already exists before creating 

### DIFF
--- a/cloud/azure/bin/lib/key_vault.sh
+++ b/cloud/azure/bin/lib/key_vault.sh
@@ -22,6 +22,18 @@ function key_vault::create_vault() {
 }
 
 #######################################
+# Check if key vault exists
+# Arguments:
+#   1: The resource group name for the key vault
+#   2: The name of the key vault 
+#######################################
+function key_vault::check_if_vault_exists() {
+  az keyvault show \
+    --name "${2}" \
+    --resource-group "${1}"
+}
+
+#######################################
 # Assign the role 'Key Vault Secrets officer' to the current user
 # Arguments:
 #   1. The resource group to scope the role assignment to

--- a/cloud/azure/bin/setup-keyvault
+++ b/cloud/azure/bin/setup-keyvault
@@ -35,8 +35,12 @@ fi
 echo "Creating resource group ${resource_group}"
 azure::create_resource_group "${resource_group}" "${location}"
 
-echo "Creating key vault ${vault_name}"
-key_vault::create_vault "${resource_group}" "${location}" "${vault_name}"
+if key_vault::check_if_vault_exists "${resource_group}" "${vault_name}"; then
+  echo "Key vault ${vault_name} already exists in resource group ${resource_group}"
+else
+  echo "Creating key vault ${vault_name}"
+  key_vault::create_vault "${resource_group}" "${location}" "${vault_name}"
+fi
 
 echo "Adding key vault secrets officer role to signed in user"
 key_vault::assign_secrets_officer_role_to_user "${resource_group}"


### PR DESCRIPTION
(otherwise re-running the script fails)

### Description
Use the azure cli to test if the keyvault already exists before attempting to recreate it. 

If your deploy setup fails partway through, trying to re-create an already existing keyvault returns an error and causes the script to fail.