### PR TITLE
Add ability to specify the port the test OIDC provider runs on

### DIFF
--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -43,8 +43,5 @@ process.on('SIGINT', () => {
 });
 
 const server = oidc.listen(oidcPort, () => {
-  console.log(
-    'oidc-provider listening on port %d, check http://localhost:%d/.well-known/openid-configuration',
-    oidcPort,
-    oidcPort);
+  console.log(`oidc-provider listening on port ${oidcPort}, check http://localhost:${oidcPort}/.well-known/openid-configuration`);
 });

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -34,14 +34,17 @@ const configuration = {
   }
 };
 
-const oidc = new Provider('http://localhost:3380', configuration);
+const oidc_port = process.env.OIDC_PORT ? process.env.OIDC_PORT : 3380;
+const oidc = new Provider('http://localhost:' + oidc_port, configuration);
 
-var process = require('process');
 process.on('SIGINT', () => {
   console.info("Interrupted")
   process.exit(0)
 });
 
-const server = oidc.listen(3380, () => {
-  console.log('oidc-provider listening on port 3380, check http://localhost:3380/.well-known/openid-configuration');
+const server = oidc.listen(oidc_port, () => {
+  console.log(
+    'oidc-provider listening on port %d, check http://localhost:%d/.well-known/openid-configuration',
+    oidc_port,
+    oidc_port);
 });

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -34,7 +34,7 @@ const configuration = {
   }
 };
 
-const oidcPort = process.env.OIDC_PORT ? process.env.OIDC_PORT : 3380;
+const oidcPort = process.env.OIDC_PORT || 3380;
 const oidc = new Provider('http://localhost:' + oidcPort, configuration);
 
 process.on('SIGINT', () => {

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -34,17 +34,17 @@ const configuration = {
   }
 };
 
-const oidc_port = process.env.OIDC_PORT ? process.env.OIDC_PORT : 3380;
-const oidc = new Provider('http://localhost:' + oidc_port, configuration);
+const oidcPort = process.env.OIDC_PORT ? process.env.OIDC_PORT : 3380;
+const oidc = new Provider('http://localhost:' + oidcPort, configuration);
 
 process.on('SIGINT', () => {
   console.info("Interrupted")
   process.exit(0)
 });
 
-const server = oidc.listen(oidc_port, () => {
+const server = oidc.listen(oidcPort, () => {
   console.log(
     'oidc-provider listening on port %d, check http://localhost:%d/.well-known/openid-configuration',
-    oidc_port,
-    oidc_port);
+    oidcPort,
+    oidcPort);
 });


### PR DESCRIPTION
### Description
Conditionally uses a supplied port instead of the default 3380.  This is necessary to address #1938 so that the local server can specify a different port than the unit tests.
