### PR TITLE
The pull-prod-admin-config script an incorrect parameter

### DIFF
--- a/cloud/deploys/seattle/bin/pull-prod-admin-config
+++ b/cloud/deploys/seattle/bin/pull-prod-admin-config
@@ -121,8 +121,7 @@ ssh -q -o "UserKnownHostsFile=/dev/null" \
         -t questions \
         -t versions \
         -t versions_programs \
-        -t versions_questions \
-        postgres > program_data.dump"
+        -t versions_questions > program_data.dump"
 
 echo "Copying file to local computer using scp"
 scp -o "UserKnownHostsFile=/dev/null" \


### PR DESCRIPTION
Fixing the pull-prod-admin-config script which has an incorrect parameter for pg_dump. Finally remembered to check this back in. The script fails before this fix.