### PR TITLE
Reduce N+1 queries for CSV export

### DIFF
--- a/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicationRepository.java
@@ -131,7 +131,8 @@ public class ApplicationRepository {
   }
 
   public ImmutableList<Application> getAllApplications() {
-    return ImmutableList.copyOf(database.find(Application.class).findList());
+    return ImmutableList.copyOf(
+        database.find(Application.class).fetch("program").fetch("applicant.account").findList());
   }
 
   // Need to transmit both arguments to submitApplication through the CompletionStage pipeline.

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -97,6 +97,9 @@ public interface ApplicantService {
   /** Return the email of the given applicant id if they have one. */
   CompletionStage<Optional<String>> getEmail(long applicantId);
 
-  /** Return all applications, including applications from previous versions. */
+  /**
+   * Return all applications, including applications from previous versions, with program,
+   * applicant, and account associations eager loaded.
+   */
   ImmutableList<Application> getAllApplications();
 }

--- a/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
+++ b/universal-application-tool-0.0.1/app/services/export/CsvExporter.java
@@ -10,11 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import models.Application;
-import models.Program;
 import models.TrustedIntermediaryGroup;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import repository.ProgramRepository;
 import services.Path;
 import services.applicant.ReadOnlyApplicantProgramService;
 import services.program.Column;
@@ -33,21 +31,17 @@ public class CsvExporter {
   private boolean wroteHeaders;
   private ImmutableList<Column> columns;
   private Optional<String> secret;
-  private Optional<ProgramRepository> programRepository;
 
   public CsvExporter(List<Column> columns) {
     this.wroteHeaders = false;
     this.columns = ImmutableList.copyOf(columns);
     this.secret = Optional.empty();
-    this.programRepository = Optional.empty();
   }
 
   /** Provide a secret if you will need to use OPAQUE_ID type columns. */
-  public CsvExporter(
-      ImmutableList<Column> columns, String secret, ProgramRepository programRepository) {
+  public CsvExporter(ImmutableList<Column> columns, String secret) {
     this(columns);
     this.secret = Optional.of(secret);
-    this.programRepository = Optional.of(programRepository);
   }
 
   private void writeHeadersOnFirstExport(CSVPrinter printer) throws IOException {
@@ -74,7 +68,7 @@ public class CsvExporter {
       throws IOException {
     CSVPrinter printer = new CSVPrinter(writer, DEFAULT_CSV_FORMAT);
 
-    this.writeHeadersOnFirstExport(printer);
+    writeHeadersOnFirstExport(printer);
 
     ImmutableMap<Path, String> answerMap =
         roApplicantService.getSummaryData().stream()
@@ -117,27 +111,7 @@ public class CsvExporter {
           printer.print(application.getSubmitterEmail().orElse("Applicant"));
           break;
         case PROGRAM:
-          Program program = application.getProgram();
-          if (programRepository.isEmpty()) {
-            throw new RuntimeException(
-                "No program repository provided, but program details requested.");
-          }
-          // This is a strange workaround for a bug in ebean.  For some reason, the program that
-          // is returned from the application crashes ebean's server when we attempt to access
-          // anything
-          // other than the id.  This is hard to debug since ebean doesn't write code, it writes
-          // bytecode,
-          // directly.  This workaround costs 1 extremely cheap query per application - bad, but
-          // probably not problematic until the size of the database gets huge.
-          printer.print(
-              programRepository
-                  .get()
-                  .lookupProgram(program.id)
-                  .toCompletableFuture()
-                  .join()
-                  .get()
-                  .getProgramDefinition()
-                  .adminName());
+          printer.print(application.getProgram().getProgramDefinition().adminName());
           break;
         case TI_ORGANIZATION:
           printer.print(

--- a/universal-application-tool-0.0.1/app/services/export/ExporterFactory.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterFactory.java
@@ -6,19 +6,16 @@ import java.io.IOException;
 import java.util.Optional;
 import javax.inject.Inject;
 import models.Program;
-import repository.ProgramRepository;
 import services.program.CsvExportConfig;
 import services.program.PdfExportConfig;
 
 /** ExporterFactory helps create {@link CsvExporter} and {@link PdfExporter} objects. */
 public class ExporterFactory {
   private final Config config;
-  private final ProgramRepository programRepository;
 
   @Inject
-  public ExporterFactory(Config config, ProgramRepository programRepository) {
+  public ExporterFactory(Config config) {
     this.config = Preconditions.checkNotNull(config);
-    this.programRepository = Preconditions.checkNotNull(programRepository);
   }
 
   public PdfExporter pdfExporter(Program program) throws NotConfiguredException, IOException {
@@ -46,7 +43,6 @@ public class ExporterFactory {
   }
 
   public CsvExporter csvExporter(CsvExportConfig exportConfig) {
-    return new CsvExporter(
-        exportConfig.columns(), config.getString("play.http.secret.key"), programRepository);
+    return new CsvExporter(exportConfig.columns(), config.getString("play.http.secret.key"));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/export/AbstractExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/AbstractExporterTest.java
@@ -102,8 +102,8 @@ abstract class AbstractExporterTest extends ResetPostgres {
   }
 
   protected void createFakeApplications() {
-    Applicant applicantOne = new Applicant();
-    Applicant applicantTwo = new Applicant();
+    Applicant applicantOne = resourceCreator.insertApplicantWithAccount();
+    Applicant applicantTwo = resourceCreator.insertApplicantWithAccount();
     testQuestionBank.getSampleQuestionsForAllTypes().entrySet().stream()
         .forEach(
             entry ->
@@ -172,7 +172,7 @@ abstract class AbstractExporterTest extends ResetPostgres {
             .build();
 
     // First applicant has two household members, and the second one has one job.
-    applicantOne = new Applicant();
+    applicantOne = resourceCreator.insertApplicantWithAccount();
     QuestionAnswerer.answerNameQuestion(
         applicantOne.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(
@@ -222,7 +222,7 @@ abstract class AbstractExporterTest extends ResetPostgres {
     applicationOne.save();
 
     // Second applicant has one household member that has two jobs.
-    applicantTwo = new Applicant();
+    applicantTwo = resourceCreator.insertApplicantWithAccount();
     QuestionAnswerer.answerNameQuestion(
         applicantTwo.getApplicantData(),
         ApplicantData.APPLICANT_PATH.join(

--- a/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
+++ b/universal-application-tool-0.0.1/test/services/export/CsvExporterTest.java
@@ -133,6 +133,27 @@ public class CsvExporterTest extends AbstractExporterTest {
   }
 
   @Test
+  public void demographyExport_withRepeatedEntities() throws Exception {
+    createFakeProgramWithEnumerator();
+
+    ExporterService exporterService = instanceOf(ExporterService.class);
+    CSVParser parser =
+        CSVParser.parse(exporterService.getDemographicsCsv(), CsvExporter.DEFAULT_CSV_FORMAT);
+
+    int id = 0;
+    assertThat(parser.getHeaderMap())
+        .containsExactlyEntriesOf(
+            ImmutableMap.<String, Integer>builder()
+                .put("Opaque ID", id++)
+                .put("Program", id++)
+                .put("Submitter Email (Opaque)", id++)
+                .put("TI Organization", id++)
+                .put("Create time", id++)
+                .put("Submit time", id++)
+                .build());
+  }
+
+  @Test
   public void useDefaultCsvConfig_withRepeatedEntities() throws Exception {
     createFakeProgramWithEnumerator();
 

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -89,6 +89,16 @@ public class ResourceCreator {
     return account;
   }
 
+  public Applicant insertApplicantWithAccount() {
+    Applicant applicant = insertApplicant();
+    Account account = insertAccount();
+
+    applicant.setAccount(account);
+    applicant.save();
+
+    return applicant;
+  }
+
   public Account insertAccountWithEmail(String email) {
     Account account = new Account();
     account.setEmailAddress(email);


### PR DESCRIPTION
This attempts to improve the demography CSV export performance a bit. This PR eager loads program, applicant, and account data for each application, removing several N+1 queries.

Another area for improvement is in reducing the number of queries to load a program definition, specifically syncing the program definition's questions. I'm electing to address that in a separate PR.

Meant to improve https://github.com/seattle-uat/civiform/issues/2267 but won't necessarily fix it