### PR TITLE
Validate all file upload inputs

### DIFF
--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -1,15 +1,15 @@
 import {
-    AdminPrograms,
-    AdminQuestions,
-    ApplicantQuestions,
-    loginAsAdmin,
-    loginAsGuest,
-    logout,
-    resetSession,
-    selectApplicantLanguage,
-    startSession,
-  } from './support'
-  
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  resetSession,
+  selectApplicantLanguage,
+  startSession,
+} from './support'
+
 describe('file upload applicant flow', () => {
   let pageObject
 
@@ -115,7 +115,7 @@ describe('file upload applicant flow', () => {
       const error = await pageObject.$('.cf-fileupload-error')
       expect(await error.isHidden()).toEqual(false)
       await applicantQuestions.clickSkip()
-      
+
       await applicantQuestions.submitFromReviewPage(programName)
     })
 

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -1,0 +1,132 @@
+import {
+    AdminPrograms,
+    AdminQuestions,
+    ApplicantQuestions,
+    loginAsAdmin,
+    loginAsGuest,
+    logout,
+    resetSession,
+    selectApplicantLanguage,
+    startSession,
+  } from './support'
+  
+  describe('file upload applicant flow', () => {
+    let pageObject
+  
+    beforeAll(async () => {
+      const { page } = await startSession()
+      pageObject = page
+    })
+  
+    afterEach(async () => {
+      await resetSession(pageObject)
+    })
+  
+    describe('single file upload question', () => {
+      let applicantQuestions
+      const programName = 'test program for single file upload'
+  
+      beforeAll(async () => {
+        await loginAsAdmin(pageObject)
+        const adminQuestions = new AdminQuestions(pageObject)
+        const adminPrograms = new AdminPrograms(pageObject)
+        applicantQuestions = new ApplicantQuestions(pageObject)
+  
+        await adminQuestions.addFileUploadQuestion({
+          questionName: 'file-upload-test-q',
+        })
+        await adminPrograms.addAndPublishProgramWithQuestions(
+          ['file-upload-test-q'],
+          programName
+        )
+  
+        await logout(pageObject)
+      })
+  
+      it('does not show errors initially', async () => {
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
+  
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerFileUploadQuestion('file key')
+        const error = await pageObject.$('.cf-fileupload-error')
+        expect(await error.isHidden()).toEqual(true)
+      })
+  
+      it('with valid file does submit', async () => {
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
+  
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.answerFileUploadQuestion('file key')
+        await applicantQuestions.clickUpload()
+  
+        await applicantQuestions.submitFromReviewPage(programName)
+      })
+  
+      it('with no file does not submit', async () => {
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
+  
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickUpload()
+  
+        const error = await pageObject.$('.cf-fileupload-error')
+        expect(await error.isHidden()).toEqual(false)
+      })
+    })
+  
+    // Optional file upload.
+    describe('optional file upload question', () => {
+      let applicantQuestions
+      const programName = 'test program for optional file upload'
+  
+      beforeAll(async () => {
+        await loginAsAdmin(pageObject)
+        const adminQuestions = new AdminQuestions(pageObject)
+        const adminPrograms = new AdminPrograms(pageObject)
+        applicantQuestions = new ApplicantQuestions(pageObject)
+  
+        await adminQuestions.addFileUploadQuestion({
+          questionName: 'file-upload-test-optional-q',
+        })
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.editProgramBlockWithOptional(
+          programName,
+          'Optional question block',
+          [],
+          'file-upload-test-optional-q'
+        )
+        await adminPrograms.gotoAdminProgramsPage()
+        await adminPrograms.publishAllPrograms()
+  
+        await logout(pageObject)
+      })
+
+      it('with missing file can be skipped', async () => {
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
+
+        await applicantQuestions.applyProgram(programName)
+        // Initially clicking upload with no file provided generates
+        // an error. Then we click skip to ensure that the question
+        // is optional.
+        await applicantQuestions.clickUpload()
+        const error = await pageObject.$('.cf-fileupload-error')
+        expect(await error.isHidden()).toEqual(false)
+        await applicantQuestions.clickSkip()
+        
+        await applicantQuestions.submitFromReviewPage(programName)
+      })
+
+      it('can be skipped', async () => {
+        await loginAsGuest(pageObject)
+        await selectApplicantLanguage(pageObject, 'English')
+
+        await applicantQuestions.applyProgram(programName)
+        await applicantQuestions.clickSkip()
+        await applicantQuestions.submitFromReviewPage(programName)
+      })
+    })
+  })
+  

--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -10,123 +10,122 @@ import {
     startSession,
   } from './support'
   
-  describe('file upload applicant flow', () => {
-    let pageObject
-  
+describe('file upload applicant flow', () => {
+  let pageObject
+
+  beforeAll(async () => {
+    const { page } = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single file upload question', () => {
+    let applicantQuestions
+    const programName = 'test program for single file upload'
+
     beforeAll(async () => {
-      const { page } = await startSession()
-      pageObject = page
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addFileUploadQuestion({
+        questionName: 'file-upload-test-q',
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['file-upload-test-q'],
+        programName
+      )
+
+      await logout(pageObject)
     })
-  
-    afterEach(async () => {
-      await resetSession(pageObject)
+
+    it('does not show errors initially', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerFileUploadQuestion('file key')
+      const error = await pageObject.$('.cf-fileupload-error')
+      expect(await error.isHidden()).toEqual(true)
     })
-  
-    describe('single file upload question', () => {
-      let applicantQuestions
-      const programName = 'test program for single file upload'
-  
-      beforeAll(async () => {
-        await loginAsAdmin(pageObject)
-        const adminQuestions = new AdminQuestions(pageObject)
-        const adminPrograms = new AdminPrograms(pageObject)
-        applicantQuestions = new ApplicantQuestions(pageObject)
-  
-        await adminQuestions.addFileUploadQuestion({
-          questionName: 'file-upload-test-q',
-        })
-        await adminPrograms.addAndPublishProgramWithQuestions(
-          ['file-upload-test-q'],
-          programName
-        )
-  
-        await logout(pageObject)
-      })
-  
-      it('does not show errors initially', async () => {
-        await loginAsGuest(pageObject)
-        await selectApplicantLanguage(pageObject, 'English')
-  
-        await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.answerFileUploadQuestion('file key')
-        const error = await pageObject.$('.cf-fileupload-error')
-        expect(await error.isHidden()).toEqual(true)
-      })
-  
-      it('with valid file does submit', async () => {
-        await loginAsGuest(pageObject)
-        await selectApplicantLanguage(pageObject, 'English')
-  
-        await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.answerFileUploadQuestion('file key')
-        await applicantQuestions.clickUpload()
-  
-        await applicantQuestions.submitFromReviewPage(programName)
-      })
-  
-      it('with no file does not submit', async () => {
-        await loginAsGuest(pageObject)
-        await selectApplicantLanguage(pageObject, 'English')
-  
-        await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.clickUpload()
-  
-        const error = await pageObject.$('.cf-fileupload-error')
-        expect(await error.isHidden()).toEqual(false)
-      })
+
+    it('with valid file does submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerFileUploadQuestion('file key')
+      await applicantQuestions.clickUpload()
+
+      await applicantQuestions.submitFromReviewPage(programName)
     })
-  
-    // Optional file upload.
-    describe('optional file upload question', () => {
-      let applicantQuestions
-      const programName = 'test program for optional file upload'
-  
-      beforeAll(async () => {
-        await loginAsAdmin(pageObject)
-        const adminQuestions = new AdminQuestions(pageObject)
-        const adminPrograms = new AdminPrograms(pageObject)
-        applicantQuestions = new ApplicantQuestions(pageObject)
-  
-        await adminQuestions.addFileUploadQuestion({
-          questionName: 'file-upload-test-optional-q',
-        })
-        await adminPrograms.addProgram(programName)
-        await adminPrograms.editProgramBlockWithOptional(
-          programName,
-          'Optional question block',
-          [],
-          'file-upload-test-optional-q'
-        )
-        await adminPrograms.gotoAdminProgramsPage()
-        await adminPrograms.publishAllPrograms()
-  
-        await logout(pageObject)
-      })
 
-      it('with missing file can be skipped', async () => {
-        await loginAsGuest(pageObject)
-        await selectApplicantLanguage(pageObject, 'English')
+    it('with no file does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
 
-        await applicantQuestions.applyProgram(programName)
-        // Initially clicking upload with no file provided generates
-        // an error. Then we click skip to ensure that the question
-        // is optional.
-        await applicantQuestions.clickUpload()
-        const error = await pageObject.$('.cf-fileupload-error')
-        expect(await error.isHidden()).toEqual(false)
-        await applicantQuestions.clickSkip()
-        
-        await applicantQuestions.submitFromReviewPage(programName)
-      })
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.clickUpload()
 
-      it('can be skipped', async () => {
-        await loginAsGuest(pageObject)
-        await selectApplicantLanguage(pageObject, 'English')
-
-        await applicantQuestions.applyProgram(programName)
-        await applicantQuestions.clickSkip()
-        await applicantQuestions.submitFromReviewPage(programName)
-      })
+      const error = await pageObject.$('.cf-fileupload-error')
+      expect(await error.isHidden()).toEqual(false)
     })
   })
-  
+
+  // Optional file upload.
+  describe('optional file upload question', () => {
+    let applicantQuestions
+    const programName = 'test program for optional file upload'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addFileUploadQuestion({
+        questionName: 'file-upload-test-optional-q',
+      })
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+        programName,
+        'Optional question block',
+        [],
+        'file-upload-test-optional-q'
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with missing file can be skipped', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      // Initially clicking upload with no file provided generates
+      // an error. Then we click skip to ensure that the question
+      // is optional.
+      await applicantQuestions.clickUpload()
+      const error = await pageObject.$('.cf-fileupload-error')
+      expect(await error.isHidden()).toEqual(false)
+      await applicantQuestions.clickSkip()
+      
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('can be skipped', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.clickSkip()
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+  })
+})

--- a/universal-application-tool-0.0.1/app/assets/javascripts/azure_upload.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/azure_upload.ts
@@ -4,20 +4,19 @@
 
 class AzureUploadController {
   static UPLOAD_CONTAINER_ID = 'azure-upload-form-component'
-  static FILEUPLOAD_SUBMIT_FORM_ID = 'cf-block-submit'
+  static FILEUPLOAD_FORM_ID = 'cf-block-form'
 
   constructor() {
     const uploadContainer = document.getElementById(
       AzureUploadController.UPLOAD_CONTAINER_ID
     )
 
-    const uploadButton = document.getElementById(
-      AzureUploadController.FILEUPLOAD_SUBMIT_FORM_ID
+    const blockForm = document.getElementById(
+      AzureUploadController.FILEUPLOAD_FORM_ID
     )
-
-    uploadButton.addEventListener('click', (event) =>
+    blockForm.addEventListener('submit', (event) => {
       this.attemptUpload(event, uploadContainer)
-    )
+    })
   }
 
   getValueFromInputLabel(label: string): string {

--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -188,28 +188,27 @@ class ValidationController {
 
   /** Add listeners to file input to update validation on changes. */
   private addFileUploadListener() {
-    // Assumption: There is only ever zero or one file input per block.
-    const fileQuestion = document.querySelector(
-      ValidationController.FILEUPLOAD_QUESTION_CLASS
+    const fileQuestions = Array.from(
+      <NodeListOf<HTMLInputElement>>(
+        document.querySelectorAll(
+          `${ValidationController.FILEUPLOAD_QUESTION_CLASS} input[type=file]`
+        )
+      )
     )
-    if (fileQuestion) {
-      const fileInput = fileQuestion.querySelector('input[type=file]')
-      // Whenever the input changes we need to revalidate.
-      if (fileInput) {
-        fileInput.addEventListener('input', () => {
-          this.onFileChanged()
-        })
-      }
-    }
+    fileQuestions.forEach((fileQuestion) => {
+      fileQuestion.addEventListener('input', () => {
+        this.onFileChanged()
+      })
+    })
   }
 
   checkAllQuestionTypes() {
-    this.isAddressValid = this.validateAddressQuestion()
-    this.isCurrencyValid = this.validateCurrencyQuestion()
+    this.isAddressValid = this.validateAddressQuestions()
+    this.isCurrencyValid = this.validateCurrencyQuestions()
     this.isEnumeratorValid = this.validateEnumeratorQuestion()
-    this.isFileUploadValid = this.validateFileUploadQuestion()
-    this.isNameValid = this.validateNameQuestion()
-    this.isNumberValid = this.validateNumberQuestion()
+    this.isFileUploadValid = this.validateFileUploadQuestions()
+    this.isNameValid = this.validateNameQuestions()
+    this.isNumberValid = this.validateNumberQuestions()
     this.updateSubmitButton()
   }
 
@@ -225,12 +224,12 @@ class ValidationController {
   }
 
   onAddressChanged() {
-    this.isAddressValid = this.validateAddressQuestion()
+    this.isAddressValid = this.validateAddressQuestions()
     this.updateSubmitButton()
   }
 
   onCurrencyChanged() {
-    this.isCurrencyValid = this.validateCurrencyQuestion()
+    this.isCurrencyValid = this.validateCurrencyQuestions()
     this.updateSubmitButton()
   }
 
@@ -240,17 +239,17 @@ class ValidationController {
   }
 
   onFileChanged() {
-    this.isFileUploadValid = this.validateFileUploadQuestion()
+    this.isFileUploadValid = this.validateFileUploadQuestions()
     this.updateSubmitButton()
   }
 
   onNameChanged() {
-    this.isNameValid = this.validateNameQuestion()
+    this.isNameValid = this.validateNameQuestions()
     this.updateSubmitButton()
   }
 
   onNumberChanged() {
-    this.isNumberValid = this.validateNumberQuestion()
+    this.isNumberValid = this.validateNumberQuestions()
     this.updateSubmitButton()
   }
 
@@ -292,7 +291,7 @@ class ValidationController {
   }
 
   /** Validates all address questions. */
-  validateAddressQuestion(): boolean {
+  validateAddressQuestions(): boolean {
     let allValid = true
     const addressQuestions = Array.from(
       document.querySelectorAll(ValidationController.ADDRESS_QUESTION_CLASS)
@@ -370,7 +369,7 @@ class ValidationController {
    * Validates that the value is present and in integer format (optionally with
    * commas), optionally with exactly 2 decimals.
    */
-  validateCurrencyQuestion(): boolean {
+  validateCurrencyQuestions(): boolean {
     let isAllValid = true
     const questions = Array.from(
       document.querySelectorAll(ValidationController.CURRENCY_QUESTION_CLASS)
@@ -463,29 +462,30 @@ class ValidationController {
   }
 
   /** Validates that a file is selected. */
-  validateFileUploadQuestion(): boolean {
-    let isValid = true
-    const fileUploadQuestion = document.querySelector(
-      ValidationController.FILEUPLOAD_QUESTION_CLASS
+  validateFileUploadQuestions(): boolean {
+    let isAllValid = true
+    const questions = Array.from(
+        document.querySelectorAll(ValidationController.FILEUPLOAD_QUESTION_CLASS)
     )
-    if (fileUploadQuestion) {
+    for (const question of questions) {
       // validate a file is selected.
       const fileInput = <HTMLInputElement>(
-        fileUploadQuestion.querySelector('input[type=file]')
+        question.querySelector('input[type=file]')
       )
-      isValid = fileInput.value != ''
+      const isValid = fileInput.value != ''
 
       // Toggle the error div if invalid.
-      const errorDiv = fileUploadQuestion.querySelector('.cf-fileupload-error')
+      const errorDiv = question.querySelector('.cf-fileupload-error')
       if (errorDiv) {
         errorDiv.classList.toggle('hidden', isValid)
       }
+      isAllValid = isAllValid && isValid
     }
-    return isValid
+    return isAllValid
   }
 
   /** Validates that first and last name are not empty. */
-  validateNameQuestion(): boolean {
+  validateNameQuestions(): boolean {
     let isAllValid = true
     const nameQuestions = Array.from(
       document.querySelectorAll(ValidationController.NAME_QUESTION_CLASS)
@@ -525,7 +525,7 @@ class ValidationController {
   }
 
   /** Validates that numbers are positive integers. */
-  validateNumberQuestion(): boolean {
+  validateNumberQuestions(): boolean {
     let isAllValid = true
     const numberQuestions = Array.from(
       <NodeListOf<HTMLInputElement>>(

--- a/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
+++ b/universal-application-tool-0.0.1/app/assets/javascripts/validation.ts
@@ -465,7 +465,7 @@ class ValidationController {
   validateFileUploadQuestions(): boolean {
     let isAllValid = true
     const questions = Array.from(
-        document.querySelectorAll(ValidationController.FILEUPLOAD_QUESTION_CLASS)
+      document.querySelectorAll(ValidationController.FILEUPLOAD_QUESTION_CLASS)
     )
     for (const question of questions) {
       // validate a file is selected.

--- a/universal-application-tool-0.0.1/app/views/dev/AzureStorageDevViewStrategy.java
+++ b/universal-application-tool-0.0.1/app/views/dev/AzureStorageDevViewStrategy.java
@@ -2,6 +2,7 @@ package views.dev;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.a;
+import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.input;
@@ -47,9 +48,7 @@ public class AzureStorageDevViewStrategy implements CloudStorageDevViewStrategy 
         viewUtils.makeWebJarsTag(/* assetsRoute= */ WebJarJsPaths.AZURE_STORAGE_BLOB));
     bundle.addFooterScripts(viewUtils.makeLocalJsTag(/* filename= */ "azure_upload"));
 
-    ContainerTag formTag = form().withId("azure-upload-form-component");
-
-    return formTag
+    ContainerTag formTag = form().withId("cf-block-form")
         .with(input().withType("file").withName("file"))
         .with(input().withType("hidden"))
         .withName("key")
@@ -69,6 +68,8 @@ public class AzureStorageDevViewStrategy implements CloudStorageDevViewStrategy 
             TagCreator.button(text("Upload to Azure Blob Storage"))
                 .withType("submit")
                 .withId("cf-block-submit"));
+    return div(formTag)
+        .withId("azure-upload-form-component");
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/dev/AzureStorageDevViewStrategy.java
+++ b/universal-application-tool-0.0.1/app/views/dev/AzureStorageDevViewStrategy.java
@@ -48,28 +48,33 @@ public class AzureStorageDevViewStrategy implements CloudStorageDevViewStrategy 
         viewUtils.makeWebJarsTag(/* assetsRoute= */ WebJarJsPaths.AZURE_STORAGE_BLOB));
     bundle.addFooterScripts(viewUtils.makeLocalJsTag(/* filename= */ "azure_upload"));
 
-    ContainerTag formTag = form().withId("cf-block-form")
-        .with(input().withType("file").withName("file"))
-        .with(input().withType("hidden"))
-        .withName("key")
-        .withValue(request.fileName())
-        .with(input().withType("hidden").withName("sasToken").withValue(request.sasToken()))
-        .with(input().withType("hidden").withName("blobUrl").withValue(request.blobUrl()))
-        .with(
-            input().withType("hidden").withName("containerName").withValue(request.containerName()))
-        .with(input().withType("hidden").withName("fileName").withValue(request.fileName()))
-        .with(input().withType("hidden").withName("accountName").withValue(request.accountName()))
-        .with(
-            input()
-                .withType("hidden")
-                .withName("successActionRedirect")
-                .withValue(request.successActionRedirect()))
-        .with(
-            TagCreator.button(text("Upload to Azure Blob Storage"))
-                .withType("submit")
-                .withId("cf-block-submit"));
-    return div(formTag)
-        .withId("azure-upload-form-component");
+    ContainerTag formTag =
+        form()
+            .withId("cf-block-form")
+            .with(input().withType("file").withName("file"))
+            .with(input().withType("hidden"))
+            .withName("key")
+            .withValue(request.fileName())
+            .with(input().withType("hidden").withName("sasToken").withValue(request.sasToken()))
+            .with(input().withType("hidden").withName("blobUrl").withValue(request.blobUrl()))
+            .with(
+                input()
+                    .withType("hidden")
+                    .withName("containerName")
+                    .withValue(request.containerName()))
+            .with(input().withType("hidden").withName("fileName").withValue(request.fileName()))
+            .with(
+                input().withType("hidden").withName("accountName").withValue(request.accountName()))
+            .with(
+                input()
+                    .withType("hidden")
+                    .withName("successActionRedirect")
+                    .withValue(request.successActionRedirect()))
+            .with(
+                TagCreator.button(text("Upload to Azure Blob Storage"))
+                    .withType("submit")
+                    .withId("cf-block-submit"));
+    return div(formTag).withId("azure-upload-form-component");
   }
 
   @Override


### PR DESCRIPTION
### Description
On-page file upload validation now validates ALL file upload questions in a block rather than assuming there is just one. Also fixes issue where Azure uploads threw an uncaught exception if a required file hadn't been uploaded (rather than showing a validation error to the user).

Note: Only one file upload is allowed per block by the admin controller. That said, there's not a strong need to bake that in at the validation level.

While here, I also:
  1) Renamed `validateFooQuestion` method names to `validateFooQuestions` to indicate they would validate all questions rather than just a single question.
  2) Added focused tests for file upload questions (which exposed a bug in the Azure file upload path, also fixed here).

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1695; Fixes #1696
