### PR TITLE
Open external links in a new tab

### DIFF
--- a/universal-application-tool-0.0.1/app/views/components/TextFormatter.java
+++ b/universal-application-tool-0.0.1/app/views/components/TextFormatter.java
@@ -78,7 +78,9 @@ public class TextFormatter {
       contentBuilder.add(
           a().withText(url.getOriginalUrl())
               .withHref(url.getFullUrl())
-              .withClasses(Styles.OPACITY_75));
+              .withClasses(Styles.OPACITY_75)
+              .withTarget("_blank"));
+
       content = content.substring(index + url.getOriginalUrl().length());
     }
     // If there's content leftover, add it.


### PR DESCRIPTION
### Description
Set the target to blank where urls are being created.

This would will open all links made this way in a new tab. So I've swapped my problem. I want to keep links to pages within the application still opening in the same tab.

There are two ways I'm thinking of doing this

1) See if the url starts with a forward slash. That looks like that would be a good indicator of a relative link. I could also see if the url starts with http|https as a cue for an external link, it's probably fine just looking at those. It's probably very unlikely that ftp or another scheme would be used. I'd prefer this route, but I'm not sure if I can guarantee all internal app links would have relative paths.

2) Use the hostname to determine if a link is internal or external. If the link starts with the hostname it's internal otherwise it's external. I don't know if getting the hostname is accessible to the method already.


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2128 
