### PR TITLE
Set a locationConstraint when creating an S3 bucket for CI tests

### DIFF
--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -7,6 +7,7 @@ source bin/localstack/lib.sh
 
 create_s3_bucket="s3api create-bucket
   --bucket civiform-local-s3
-  --region us-west-2"
+  --region us-west-2
+  --create-bucket-configuration LocationConstraint=us-west-2"
 
 localstack::run_command "${create_s3_bucket}"


### PR DESCRIPTION
Localstack appears to be rejecting these in CI.

### Description
Please explain the changes you made here.

### Tested

- [X] `bin/run-browser-tests address.test.ts` passes locally
- [X] `bin/run-dev` starts successfully
- [X] CI passes

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
