### PR TITLE
Line break question action items to be clearer.

### DIFF
--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionsListView.java
@@ -1,16 +1,7 @@
 package views.admin.questions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.a;
-import static j2html.TagCreator.div;
-import static j2html.TagCreator.each;
-import static j2html.TagCreator.p;
-import static j2html.TagCreator.table;
-import static j2html.TagCreator.tbody;
-import static j2html.TagCreator.td;
-import static j2html.TagCreator.th;
-import static j2html.TagCreator.thead;
-import static j2html.TagCreator.tr;
+import static j2html.TagCreator.*;
 
 import com.google.inject.Inject;
 import j2html.tags.ContainerTag;
@@ -267,27 +258,27 @@ public final class QuestionsListView extends BaseHtmlView {
       Http.Request request) {
     ContainerTag td = td().withClasses(BaseStyles.TABLE_CELL_STYLES, Styles.TEXT_RIGHT);
     if (active.isPresent() && draft.isEmpty()) {
-      td.with(renderQuestionViewLink(active.get(), "View →"));
-      td.with(renderQuestionEditLink(active.get(), "New Version →"));
+      td.with(renderQuestionViewLink(active.get(), "View →")).with(br());
+      td.with(renderQuestionEditLink(active.get(), "New Version →")).with(br());
     } else if (active.isEmpty() && draft.isPresent()) {
-      td.with(renderQuestionEditLink(draft.get(), "Edit Draft →"));
-      td.with(renderQuestionTranslationLink(draft.get(), "Manage Translations →"));
+      td.with(renderQuestionEditLink(draft.get(), "Edit Draft →")).with(br());
+      td.with(renderQuestionTranslationLink(draft.get(), "Manage Translations →")).with(br());
     } else if (active.isPresent() && draft.isPresent()) {
-      td.with(renderQuestionViewLink(active.get(), "View Published →"));
-      td.with(renderQuestionEditLink(draft.get(), "Edit Draft →"));
-      td.with(renderQuestionTranslationLink(draft.get(), "Manage Draft Translations →"));
+      td.with(renderQuestionViewLink(active.get(), "View Published →")).with(br());
+      td.with(renderQuestionEditLink(draft.get(), "Edit Draft →")).with(br());
+      td.with(renderQuestionTranslationLink(draft.get(), "Manage Draft Translations →")).with(br());
     } else if (active.isEmpty() && draft.isEmpty()) {
-      td.with(renderQuestionViewLink(definition, "View →"));
+      td.with(renderQuestionViewLink(definition, "View →")).with(br());
     }
     if (active.isPresent()) {
       if (deletionStatus.equals(DeletionStatus.PENDING_DELETION)) {
-        td.with(renderRestoreQuestionLink(active.get(), "Restore Archived →", request));
+        td.with(renderRestoreQuestionLink(active.get(), "Restore Archived →", request)).with(br());
       } else if (deletionStatus.equals(DeletionStatus.DELETABLE)) {
-        td.with(renderArchiveQuestionLink(active.get(), "Archive →", request));
+        td.with(renderArchiveQuestionLink(active.get(), "Archive →", request)).with(br());
       }
     }
     if (draft.isPresent()) {
-      td.with(renderDiscardDraftLink(draft.get(), "Discard Draft →", request));
+      td.with(renderDiscardDraftLink(draft.get(), "Discard Draft →", request)).with(br());
     }
     return td;
   }


### PR DESCRIPTION
### Description
Add a `<BR>` after each question action for clearer alignment and usability.

Before:
![before](https://user-images.githubusercontent.com/90928876/163077324-bc6003fd-e1b7-4785-a647-5b4699c71200.png)

After:
![after](https://user-images.githubusercontent.com/90928876/163077136-1de09052-cc6c-4d9c-80b9-0ce850b0f027.png)


