### PR TITLE
Make no-op test evaluate something to appease linter.

### DIFF
--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -35,16 +35,17 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .setName("Screen Name")
             .setDescription("Screen Description")
             .build();
-    ProgramDefinition def = ProgramDefinition.builder()
-        .setId(123L)
-        .setAdminName("Admin name")
-        .setAdminDescription("Admin description")
-        .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
-        .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
-        .setExternalLink("")
-        .setDisplayMode(DisplayMode.PUBLIC)
-        .addBlockDefinition(blockA)
-        .build();
+    ProgramDefinition def =
+        ProgramDefinition.builder()
+            .setId(123L)
+            .setAdminName("Admin name")
+            .setAdminDescription("Admin description")
+            .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
+            .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setExternalLink("")
+            .setDisplayMode(DisplayMode.PUBLIC)
+            .addBlockDefinition(blockA)
+            .build();
 
     assertThat(def.id()).isEqualTo(123L);
   }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -35,7 +35,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .setName("Screen Name")
             .setDescription("Screen Description")
             .build();
-    ProgramDefinition.builder()
+    ProgramDefinition def = ProgramDefinition.builder()
         .setId(123L)
         .setAdminName("Admin name")
         .setAdminDescription("Admin description")
@@ -45,6 +45,8 @@ public class ProgramDefinitionTest extends ResetPostgres {
         .setDisplayMode(DisplayMode.PUBLIC)
         .addBlockDefinition(blockA)
         .build();
+
+    assertThat(def.id()).isEqualTo(123L);
   }
 
   @Test


### PR DESCRIPTION
### Description
Make test actually evaluate something.  A new linter will fail on this.  #2256

