### PR TITLE
Adding visual indicator of whether a question is required or optional

### DIFF
--- a/browser-test/src/program_deep_link.test.ts
+++ b/browser-test/src/program_deep_link.test.ts
@@ -50,7 +50,7 @@ describe('navigating to a deep link', () => {
     // Assert
     await page.click('#continue-application-button')
     expect(await page.innerText('.cf-applicant-question-text')).toEqual(
-      questionText
+      questionText + "*"
     )
 
     await logout(page)
@@ -64,7 +64,7 @@ describe('navigating to a deep link', () => {
     // Assert
     await page.click('#continue-application-button')
     expect(await page.innerText('.cf-applicant-question-text')).toEqual(
-      questionText
+      questionText + "*"
     )
 
     await endSession(browser)

--- a/universal-application-tool-0.0.1/app/services/MessageKey.java
+++ b/universal-application-tool-0.0.1/app/services/MessageKey.java
@@ -43,6 +43,7 @@ public enum MessageKey {
   CONTENT_GET_BENEFITS("content.benefits"),
   CONTENT_LOGIN_PROMPT("content.loginPrompt"),
   CONTENT_LOGIN_PROMPT_ALTERNATIVE("content.alternativeLoginPrompt"),
+  CONTENT_OPTIONAL_QUESTION_TEXT("content.optionalQuestionText"),
   CONTENT_OR("content.or"),
   CONTENT_PLEASE_CREATE_ACCOUNT("content.pleaseCreateAccount"),
   CONTENT_SELECT_LANGUAGE("label.selectLanguage"),

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -2,6 +2,7 @@ package views.questiontypes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.span;
 
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
@@ -52,11 +53,7 @@ public abstract class ApplicantQuestionRenderer {
     ContainerTag questionTextDiv =
         div()
             // Question text
-            .with(
-                div()
-                    .withClasses(
-                        ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT)
-                    .with(TextFormatter.createLinksAndEscapeText(question.getQuestionText())))
+            .with(createQuestionTextTag())
             // Question help text
             .with(
                 div()
@@ -84,5 +81,20 @@ public abstract class ApplicantQuestionRenderer {
         .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
         .with(questionTextDiv)
         .with(questionFormContent);
+  }
+
+  private ContainerTag createQuestionTextTag() {
+    ContainerTag containerTag =
+        div()
+            .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT)
+            .with(TextFormatter.createLinksAndEscapeText(question.getQuestionText()));
+
+    if (!question.isOptional()) {
+      containerTag.with(span("*").withClasses(Styles.P_1, Styles.TEXT_RED_600));
+    } else {
+      containerTag.with(span("(optional)").withClass(Styles.P_1));
+    }
+
+    return containerTag;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -53,7 +53,7 @@ public abstract class ApplicantQuestionRenderer {
     ContainerTag questionTextDiv =
         div()
             // Question text
-            .with(createQuestionTextTag())
+            .with(createQuestionTextTag(messages))
             // Question help text
             .with(
                 div()
@@ -83,7 +83,7 @@ public abstract class ApplicantQuestionRenderer {
         .with(questionFormContent);
   }
 
-  private ContainerTag createQuestionTextTag() {
+  private ContainerTag createQuestionTextTag(Messages messages) {
     ContainerTag containerTag =
         div()
             .withClasses(ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT)
@@ -92,7 +92,9 @@ public abstract class ApplicantQuestionRenderer {
     if (!question.isOptional()) {
       containerTag.with(span("*").withClasses(Styles.P_1, Styles.TEXT_RED_600));
     } else {
-      containerTag.with(span("(optional)").withClass(Styles.P_1));
+      containerTag.with(
+          span(messages.at(MessageKey.CONTENT_OPTIONAL_QUESTION_TEXT.getKeyName()))
+              .withClass(Styles.P_1));
     }
 
     return containerTag;

--- a/universal-application-tool-0.0.1/conf/messages
+++ b/universal-application-tool-0.0.1/conf/messages
@@ -90,6 +90,9 @@ button.skipFileUpload=Skip
 # The text on the button an applicant clicks to upload a file and continue to the next screen.
 button.upload=Upload
 
+# The text shown next to a question indicating that it is optional
+content.optionalQuestionText=(optional)
+
 # A toast message that displays when a program is not fully localized to the applicant's preferred locale.
 toast.localeNotSupported=We''re sorry, this program is not fully translated to your preferred language.
 

--- a/universal-application-tool-0.0.1/conf/messages.en-US
+++ b/universal-application-tool-0.0.1/conf/messages.en-US
@@ -18,6 +18,7 @@ button.review=Review
 button.skipFileUpload=Skip
 button.submit=Submit
 button.upload=Upload
+content.optionalQuestionText=(optional)
 footer.supportLinkDescription=For technical support, contact
 toast.localeNotSupported=We''re sorry, this program is not fully translated to English.
 toast.programCompleted=Application was already completed.


### PR DESCRIPTION
Showing whether or not a question is required by adding an asterisk or optional text at the end of the question.

### Description
Moved the creation of the question text div into it's own method. Adding either an asterisk or optional text based on how the question is configured. The optional text pulls from messages so it can be localized.

Sample of rendered questions:

![image](https://user-images.githubusercontent.com/195162/161313870-c40f4334-d343-44db-ba63-d254451125ee.png)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1423
