### PR TITLE
Fix behavior of discardDraft(Question) to remove silent creation of invalid data.

### DIFF
--- a/browser-test/src/question_delete.test.ts
+++ b/browser-test/src/question_delete.test.ts
@@ -25,10 +25,15 @@ describe('deleting question lifecycle', () => {
       'qlc program description',
       [onlyUsedQuestion]
     )
-    await adminQuestions.discardDraft(questions[1])
     await adminPrograms.publishProgram(programName)
     await adminQuestions.expectActiveQuestionExist(onlyUsedQuestion)
-    await adminQuestions.expectActiveQuestionNotExist(questions[1])
+
+    // Make a Draft then discard it.
+    await adminQuestions.createNewVersion(questions[1])
+    await adminQuestions.expectDraftQuestionExist(questions[1])
+    await adminQuestions.discardDraft(questions[1])
+    await adminQuestions.expectActiveQuestionExist(questions[1])
+    // Archive, unarchive, archive all other questions.
     for (let i = 2; i < questions.length; i++) {
       await adminQuestions.expectActiveQuestionExist(questions[i])
       await adminQuestions.archiveQuestion(questions[i])
@@ -36,6 +41,7 @@ describe('deleting question lifecycle', () => {
       await adminQuestions.expectActiveQuestionExist(questions[i])
       await adminQuestions.archiveQuestion(questions[i])
     }
+    // Publish all the above changes.
     await adminPrograms.createNewVersion(programName)
     await adminPrograms.publishProgram(programName)
     await adminQuestions.expectActiveQuestionExist(onlyUsedQuestion)

--- a/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/QuestionRepository.java
@@ -106,7 +106,7 @@ public class QuestionRepository {
    * Update DRAFT and ACTIVE questions that reference {@code oldEnumeratorId} to reference {@code
    * newEnumeratorId}.
    */
-  private void updateAllRepeatedQuestions(long newEnumeratorId, long oldEnumeratorId) {
+  public void updateAllRepeatedQuestions(long newEnumeratorId, long oldEnumeratorId) {
     // TODO: This seems error prone as a question could be present as a DRAFT and ACTIVE.
     // Investigate further.
     Stream.concat(

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -2,6 +2,7 @@ package services.question;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -126,27 +127,39 @@ public final class QuestionServiceImpl implements QuestionService {
   }
 
   @Override
-  public void discardDraft(Long id) throws InvalidUpdateException {
-    Optional<Question> question =
-        questionRepository.lookupQuestion(id).toCompletableFuture().join();
-    if (question.isEmpty()) {
-      throw new InvalidUpdateException("Did not find question.");
-    }
+  public void discardDraft(Long draftId) throws InvalidUpdateException {
+    Question question =
+        questionRepository
+            .lookupQuestion(draftId)
+            .toCompletableFuture()
+            .join()
+            .orElseThrow(() -> new InvalidUpdateException("Did not find question."));
+
+    // Find the Active version.
+    Version activeVersion = versionRepositoryProvider.get().getActiveVersion();
+    long activeId =
+        activeVersion
+            .getQuestionByName(question.getQuestionDefinition().getName())
+            .orElseThrow()
+            .id;
+    Preconditions.checkArgument(
+        !draftId.equals(activeId),
+        "Draft and Active IDs are the same ({}) for Question {}, this should not be possible.",
+        draftId,
+        question.getQuestionDefinition().getName());
+
     Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
-    if (!question.get().removeVersion(draftVersion)) {
+    if (!question.removeVersion(draftVersion)) {
       throw new InvalidUpdateException("Did not find question in draft version.");
     }
-    question.get().save();
+    question.save();
 
     // Update any repeated questions that may have referenced the discarded question.
-    Version activeVersion = versionRepositoryProvider.get().getActiveVersion();
-    Optional<Question> activeQuestion =
-        activeVersion.getQuestionByName(question.get().getQuestionDefinition().getName());
     questionRepository.updateAllRepeatedQuestions(
-        /* newEnumeratorId= */ activeQuestion.get().id, /* oldEnumeratorId= */ id);
+        /* newEnumeratorId= */ activeId, /* oldEnumeratorId= */ draftId);
 
     // Update any programs that may have referenced the discarded question.
-    versionRepositoryProvider.get().updateProgramsThatReferenceQuestion(id);
+    versionRepositoryProvider.get().updateProgramsThatReferenceQuestion(draftId);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -141,7 +141,10 @@ public final class QuestionServiceImpl implements QuestionService {
         activeVersion
             .getQuestionByName(question.getQuestionDefinition().getName())
             // TODO: If nothing depends on this question then it could be removed.
-            .orElseThrow(() -> new InvalidUpdateException("Deleting the first version of a question is not supported."))
+            .orElseThrow(
+                () ->
+                    new InvalidUpdateException(
+                        "Deleting the first version of a question is not supported."))
             .id;
     Preconditions.checkArgument(
         !draftId.equals(activeId),

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -137,10 +137,11 @@ public final class QuestionServiceImpl implements QuestionService {
 
     // Find the Active version.
     Version activeVersion = versionRepositoryProvider.get().getActiveVersion();
-    long activeId =
+    Long activeId =
         activeVersion
             .getQuestionByName(question.getQuestionDefinition().getName())
-            .orElseThrow()
+            // TODO: If nothing depends on this question then it could be removed.
+            .orElseThrow(() -> new InvalidUpdateException("Deleting the first version of a question is not supported."))
             .id;
     Preconditions.checkArgument(
         !draftId.equals(activeId),

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -137,6 +137,15 @@ public final class QuestionServiceImpl implements QuestionService {
       throw new InvalidUpdateException("Did not find question in draft version.");
     }
     question.get().save();
+
+    // Update any repeated questions that may have referenced the discarded question.
+    Version activeVersion = versionRepositoryProvider.get().getActiveVersion();
+    Optional<Question> activeQuestion =
+        activeVersion.getQuestionByName(question.get().getQuestionDefinition().getName());
+    questionRepository.updateAllRepeatedQuestions(
+        /* newEnumeratorId= */ activeQuestion.get().id, /* oldEnumeratorId= */ id);
+
+    // Update any programs that may have referenced the discarded question.
     versionRepositoryProvider.get().updateProgramsThatReferenceQuestion(id);
   }
 

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -202,7 +202,8 @@ public class QuestionServiceImplTest extends ResetPostgres {
             .getSampleQuestionsForAllTypes()
             .get(QuestionType.ENUMERATOR)
             .getQuestionDefinition();
-    long enumeratorDraftId = enumeratorQuestion.getId() + 100000;
+    long enumeratorActiveId = enumeratorQuestion.getId();
+    long enumeratorDraftId = enumeratorActiveId + 100000;
 
     testQuestionBank.maybeSave(
         new QuestionDefinitionBuilder(enumeratorQuestion).setId(enumeratorDraftId).build(),
@@ -221,9 +222,7 @@ public class QuestionServiceImplTest extends ResetPostgres {
     Optional<Question> dependentDraft =
         versionRepository.getDraftVersion().getQuestionByName(dependentQuestion.getName());
     assertThat(dependentDraft).isPresent();
-    // TODO(#2249): This should actually have been updated to a valid id, and not still be the one
-    // that was discarded.
     assertThat(dependentDraft.get().getQuestionDefinition().getEnumeratorId().get())
-        .isEqualTo(enumeratorDraftId);
+        .isEqualTo(enumeratorActiveId);
   }
 }


### PR DESCRIPTION
### Description
1. Fixes discardDraft to also update Questions that reference the discarded draft, and prevents discarding the very first draft.

The code already handled programs but didn't account for enumeration references which leaves those in an invalid state.

2. The behavior of non-existent -> DRAFT -> discard was allowable on all drafts and largely undefined.  This could create invalid state if the draft was referenced before discard.  EG programs or enumerated questions if one referenced the discard question.

The code now disallows discarding the very first draft (through exception) rather than allowing invalid state to be silently created. We can allow it in the future but it'd be more complicate code, as we would have to detect tif he situation is or is not permissible.  

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2249 