### PR TITLE
Adding in robots.txt. Hard-coded in controller action for now.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/HomeController.java
+++ b/universal-application-tool-0.0.1/app/controllers/HomeController.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.play.java.Secure;
+import play.Environment;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Controller;
@@ -25,17 +26,20 @@ public class HomeController extends Controller {
   private final ProfileUtils profileUtils;
   private final MessagesApi messagesApi;
   private final HttpExecutionContext httpExecutionContext;
+  private final Environment environment;
 
   @Inject
   public HomeController(
       LoginForm form,
       ProfileUtils profileUtils,
       MessagesApi messagesApi,
-      HttpExecutionContext httpExecutionContext) {
+      HttpExecutionContext httpExecutionContext,
+      Environment environment) {
     this.loginForm = checkNotNull(form);
     this.profileUtils = checkNotNull(profileUtils);
     this.messagesApi = checkNotNull(messagesApi);
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
+    this.environment = checkNotNull(environment);
   }
 
   public CompletionStage<Result> index(Http.Request request) {
@@ -80,6 +84,18 @@ public class HomeController extends Controller {
   public Result loginForm(Http.Request request, Optional<String> message)
       throws TechnicalException {
     return ok(loginForm.render(request, messagesApi.preferred(request), message));
+  }
+
+  public Result robotsTxt() {
+    if (environment.isProd()) {
+      return ok("User-agent: *\n" +
+              "Allow: /$\n" +
+              "Allow: /loginForm$\n" +
+              "Disallow: /\n");
+    } else {
+      return ok("User-agent: *\n" +
+              "Disallow: /\n");
+    }
   }
 
   public Result playIndex() {

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -9,6 +9,7 @@ GET /*path/ controllers.UntrailingController.untrail(path: String)
 GET     /                           controllers.HomeController.index(request: Request)
 GET     /playIndex                  controllers.HomeController.playIndex()
 GET     /securePlayIndex            controllers.HomeController.securePlayIndex()
+GET     /robots.txt                 controllers.HomeController.robotsTxt()
 
 # A controller for pages for an admin to create and maintain programs
 GET     /admin/programs                                         controllers.admin.AdminProgramController.index(request: Request)


### PR DESCRIPTION
### Description
I want control indexing by search engines, but maybe I'm overthinking the problem. 

Currently I have it set to have the robots.txt deny indexing of all pages, except if the site is prod then to allow indexing / and the loginForm page. The values are hard-coded in the controller action since I'm not sure where best to put them.

I figure this will block indexing for any staging sites, but still allow some indexing for prod for SEO purposes. I don't think we want to have bots indexing past the login page. Especially in the event they manage to successfully continue as a guest.

If we want to just block all indexing no matter the environment I'll just switch this to a static asset file and drop the controller action.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2252 
