### PR TITLE
Admin UI tweaks

### DIFF
--- a/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
@@ -53,8 +53,9 @@ public class VersionListView extends BaseHtmlView {
     ImmutableList<Version> olderVersions =
         allVersions.stream()
             .filter(version -> version.getLifecycleStage().equals(LifecycleStage.OBSOLETE))
-            .collect(ImmutableList.toImmutableList())
-            .reverse();
+            // Sort from newest to oldest. IDs are DB-generated and increment monotonically.
+            .sorted((a, b) -> (int) (b.id - a.id))
+            .collect(ImmutableList.toImmutableList());
 
     String title = "Program Versions";
     HtmlBundle htmlBundle =

--- a/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
@@ -53,7 +53,7 @@ public class VersionListView extends BaseHtmlView {
     ImmutableList<Version> olderVersions =
         allVersions.stream()
             .filter(version -> version.getLifecycleStage().equals(LifecycleStage.OBSOLETE))
-            .collect(ImmutableList.toImmutableList());
+            .collect(ImmutableList.toImmutableList()).reverse();
 
     String title = "Program Versions";
     HtmlBundle htmlBundle =

--- a/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
@@ -54,8 +54,9 @@ public class VersionListView extends BaseHtmlView {
         allVersions.stream()
             .filter(version -> version.getLifecycleStage().equals(LifecycleStage.OBSOLETE))
             // Sort from newest to oldest. IDs are DB-generated and increment monotonically.
-            .sorted((a, b) -> (int) (b.id - a.id))
-            .collect(ImmutableList.toImmutableList());
+            .sorted((a, b) -> a.id.compareTo(b.id))
+            .collect(ImmutableList.toImmutableList())
+            .reverse();
 
     String title = "Program Versions";
     HtmlBundle htmlBundle =

--- a/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/versions/VersionListView.java
@@ -53,7 +53,8 @@ public class VersionListView extends BaseHtmlView {
     ImmutableList<Version> olderVersions =
         allVersions.stream()
             .filter(version -> version.getLifecycleStage().equals(LifecycleStage.OBSOLETE))
-            .collect(ImmutableList.toImmutableList()).reverse();
+            .collect(ImmutableList.toImmutableList())
+            .reverse();
 
     String title = "Program Versions";
     HtmlBundle htmlBundle =

--- a/universal-application-tool-0.0.1/app/views/style/AdminStyles.java
+++ b/universal-application-tool-0.0.1/app/views/style/AdminStyles.java
@@ -72,7 +72,7 @@ public class AdminStyles {
           Styles.FLEX);
 
   public static final String MAIN_CENTERED =
-      StyleUtils.joinStyles(Styles.PX_2, Styles.MAX_W_SCREEN_XL, Styles.MX_AUTO);
+      StyleUtils.joinStyles(Styles.PX_2, Styles.MAX_W_SCREEN_2XL, Styles.MX_AUTO);
 
   public static final String MAIN_FULL = StyleUtils.joinStyles(Styles.FLEX, Styles.FLEX_ROW);
 


### PR DESCRIPTION
- Increase the max width of the `main` element for the admin so Seattle's question content doesn't require a horizontal scrollbar
- Reverse the list of versions so most recent is at the top