### PR TITLE
Validate all name inputs

### DIFF
--- a/browser-test/src/name.test.ts
+++ b/browser-test/src/name.test.ts
@@ -1,0 +1,270 @@
+import { Page } from 'playwright'
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  resetSession,
+  selectApplicantLanguage,
+  startSession,
+} from './support'
+
+const NAME_FIRST = ".cf-name-first";
+const NAME_LAST = ".cf-name-last";
+
+describe('name applicant flow', () => {
+  let pageObject: Page
+
+  beforeAll(async () => {
+    const { page } = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single required name question', () => {
+    let applicantQuestions: ApplicantQuestions
+    const programName = 'test program for single name'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addNameQuestion({
+        questionName: 'name-test-q',
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+          ['name-test-q'],
+          programName
+      )
+      debugger;
+      await logout(pageObject)
+    })
+
+    it('does not show errors initially', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion(
+          '',
+          '',
+          '',
+      )
+      let error = await pageObject.$(`${NAME_FIRST}-error`)
+      expect(await error?.isHidden()).toEqual(true)
+      error = await pageObject.$(`${NAME_LAST}-error`)
+      expect(await error?.isHidden()).toEqual(true)
+    })
+
+    it('with valid name does submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion(
+          'Tommy',
+          'Pickles',
+          '',
+      )
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with empty name does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion('', '', '')
+      await applicantQuestions.clickNext()
+
+      let error = await pageObject.$(`${NAME_FIRST}-error`)
+      expect(await error?.isHidden()).toEqual(false)
+      error = await pageObject.$(`${NAME_LAST}-error`)
+      expect(await error?.isHidden()).toEqual(false)
+    })
+  })
+
+  describe('multiple name questions', () => {
+    let applicantQuestions: ApplicantQuestions
+    const programName = 'test program for multiple names'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addNameQuestion({
+        questionName: 'name-test-a-q',
+      })
+      await adminQuestions.addNameQuestion({
+        questionName: 'name-test-b-q',
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+          ['name-test-a-q', 'name-test-b-q'],
+          programName
+      )
+
+      await logout(pageObject)
+    })
+
+    it('with valid name does submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion(
+          'Tommy',
+          'Pickles',
+          '',
+          0
+      )
+      await applicantQuestions.answerNameQuestion(
+          'Chuckie',
+          'Finster',
+          '',
+          1
+      )
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with first invalid does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion('', '', '', 0)
+      await applicantQuestions.answerNameQuestion(
+          'Chuckie',
+          'Finster',
+          '',
+          1
+      )
+      await applicantQuestions.clickNext()
+
+      // First question has errors.
+      let error = await pageObject.$(`${NAME_FIRST}-error >> nth=0`)
+      expect(await error?.isHidden()).toEqual(false)
+      error = await pageObject.$(`${NAME_LAST}-error >> nth=0`)
+      expect(await error?.isHidden()).toEqual(false)
+
+      // Second question has no errors.
+      error = await pageObject.$(`${NAME_FIRST}-error >> nth=1`)
+      expect(await error?.isHidden()).toEqual(true)
+      error = await pageObject.$(`${NAME_LAST}-error >> nth=1`)
+      expect(await error?.isHidden()).toEqual(true)
+    })
+
+    it('with second invalid does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion(
+          'Tommy',
+          'Pickles',
+          '',
+          0
+      )
+      await applicantQuestions.answerNameQuestion('', '', '', 1)
+      await applicantQuestions.clickNext()
+
+      // First question has no errors.
+      let error = await pageObject.$(`${NAME_FIRST}-error >> nth=0`)
+      expect(await error?.isHidden()).toEqual(true)
+      error = await pageObject.$(`${NAME_LAST}-error >> nth=0`)
+      expect(await error?.isHidden()).toEqual(true)
+
+      // Second question has errors.
+      error = await pageObject.$(`${NAME_FIRST}-error >> nth=1`)
+      expect(await error?.isHidden()).toEqual(false)
+      error = await pageObject.$(`${NAME_LAST}-error >> nth=1`)
+      expect(await error?.isHidden()).toEqual(false)
+    })
+  })
+
+  // One optional name followed by one required name.
+  describe('optional name question', () => {
+    let applicantQuestions: ApplicantQuestions
+    const programName = 'test program for optional name'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addNameQuestion({
+        questionName: 'name-test-optional-q',
+      })
+      await adminQuestions.addNameQuestion({
+        questionName: 'name-test-required-q',
+      })
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          ['name-test-required-q'],
+          'name-test-optional-q'
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with valid required name does submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerNameQuestion(
+          'Tommy',
+          'Pickles',
+          '',
+          1
+      )
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    describe('with invalid required name', () => {
+      beforeEach(async () => {
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
+
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerNameQuestion('', '', '', 1)
+        await applicantQuestions.clickNext()
+      })
+
+      it('does not submit', async () => {
+        // Second question has errors.
+        let error = await pageObject.$(`${NAME_FIRST}-error >> nth=1`)
+        expect(await error?.isHidden()).toEqual(false)
+        error = await pageObject.$(`${NAME_LAST}-error >> nth=1`)
+        expect(await error?.isHidden()).toEqual(false)
+      })
+
+      it('optional has no errors', async () => {
+        // First question has no errors.
+        let error = await pageObject.$(`${NAME_FIRST}-error >> nth=0`)
+        expect(await error?.isHidden()).toEqual(true)
+        error = await pageObject.$(`${NAME_LAST}-error >> nth=0`)
+        expect(await error?.isHidden()).toEqual(true)
+      })
+    })
+  })
+})

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -48,11 +48,12 @@ export class ApplicantQuestions {
   async answerNameQuestion(
     firstName: string,
     lastName: string,
-    middleName = ''
+    middleName = '',
+    index = 0
   ) {
-    await this.page.fill('.cf-name-first input', firstName)
-    await this.page.fill('.cf-name-middle input', middleName)
-    await this.page.fill('.cf-name-last input', lastName)
+    await this.page.fill(`.cf-name-first input >> nth=${index}`, firstName)
+    await this.page.fill(`.cf-name-middle input >> nth=${index}`, middleName)
+    await this.page.fill(`.cf-name-last input >> nth=${index}`, lastName)
   }
 
   async checkNameQuestionValue(

--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -486,7 +486,7 @@ class ValidationController {
 
   /** Validates that first and last name are not empty. */
   validateNameQuestion(): boolean {
-    let isValid = true
+    let isAllValid = true
     const nameQuestions = Array.from(
       document.querySelectorAll(ValidationController.NAME_QUESTION_CLASS)
     )
@@ -518,10 +518,10 @@ class ValidationController {
       const emptyOptional =
         isOptional && firstNameEmpty && lastNameEmpty && middleNameEmpty
 
-      // TODO: Fix bug where only the last questions validity is used.
-      isValid = emptyOptional || (!firstNameEmpty && !lastNameEmpty)
+      let isValid = emptyOptional || (!firstNameEmpty && !lastNameEmpty)
+      isAllValid = isValid && isAllValid
     }
-    return isValid
+    return isAllValid
   }
 
   /** Validates that numbers are positive integers. */


### PR DESCRIPTION
### Description
Causes `validateNameQuestion() to fail if any of the name inputs are invalid. Previously, only the last name input determined whether the question was valid. See `with first invalid does not submit` test as an example.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1693 
