### PR TITLE
Make dev secret generation a little easier

### DIFF
--- a/cloud/azure/bin/lib/key_vault.sh
+++ b/cloud/azure/bin/lib/key_vault.sh
@@ -70,8 +70,14 @@ function key_vault::add_secret_from_input() {
   local SECRET
   echo "Please enter the value for ${2}: "
   read -s SECRET
+
+  while [[ -z "$SECRET" ]]; do
+    printf '%s\n' "No input entered"
+    read -s SECRET
+  done
+
   unset REPLY
-  key_vault::add_secret "${1}" "${2}" "${SECRET}"  
+  key_vault::add_secret "${1}" "${2}" "${SECRET}"
   echo "Stored secret value for ${2} in key vault ${1}"
 }
 

--- a/cloud/azure/bin/lib/storage.sh
+++ b/cloud/azure/bin/lib/storage.sh
@@ -73,3 +73,18 @@ function storage::upload_blob {
     --file "${3}" \
     --overwrite "true"
 }
+
+
+#######################################
+# Succeeds if the blob exists in the container
+# Arguments:
+#   1: The storage account name
+#   2. The name of the container 
+#   3: The name of the file 
+#######################################
+function storage::has_blob {
+  az storage blob exists \
+    --account-name "${1}" \
+    --container-name "${2}" \
+    --name "${3}" 
+}

--- a/cloud/azure/bin/setup-keyvault
+++ b/cloud/azure/bin/setup-keyvault
@@ -46,23 +46,37 @@ echo "Adding key vault secrets officer role to signed in user"
 key_vault::assign_secrets_officer_role_to_user "${resource_group}"
 
 echo "Generating and setting secrets"
-key_vault::add_generated_secrets \
-  "${vault_name}" \
-  "${POSTGRES_PASSWORD_NAME}" \
-  "${APP_SECRET_KEY_NAME}" \
+if key_vault::has_secret "${vault_name}" "${POSTGRES_PASSWORD_NAME}"; then
+  echo "Key ${POSTGRES_PASSWORD_NAME} exists in the secret store"
+else
+  key_vault::add_generated_secrets \
+    "${vault_name}" \
+    "${POSTGRES_PASSWORD_NAME}"
+fi
+
+if key_vault::has_secret "${vault_name}" "${APP_SECRET_KEY_NAME}"; then
+  echo "Key ${APP_SECRET_KEY_NAME} exists in the secret store"
+else
+  key_vault::add_generated_secrets \
+    "${vault_name}" \
+    "${APP_SECRET_KEY_NAME}"
+fi
 
 echo "Adding placeholder values for secrets we set later"
-key_vault::add_secret \
-  "${vault_name}" \
-  "${ADFS_SECRET_NAME}" \
-  "${TEMPORARY_SECRET}"
+if key_vault::has_secret "${vault_name}" "${ADFS_SECRET_NAME}"; then
+  echo "Key ${ADFS_SECRET_NAME} exists in the secret store"
+else
+  key_vault::add_secret \
+    "${vault_name}" \
+    "${ADFS_SECRET_NAME}" \
+    "${TEMPORARY_SECRET}"
+fi
 
-key_vault::add_secret \
-  "${vault_name}" \
-  "${ADFS_CLIENT_ID}" \
-  "${TEMPORARY_SECRET}"
-
-key_vault::add_secret \
-  "${vault_name}" \
-  "${ADFS_DISCOVERY_URI}" \
-  "${TEMPORARY_SECRET}"
+if key_vault::has_secret "${vault_name}" "${ADFS_DISCOVERY_URI}"; then
+  echo "Key ${ADFS_DISCOVERY_URI} exists in the secret store"
+else
+  key_vault::add_secret \
+    "${vault_name}" \
+    "${ADFS_DISCOVERY_URI}" \
+    "${TEMPORARY_SECRET}"
+fi

--- a/cloud/azure/bin/setup-saml-keystore
+++ b/cloud/azure/bin/setup-saml-keystore
@@ -4,9 +4,10 @@ source "cloud/azure/bin/lib.sh"
 
 readonly KEYSTORE_CONTAINER_NAME="saml-keystore"
 readonly KEYSTORE_FILENAME="civiformSamlKeystore.jks"
+readonly SERVICE_CERT="serviceProvider.cert"
 readonly KEYSTORE_PASS_SECRET_NAME="saml-keystore-pass"
 
-# DOC: Generate PKCS12 keystore and upload to Azure Blob Storage. 
+# DOC: Generate PKCS12 keystore and upload to Azure Blob Storage.
 # DOC: Make sure to run the key_vault_setup script before running this one.
 # DOC: Required flags are:
 # DOC: g - Azure resource group
@@ -38,6 +39,14 @@ if [[ ! "${resource_group}" ]] \
   exit 1
 fi
 
+if key_vault::has_secret "${vault_name}" "${KEYSTORE_PASS_SECRET_NAME}" &&
+  storage::has_blob "${storage_account_name}" \
+    "${KEYSTORE_CONTAINER_NAME}" \
+    "${KEYSTORE_FILENAME}"; then
+  echo "SAML keystore already exists"
+  exit 0
+fi
+
 echo "Assign the role 'Storage Blob Data Contributor' to the current user"
 storage::assign_storage_blob_data_contributor_role_to_user "${resource_group}"
 
@@ -46,12 +55,12 @@ azure::create_resource_group "${resource_group}" "${location}"
 
 echo "Creating container ${KEYSTORE_CONTAINER_NAME} in account ${storage_account_name}"
 storage::create_storage_account "${resource_group}" "${location}" "${storage_account_name}"
-storage::create_storage_container "${storage_account_name}" ${KEYSTORE_CONTAINER_NAME}
+storage::create_storage_container "${storage_account_name}" "${KEYSTORE_CONTAINER_NAME}"
 
-echo "Generating and storing keystore password"
+echo "Generating and storing saml keystore password"
 key_vault::add_generated_secrets "${vault_name}" "${KEYSTORE_PASS_SECRET_NAME}"
 
-echo "Generating keystore file"
+echo "Generating saml keystore file"
 # PKCS12 keys require the keypass and storepass to be the same, so we'll only use one secret here.
 KEYSTORE_PASS=$(key_vault::get_secret_value "${vault_name}"  "${KEYSTORE_PASS_SECRET_NAME}")
 # This step is interactive but can be parametrized and automated if necessary.
@@ -63,7 +72,7 @@ keytool -genkeypair \
     -keyalg RSA -keysize 2048 -validity 3650
 
 echo "Uploading keystore file"
-storage::upload_blob "${storage_account_name}" ${KEYSTORE_CONTAINER_NAME} "civiformSamlKeystore.jks"
+storage::upload_blob "${storage_account_name}" "${KEYSTORE_CONTAINER_NAME}" "${KEYSTORE_FILENAME}"
 
 echo "Printing public certificate."
 keytool -exportcert \
@@ -71,15 +80,15 @@ keytool -exportcert \
   -keystore "${KEYSTORE_FILENAME}" \
   -storepass "${KEYSTORE_PASS}" \
   -rfc \
-  -file "serviceProvider.cert"
+  -file "${SERVICE_CERT}"
 
 # The cert printed here should be copied and pasted into Service Provider Certificate
 # field when configuring the identity provider (e.g. LoginRadius)
 printf "\n\n"
-cat "serviceProvider.cert"
+cat "${SERVICE_CERT}"
 printf "\n\n"
 
 echo "Cleaning up certificate and keystore files"
-rm "${KEYSTORE_FILENAME}" "serviceProvider.cert"
+rm "${KEYSTORE_FILENAME}" "${SERVICE_CERT}"
 echo "Copy the certificate above into the Service Provider Certificate field when configuring the SAML Identity Provider"
 read -rsp 'Press any key to continue...' -n1

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -73,9 +73,9 @@ class Setup:
     def _input_to_keystore(self, secret_id):
         key_vault_name = self.config.get_config_var("KEY_VAULT_NAME")
         subprocess.run([
-            "cloud/azure/bin/input-secrets-to-keystore", 
-            "-k", key_vault_name, 
-            "-s", secret_id], 
+            "cloud/azure/bin/input-secrets-to-keystore",
+            "-k", key_vault_name,
+            "-s", secret_id],
             check=True)
     
     def _setup_resource_group(self): 
@@ -89,8 +89,8 @@ class Setup:
         self.resource_group = resource_group
         self.resource_group_location = resource_group_location
 
-    def _create_ssh_keyfile(self): 
-        subprocess.run(["/bin/bash", 
+    def _create_ssh_keyfile(self):
+        subprocess.run(["/bin/bash",
             "-c", "ssh-keygen -q -t rsa -b 4096 -N '' -f $HOME/.ssh/bastion <<< y"
         ], check=True)
     
@@ -106,39 +106,39 @@ class Setup:
                 "cloud/azure/bin/setup_tf_shared_state",
                 f"{self.config.get_template_dir()}/{self.config.backend_vars_filename}"
             ], check=True)
-    
-    def _setup_keyvault(self): 
-        if not self.resource_group: 
+
+    def _setup_keyvault(self):
+        if not self.resource_group:
             raise RuntimeError("Resource group required")
         key_vault_name = self.config.get_config_var("KEY_VAULT_NAME")
         subprocess.run([
-            "cloud/azure/bin/setup-keyvault", 
-            "-g", self.resource_group, 
+            "cloud/azure/bin/setup-keyvault",
+            "-g", self.resource_group,
             "-v", key_vault_name, "-l", self.resource_group_location
         ], check=True)
         self.key_vault_name = key_vault_name
-    
-    def _setup_saml_keystore(self): 
-        if not self.resource_group: 
+
+    def _setup_saml_keystore(self):
+        if not self.resource_group:
             raise RuntimeError("Resource group required")
-        if not self.key_vault_name: 
-            raise RuntimeError("Key Vault Setup Required")
-        
+        if not self.key_vault_name:
+            raise RuntimeError("Key Vault Name Required")
+
         saml_keystore_storage_account = self.config.get_config_var("SAML_KEYSTORE_ACCOUNT_NAME")
         subprocess.run([
             "cloud/azure/bin/setup-saml-keystore",
-            "-g", self.resource_group, 
-            "-v", self.key_vault_name, 
-            "-l", self.resource_group_location, 
+            "-g", self.resource_group,
+            "-v", self.key_vault_name,
+            "-l", self.resource_group_location,
             "-s", saml_keystore_storage_account
         ], check=True)
-    
-    def _setup_ses(self): 
-        if not self.key_vault_name: 
+
+    def _setup_ses(self):
+        if not self.key_vault_name:
             raise RuntimeError("Key Vault Setup Required")
         aws_username = self.config.get_config_var("AWS_USERNAME")
         subprocess.run([
-            "cloud/azure/bin/ses-to-keyvault", 
+            "cloud/azure/bin/ses-to-keyvault",
             "-v", self.key_vault_name,
             "-u", aws_username
         ], check=True)


### PR DESCRIPTION
### Description
Update the generation of secrets to be more resilient, and not re-generate secrets that already exist

-Allow the deploy script to be re-run to account for errors (without it re-creating the login radius cert or overriding set secrets)
-Don't accept blank lines for secrets
-Lint files

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
