### PR TITLE
Update OpenJDK to 11.0.14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG PLATFORM="amd64"
 # workaround uses an aarch64 (arm64) image instead when an optional platform argument is set to arm64.
 # Docker's BuildKit skips unused stages so the image for the platform that isn't used will not be built.
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine-slim as amd64
+FROM adoptopenjdk/openjdk11:jdk-11.0.14.1_1-alpine-slim as amd64
 FROM bellsoft/liberica-openjdk-alpine:11.0.11-9-aarch64 as arm64
 
 FROM ${PLATFORM}

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine-slim AS stage1
+FROM adoptopenjdk/openjdk11:jdk-11.0.14.1_1-alpine-slim AS stage1
 
 ENV SBT_VERSION "1.6.2"
 ENV INSTALL_DIR /usr/local


### PR DESCRIPTION
See Issue #2315 for context. This only updates  the x86/amd64 version, and does not bump the arm64 version, since it is [not yet available](https://hub.docker.com/r/bellsoft/liberica-openjdk-alpine/tags). arm64 is not urgent (to my knowledge) since it is only used for local Mac M1 development.

Fixes (in part) issue #2315. 