### PR TITLE
Removing Question.has* methods since all implementations share the sa…

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
@@ -34,11 +34,6 @@ public class AddressQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
@@ -59,11 +54,6 @@ public class AddressQuestion implements Question {
     }
 
     return errors.build();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -175,7 +175,8 @@ public class ApplicantQuestion {
   }
 
   public boolean hasErrors() {
-    return !errorsPresenter().getQuestionErrors().isEmpty() || !errorsPresenter().getAllTypeSpecificErrors().isEmpty();
+    return !errorsPresenter().getQuestionErrors().isEmpty()
+        || !errorsPresenter().getAllTypeSpecificErrors().isEmpty();
   }
 
   public Optional<Long> getUpdatedInProgramMetadata() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -175,7 +175,7 @@ public class ApplicantQuestion {
   }
 
   public boolean hasErrors() {
-    return errorsPresenter().hasConditionErrors() || errorsPresenter().hasTypeSpecificErrors();
+    return !errorsPresenter().getQuestionErrors().isEmpty() || !errorsPresenter().getAllTypeSpecificErrors().isEmpty();
   }
 
   public Optional<Long> getUpdatedInProgramMetadata() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/CurrencyQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/CurrencyQuestion.java
@@ -32,18 +32,8 @@ public class CurrencyQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/DateQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/DateQuestion.java
@@ -27,18 +27,8 @@ public class DateQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EmailQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EmailQuestion.java
@@ -24,18 +24,8 @@ public class EmailQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -24,19 +24,9 @@ public class EnumeratorQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableList<Path> getAllPaths() {
     // Not intended to return the leaf question paths.
     return ImmutableList.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
@@ -31,11 +31,6 @@ public class FileUploadQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     // TODO: Implement admin-defined validation.
     return ImmutableSet.of();
@@ -45,11 +40,6 @@ public class FileUploadQuestion implements Question {
   public ImmutableList<Path> getAllPaths() {
     // We can't predict ahead of time what the path will be.
     return ImmutableList.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/IdQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/IdQuestion.java
@@ -31,11 +31,6 @@ public class IdQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
@@ -65,11 +60,6 @@ public class IdQuestion implements Question {
     }
 
     return errors.build();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
@@ -32,11 +32,6 @@ public class MultiSelectQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
@@ -66,11 +61,6 @@ public class MultiSelectQuestion implements Question {
       }
     }
     return errors.build();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NameQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NameQuestion.java
@@ -34,19 +34,9 @@ public class NameQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     // TODO: Implement admin-defined validation.
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -30,11 +30,6 @@ public class NumberQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
@@ -68,11 +63,6 @@ public class NumberQuestion implements Question {
     }
 
     return errors.build();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Question.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Question.java
@@ -18,17 +18,8 @@ import services.applicant.ValidationErrorMessage;
  * </ul>
  */
 public interface Question {
-  /** Returns true if values do not meet conditions defined by admins. */
-  boolean hasConditionErrors();
-
   /** Returns a set of {@link ValidationErrorMessage}s related to conditions defined by admins. */
   ImmutableSet<ValidationErrorMessage> getQuestionErrors();
-
-  /**
-   * Returns true if there is any type specific errors. The validation does not consider
-   * admin-defined conditions.
-   */
-  boolean hasTypeSpecificErrors();
 
   /**
    * Returns a set of {@link ValidationErrorMessage}s to be shown to the applicant. These errors are

--- a/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
@@ -29,11 +29,6 @@ public class SingleSelectQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableList<Path> getAllPaths() {
     return ImmutableList.of(getSelectionPath());
   }
@@ -42,11 +37,6 @@ public class SingleSelectQuestion implements Question {
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     // Only one selection is possible - there is no admin-configured validation.
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/StaticContentQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/StaticContentQuestion.java
@@ -34,18 +34,8 @@ public class StaticContentQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return false;
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return false;
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/TextQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/TextQuestion.java
@@ -30,11 +30,6 @@ public class TextQuestion implements Question {
   }
 
   @Override
-  public boolean hasConditionErrors() {
-    return !getQuestionErrors().isEmpty();
-  }
-
-  @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
@@ -59,11 +54,6 @@ public class TextQuestion implements Question {
     }
 
     return errors.build();
-  }
-
-  @Override
-  public boolean hasTypeSpecificErrors() {
-    return !getAllTypeSpecificErrors().isEmpty();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -72,7 +72,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
             .withClasses(
                 ReferenceClasses.ENUMERATOR_ERROR,
                 BaseStyles.FORM_ERROR_TEXT_BASE,
-                enumeratorQuestion.hasConditionErrors() ? "" : Styles.HIDDEN);
+                enumeratorQuestion.getQuestionErrors().isEmpty() ? Styles.HIDDEN : "");
 
     Tag enumeratorQuestionFormContent =
         div()

--- a/universal-application-tool-0.0.1/test/services/applicant/question/AddressQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/AddressQuestionTest.java
@@ -57,8 +57,8 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = new AddressQuestion(applicantQuestion);
 
-    assertThat(addressQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(addressQuestion.hasConditionErrors()).isFalse();
+    assertThat(addressQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(addressQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -76,8 +76,8 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
-    assertThat(addressQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(addressQuestion.hasConditionErrors()).isFalse();
+    assertThat(addressQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(addressQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(addressQuestion.getStreetValue().get()).isEqualTo("PO Box 123");
     assertThat(addressQuestion.getLine2Value().get()).isEqualTo("Line 2");
     assertThat(addressQuestion.getCityValue().get()).isEqualTo("Seattle");
@@ -94,7 +94,7 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
-    assertThat(addressQuestion.hasTypeSpecificErrors()).isTrue();
+    assertThat(addressQuestion.getAllTypeSpecificErrors().isEmpty()).isFalse();
     assertThat(addressQuestion.getStreetErrors())
         .contains(ValidationErrorMessage.create(MessageKey.ADDRESS_VALIDATION_STREET_REQUIRED));
     assertThat(addressQuestion.getCityErrors())
@@ -121,7 +121,7 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
-    assertThat(addressQuestion.hasTypeSpecificErrors()).isTrue();
+    assertThat(addressQuestion.getAllTypeSpecificErrors().isEmpty()).isFalse();
     assertThat(addressQuestion.getZipErrors())
         .contains(ValidationErrorMessage.create(MessageKey.ADDRESS_VALIDATION_INVALID_ZIPCODE));
     assertThat(addressQuestion.getStreetErrors()).isEmpty();
@@ -145,8 +145,8 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
-    assertThat(addressQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(addressQuestion.hasConditionErrors()).isFalse();
+    assertThat(addressQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(addressQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -176,7 +176,7 @@ public class AddressQuestionTest {
 
     AddressQuestion addressQuestion = applicantQuestion.createAddressQuestion();
 
-    assertThat(addressQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(addressQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(addressQuestion.getQuestionErrors())
         .containsOnly(ValidationErrorMessage.create(MessageKey.ADDRESS_VALIDATION_NO_PO_BOX));
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/ApplicantQuestionTest.java
@@ -70,7 +70,7 @@ public class ApplicantQuestionTest {
     ApplicantQuestion question =
         new ApplicantQuestion(definition, new ApplicantData(), Optional.empty());
 
-    assertThat(question.errorsPresenter().hasTypeSpecificErrors()).isFalse();
+    assertThat(question.errorsPresenter().getAllTypeSpecificErrors().isEmpty()).isTrue();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/CurrencyQuestionTest.java
@@ -45,8 +45,8 @@ public class CurrencyQuestionTest {
     CurrencyQuestion currencyQuestion = new CurrencyQuestion(applicantQuestion);
 
     assertThat(currencyQuestion.getValue()).isEmpty();
-    assertThat(currencyQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(currencyQuestion.hasConditionErrors()).isFalse();
+    assertThat(currencyQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(currencyQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -71,8 +71,8 @@ public class CurrencyQuestionTest {
 
     CurrencyQuestion currencyQuestion = applicantQuestion.createCurrencyQuestion();
 
-    assertThat(currencyQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(currencyQuestion.hasConditionErrors()).isFalse();
+    assertThat(currencyQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(currencyQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(currencyQuestion.getValue().isPresent()).isTrue();
     assertThat(currencyQuestion.getValue().get().getCents()).isEqualTo(cents);
   }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/DateQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/DateQuestionTest.java
@@ -43,8 +43,8 @@ public class DateQuestionTest extends ResetPostgres {
 
     DateQuestion dateQuestion = new DateQuestion(applicantQuestion);
 
-    assertThat(dateQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(dateQuestion.hasConditionErrors()).isFalse();
+    assertThat(dateQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(dateQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -57,7 +57,7 @@ public class DateQuestionTest extends ResetPostgres {
     DateQuestion dateQuestion = new DateQuestion(applicantQuestion);
 
     assertThat(dateQuestion.getDateValue().get()).isEqualTo("2021-05-10");
-    assertThat(dateQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(dateQuestion.hasConditionErrors()).isFalse();
+    assertThat(dateQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(dateQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EmailQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EmailQuestionTest.java
@@ -43,8 +43,8 @@ public class EmailQuestionTest extends ResetPostgres {
 
     EmailQuestion emailQuestion = new EmailQuestion(applicantQuestion);
 
-    assertThat(emailQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(emailQuestion.hasConditionErrors()).isFalse();
+    assertThat(emailQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(emailQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -57,7 +57,7 @@ public class EmailQuestionTest extends ResetPostgres {
     EmailQuestion emailQuestion = new EmailQuestion(applicantQuestion);
 
     assertThat(emailQuestion.getEmailValue().get()).isEqualTo("test1@gmail.com");
-    assertThat(emailQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(emailQuestion.hasConditionErrors()).isFalse();
+    assertThat(emailQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(emailQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -58,8 +58,8 @@ public class EnumeratorQuestionTest extends ResetPostgres {
     EnumeratorQuestion enumeratorQuestion = new EnumeratorQuestion(applicantQuestion);
 
     assertThat(enumeratorQuestion.isAnswered()).isFalse();
-    assertThat(enumeratorQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(enumeratorQuestion.hasConditionErrors()).isFalse();
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(enumeratorQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -75,8 +75,8 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).contains("first", "second", "third");
-    assertThat(enumeratorQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(enumeratorQuestion.hasConditionErrors()).isFalse();
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(enumeratorQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -91,8 +91,7 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).containsExactly(value);
-    assertThat(enumeratorQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(enumeratorQuestion.hasConditionErrors()).isTrue();
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
     assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
         .isEqualTo("Please enter a value for each line.");
@@ -111,8 +110,7 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).containsExactly("hello", "hello");
-    assertThat(enumeratorQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(enumeratorQuestion.hasConditionErrors()).isTrue();
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
     assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
         .isEqualTo("Please enter a unique value for each line.");

--- a/universal-application-tool-0.0.1/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/FileUploadQuestionTest.java
@@ -42,8 +42,8 @@ public class FileUploadQuestionTest {
 
     FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
 
-    assertThat(fileUploadQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(fileUploadQuestion.hasConditionErrors()).isFalse();
+    assertThat(fileUploadQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(fileUploadQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -56,8 +56,8 @@ public class FileUploadQuestionTest {
     FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
 
     assertThat(fileUploadQuestion.getFileKeyValue().get()).isEqualTo("file-key");
-    assertThat(fileUploadQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(fileUploadQuestion.hasConditionErrors()).isFalse();
+    assertThat(fileUploadQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(fileUploadQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/question/IdQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/IdQuestionTest.java
@@ -61,8 +61,8 @@ public class IdQuestionTest extends ResetPostgres {
 
     IdQuestion idQuestion = new IdQuestion(applicantQuestion);
 
-    assertThat(idQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(idQuestion.hasConditionErrors()).isFalse();
+    assertThat(idQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(idQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -75,8 +75,8 @@ public class IdQuestionTest extends ResetPostgres {
     IdQuestion idQuestion = new IdQuestion(applicantQuestion);
 
     assertThat(idQuestion.getIdValue().get()).isEqualTo("12345");
-    assertThat(idQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(idQuestion.hasConditionErrors()).isFalse();
+    assertThat(idQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(idQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -90,8 +90,8 @@ public class IdQuestionTest extends ResetPostgres {
     IdQuestion idQuestion = new IdQuestion(applicantQuestion);
 
     assertThat(idQuestion.getIdValue().get()).isEqualTo(value);
-    assertThat(idQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(idQuestion.hasConditionErrors()).isFalse();
+    assertThat(idQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(idQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -113,7 +113,7 @@ public class IdQuestionTest extends ResetPostgres {
     if (idQuestion.getIdValue().isPresent()) {
       assertThat(idQuestion.getIdValue().get()).isEqualTo(value);
     }
-    assertThat(idQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(idQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(idQuestion.getQuestionErrors()).hasSize(1);
     String errorMessage = idQuestion.getQuestionErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);

--- a/universal-application-tool-0.0.1/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -51,8 +51,8 @@ public class MultiSelectQuestionTest {
 
     MultiSelectQuestion multiSelectQuestion = new MultiSelectQuestion(applicantQuestion);
 
-    assertThat(multiSelectQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(multiSelectQuestion.hasConditionErrors()).isFalse();
+    assertThat(multiSelectQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(multiSelectQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -66,8 +66,8 @@ public class MultiSelectQuestionTest {
 
     MultiSelectQuestion multiSelectQuestion = new MultiSelectQuestion(applicantQuestion);
 
-    assertThat(multiSelectQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(multiSelectQuestion.hasConditionErrors()).isFalse();
+    assertThat(multiSelectQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(multiSelectQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -117,8 +117,8 @@ public class MultiSelectQuestionTest {
 
     MultiSelectQuestion multiSelectQuestion = applicantQuestion.createMultiSelectQuestion();
 
-    assertThat(multiSelectQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(multiSelectQuestion.hasConditionErrors()).isFalse();
+    assertThat(multiSelectQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(multiSelectQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NameQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NameQuestionTest.java
@@ -47,8 +47,8 @@ public class NameQuestionTest {
     assertThat(nameQuestion.getFirstNameValue()).isEmpty();
     assertThat(nameQuestion.getMiddleNameValue()).isEmpty();
     assertThat(nameQuestion.getLastNameValue()).isEmpty();
-    assertThat(nameQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(nameQuestion.hasConditionErrors()).isFalse();
+    assertThat(nameQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(nameQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -62,8 +62,8 @@ public class NameQuestionTest {
 
     NameQuestion nameQuestion = applicantQuestion.createNameQuestion();
 
-    assertThat(nameQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(nameQuestion.hasConditionErrors()).isFalse();
+    assertThat(nameQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(nameQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(nameQuestion.getFirstNameValue().get()).isEqualTo(firstName);
     if (nameQuestion.getMiddleNameValue().isPresent()) {
       assertThat(nameQuestion.getMiddleNameValue().get()).isEqualTo(middleName);
@@ -82,7 +82,7 @@ public class NameQuestionTest {
 
     NameQuestion nameQuestion = applicantQuestion.createNameQuestion();
 
-    assertThat(nameQuestion.hasConditionErrors()).isFalse();
-    assertThat(nameQuestion.hasTypeSpecificErrors()).isTrue();
+    assertThat(nameQuestion.getQuestionErrors().isEmpty()).isTrue();
+    assertThat(nameQuestion.getAllTypeSpecificErrors().isEmpty()).isFalse();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/NumberQuestionTest.java
@@ -62,8 +62,8 @@ public class NumberQuestionTest extends ResetPostgres {
 
     NumberQuestion numberQuestion = new NumberQuestion(applicantQuestion);
 
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(numberQuestion.hasConditionErrors()).isFalse();
+    assertThat(numberQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(numberQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -75,7 +75,7 @@ public class NumberQuestionTest extends ResetPostgres {
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(numberQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getNumberValue()).isEmpty();
   }
 
@@ -88,7 +88,7 @@ public class NumberQuestionTest extends ResetPostgres {
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(numberQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getNumberValue().get()).isEqualTo(800);
   }
 
@@ -102,8 +102,8 @@ public class NumberQuestionTest extends ResetPostgres {
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(numberQuestion.hasConditionErrors()).isFalse();
+    assertThat(numberQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(numberQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getNumberValue().get()).isEqualTo(value);
   }
 
@@ -124,7 +124,7 @@ public class NumberQuestionTest extends ResetPostgres {
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(numberQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(numberQuestion.getQuestionErrors()).hasSize(1);
     String errorMessage = numberQuestion.getQuestionErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);
@@ -140,7 +140,7 @@ public class NumberQuestionTest extends ResetPostgres {
 
     NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
 
-    assertThat(numberQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(numberQuestion.hasConditionErrors()).isFalse();
+    assertThat(numberQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(numberQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/SingleSelectQuestionTest.java
@@ -64,8 +64,8 @@ public class SingleSelectQuestionTest {
 
     SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
 
-    assertThat(singleSelectQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(singleSelectQuestion.hasConditionErrors()).isFalse();
+    assertThat(singleSelectQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(singleSelectQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(singleSelectQuestion.getSelectedOptionValue())
         .hasValue(LocalizedQuestionOption.create(1L, 1L, "option 1", Locale.US));
   }
@@ -79,8 +79,8 @@ public class SingleSelectQuestionTest {
 
     SingleSelectQuestion singleSelectQuestion = applicantQuestion.createSingleSelectQuestion();
 
-    assertThat(singleSelectQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(singleSelectQuestion.hasConditionErrors()).isFalse();
+    assertThat(singleSelectQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(singleSelectQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(singleSelectQuestion.getSelectedOptionValue()).isEmpty();
   }
 

--- a/universal-application-tool-0.0.1/test/services/applicant/question/StaticContentQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/StaticContentQuestionTest.java
@@ -43,7 +43,7 @@ public class StaticContentQuestionTest extends ResetPostgres {
 
     StaticContentQuestion question = new StaticContentQuestion(applicantQuestion);
 
-    assertThat(question.hasConditionErrors()).isFalse();
-    assertThat(question.hasTypeSpecificErrors()).isFalse();
+    assertThat(question.getQuestionErrors().isEmpty()).isTrue();
+    assertThat(question.getAllTypeSpecificErrors().isEmpty()).isTrue();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
@@ -61,8 +61,8 @@ public class TextQuestionTest extends ResetPostgres {
 
     TextQuestion textQuestion = new TextQuestion(applicantQuestion);
 
-    assertThat(textQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(textQuestion.hasConditionErrors()).isFalse();
+    assertThat(textQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(textQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -75,8 +75,8 @@ public class TextQuestionTest extends ResetPostgres {
     TextQuestion textQuestion = new TextQuestion(applicantQuestion);
 
     assertThat(textQuestion.getTextValue().get()).isEqualTo("hello");
-    assertThat(textQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(textQuestion.hasConditionErrors()).isFalse();
+    assertThat(textQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(textQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -91,8 +91,8 @@ public class TextQuestionTest extends ResetPostgres {
     TextQuestion textQuestion = new TextQuestion(applicantQuestion);
 
     assertThat(textQuestion.getTextValue().get()).isEqualTo(value);
-    assertThat(textQuestion.hasTypeSpecificErrors()).isFalse();
-    assertThat(textQuestion.hasConditionErrors()).isFalse();
+    assertThat(textQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
+    assertThat(textQuestion.getQuestionErrors().isEmpty()).isTrue();
   }
 
   @Test
@@ -114,7 +114,7 @@ public class TextQuestionTest extends ResetPostgres {
     if (textQuestion.getTextValue().isPresent()) {
       assertThat(textQuestion.getTextValue().get()).isEqualTo(value);
     }
-    assertThat(textQuestion.hasTypeSpecificErrors()).isFalse();
+    assertThat(textQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
     assertThat(textQuestion.getQuestionErrors()).hasSize(1);
     String errorMessage = textQuestion.getQuestionErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);


### PR DESCRIPTION
Removing unneeded methods on the Question interface.

### Description
Removing `Question.hasQuestionErrors()`/`Question.hasTypeSpecificErrors()` methods since they're duplicative with `Question.getQuestionErrors()`/`Question.getAllTypeSpecificErrors()`.

Noticed this as part of #1944, where the server-side question validation will likely be updated.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1944 
