### PR TITLE
ApplicationQuestionRenderer refactoring to make subclasses responsible for providing a method to render form content

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -170,10 +170,6 @@ public class ApplicantQuestion {
     }
   }
 
-  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
-    return errorsPresenter().getQuestionErrors();
-  }
-
   public boolean hasErrors() {
     return !errorsPresenter().getQuestionErrors().isEmpty()
         || !errorsPresenter().getAllTypeSpecificErrors().isEmpty();

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -10,7 +10,6 @@ import javax.annotation.Nullable;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.RepeatedEntity;
-import services.applicant.ValidationErrorMessage;
 import services.program.ProgramQuestionDefinition;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.UnsupportedQuestionTypeException;

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -30,14 +30,14 @@ public class EnumeratorQuestion implements Question {
   }
 
   @Override
-  public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
+  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {  
     // There are no inherent requirements in an enumerator question.
     return ImmutableSet.of();
   }
 
-  /** No blank values are allowed. No duplicated entity names are allowed. */
+    /** No blank values are allowed. No duplicated entity names are allowed. */
   @Override
-  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
+  public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
     }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -30,12 +30,12 @@ public class EnumeratorQuestion implements Question {
   }
 
   @Override
-  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {  
+  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     // There are no inherent requirements in an enumerator question.
     return ImmutableSet.of();
   }
 
-    /** No blank values are allowed. No duplicated entity names are allowed. */
+  /** No blank values are allowed. No duplicated entity names are allowed. */
   @Override
   public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     if (!isAnswered()) {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/IdQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/IdQuestion.java
@@ -32,6 +32,11 @@ public class IdQuestion implements Question {
 
   @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
     }
@@ -60,12 +65,6 @@ public class IdQuestion implements Question {
     }
 
     return errors.build();
-  }
-
-  @Override
-  public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
-    // Add id specific errors
-    return ImmutableSet.of();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/TextQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/TextQuestion.java
@@ -31,6 +31,11 @@ public class TextQuestion implements Question {
 
   @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     if (!isAnswered()) {
       return ImmutableSet.of();
     }
@@ -54,12 +59,6 @@ public class TextQuestion implements Question {
     }
 
     return errors.build();
-  }
-
-  @Override
-  public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
-    // There are no inherent requirements in a text question.
-    return ImmutableSet.of();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
@@ -12,7 +12,7 @@ import views.style.ReferenceClasses;
 import views.style.Styles;
 
 /** Renders an address question. */
-public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
+public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public AddressQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -24,7 +24,12 @@ public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return true;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 
@@ -81,6 +86,6 @@ public class AddressQuestionRenderer extends ApplicantQuestionRenderer {
                             .addReferenceClass(ReferenceClasses.ADDRESS_ZIP)
                             .getContainer()));
 
-    return renderInternal(messages, addressQuestionFormContent);
+    return addressQuestionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
@@ -24,11 +24,6 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return true;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -3,8 +3,8 @@ package views.questiontypes;
 import j2html.tags.Tag;
 
 /**
- * Interface for all applicant question renderers. An applicant question renderer renders a
- * question to be seen by an applicant
+ * Interface for all applicant question renderers. An applicant question renderer renders a question
+ * to be seen by an applicant
  */
 public interface ApplicantQuestionRenderer {
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRenderer.java
@@ -1,43 +1,14 @@
 package views.questiontypes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.div;
-
-import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import play.i18n.Messages;
-import services.MessageKey;
-import services.applicant.question.ApplicantQuestion;
-import views.BaseHtmlView;
-import views.components.TextFormatter;
-import views.style.ApplicantStyles;
-import views.style.ReferenceClasses;
-import views.style.Styles;
 
 /**
- * Superclass for all applicant question renderers. An applicant question renderer renders a
- * question to be seen by an applicant, including the input field(s) for the applicant to answer the
- * question.
+ * Interface for all applicant question renderers. An applicant question renderer renders a
+ * question to be seen by an applicant
  */
-public abstract class ApplicantQuestionRenderer {
+public interface ApplicantQuestionRenderer {
 
-  final ApplicantQuestion question;
-
-  public ApplicantQuestionRenderer(ApplicantQuestion question) {
-    this.question = checkNotNull(question);
-  }
-
-  public abstract String getReferenceClass();
-
-  public abstract Tag render(ApplicantQuestionRendererParams params);
-
-  private String getRequiredClass() {
-    return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
-  }
-
-  Tag renderInternal(Messages messages, Tag questionFormContent) {
-    return renderInternal(messages, questionFormContent, true);
-  }
+  String getReferenceClass();
 
   /**
    * Renders an applicant question's text, help text, errors, and the given form content.
@@ -46,43 +17,5 @@ public abstract class ApplicantQuestionRenderer {
    * the form content, so we offer the ability to specify whether or not this method should render
    * the question errors here.
    */
-  Tag renderInternal(
-      Messages messages, Tag questionFormContent, boolean shouldDisplayQuestionErrors) {
-
-    ContainerTag questionTextDiv =
-        div()
-            // Question text
-            .with(
-                div()
-                    .withClasses(
-                        ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT)
-                    .with(TextFormatter.createLinksAndEscapeText(question.getQuestionText())))
-            // Question help text
-            .with(
-                div()
-                    .withClasses(
-                        ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
-                        ApplicantStyles.QUESTION_HELP_TEXT)
-                    .with(TextFormatter.createLinksAndEscapeText(question.getQuestionHelpText())))
-            .withClasses(Styles.MB_4);
-
-    if (shouldDisplayQuestionErrors) {
-      // Question error text
-      questionTextDiv.with(BaseHtmlView.fieldErrors(messages, question.getQuestionErrors()));
-    }
-
-    if (question.isRequiredButWasSkippedInCurrentProgram()) {
-      String requiredQuestionMessage = messages.at(MessageKey.VALIDATION_REQUIRED.getKeyName());
-      questionTextDiv.with(
-          div()
-              .withClasses(Styles.P_1, Styles.TEXT_RED_600)
-              .withText("*" + requiredQuestionMessage));
-    }
-
-    return div()
-        .withId(question.getContextualizedPath().toString())
-        .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
-        .with(questionTextDiv)
-        .with(questionFormContent);
-  }
+  Tag render(ApplicantQuestionRendererParams params);
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -3,10 +3,12 @@ package views.questiontypes;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 
+import com.google.common.collect.ImmutableSet;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import play.i18n.Messages;
 import services.MessageKey;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import views.BaseHtmlView;
 import views.components.TextFormatter;
@@ -32,8 +34,6 @@ public abstract class ApplicantQuestionRendererImpl implements ApplicantQuestion
 
   protected abstract Tag renderTag(ApplicantQuestionRendererParams params);
 
-  protected abstract boolean shouldDisplayQuestionErrors();
-
   @Override
   public final Tag render(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
@@ -54,9 +54,10 @@ public abstract class ApplicantQuestionRendererImpl implements ApplicantQuestion
                     .with(TextFormatter.createLinksAndEscapeText(question.getQuestionHelpText())))
             .withClasses(Styles.MB_4);
 
-    if (shouldDisplayQuestionErrors()) {
+    ImmutableSet<ValidationErrorMessage> questionErrors = question.errorsPresenter().getQuestionErrors();
+    if (!questionErrors.isEmpty()) {
       // Question error text
-      questionTextDiv.with(BaseHtmlView.fieldErrors(messages, question.getQuestionErrors()));
+      questionTextDiv.with(BaseHtmlView.fieldErrors(messages, questionErrors));
     }
 
     if (question.isRequiredButWasSkippedInCurrentProgram()) {

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -20,11 +20,11 @@ import views.style.Styles;
  * Superclass for all applicant question renderers with input field(s) for the applicant to answer
  * the question.
  */
-public abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
+abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
 
   protected final ApplicantQuestion question;
 
-  public ApplicantQuestionRendererImpl(ApplicantQuestion question) {
+  ApplicantQuestionRendererImpl(ApplicantQuestion question) {
     this.question = checkNotNull(question);
   }
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -17,8 +17,8 @@ import views.style.ReferenceClasses;
 import views.style.Styles;
 
 /**
- * Superclass for all applicant question renderers with input field(s) for
- * the applicant to answer the question.
+ * Superclass for all applicant question renderers with input field(s) for the applicant to answer
+ * the question.
  */
 public abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
 
@@ -54,7 +54,8 @@ public abstract class ApplicantQuestionRendererImpl implements ApplicantQuestion
                     .with(TextFormatter.createLinksAndEscapeText(question.getQuestionHelpText())))
             .withClasses(Styles.MB_4);
 
-    ImmutableSet<ValidationErrorMessage> questionErrors = question.errorsPresenter().getQuestionErrors();
+    ImmutableSet<ValidationErrorMessage> questionErrors =
+        question.errorsPresenter().getQuestionErrors();
     if (!questionErrors.isEmpty()) {
       // Question error text
       questionTextDiv.with(BaseHtmlView.fieldErrors(messages, questionErrors));

--- a/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -1,0 +1,76 @@
+package views.questiontypes;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.div;
+
+import j2html.tags.ContainerTag;
+import j2html.tags.Tag;
+import play.i18n.Messages;
+import services.MessageKey;
+import services.applicant.question.ApplicantQuestion;
+import views.BaseHtmlView;
+import views.components.TextFormatter;
+import views.style.ApplicantStyles;
+import views.style.ReferenceClasses;
+import views.style.Styles;
+
+/**
+ * Superclass for all applicant question renderers with input field(s) for
+ * the applicant to answer the question.
+ */
+public abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRenderer {
+
+  protected final ApplicantQuestion question;
+
+  public ApplicantQuestionRendererImpl(ApplicantQuestion question) {
+    this.question = checkNotNull(question);
+  }
+
+  private String getRequiredClass() {
+    return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
+  }
+
+  protected abstract Tag renderTag(ApplicantQuestionRendererParams params);
+
+  protected abstract boolean shouldDisplayQuestionErrors();
+
+  @Override
+  public final Tag render(ApplicantQuestionRendererParams params) {
+    Messages messages = params.messages();
+    ContainerTag questionTextDiv =
+        div()
+            // Question text
+            .with(
+                div()
+                    .withClasses(
+                        ReferenceClasses.APPLICANT_QUESTION_TEXT, ApplicantStyles.QUESTION_TEXT)
+                    .with(TextFormatter.createLinksAndEscapeText(question.getQuestionText())))
+            // Question help text
+            .with(
+                div()
+                    .withClasses(
+                        ReferenceClasses.APPLICANT_QUESTION_HELP_TEXT,
+                        ApplicantStyles.QUESTION_HELP_TEXT)
+                    .with(TextFormatter.createLinksAndEscapeText(question.getQuestionHelpText())))
+            .withClasses(Styles.MB_4);
+
+    if (shouldDisplayQuestionErrors()) {
+      // Question error text
+      questionTextDiv.with(BaseHtmlView.fieldErrors(messages, question.getQuestionErrors()));
+    }
+
+    if (question.isRequiredButWasSkippedInCurrentProgram()) {
+      String requiredQuestionMessage = messages.at(MessageKey.VALIDATION_REQUIRED.getKeyName());
+      questionTextDiv.with(
+          div()
+              .withClasses(Styles.P_1, Styles.TEXT_RED_600)
+              .withText("*" + requiredQuestionMessage));
+    }
+
+    return div()
+        .withId(question.getContextualizedPath().toString())
+        .withClasses(Styles.MX_AUTO, Styles.MB_8, getReferenceClass(), getRequiredClass())
+        .with(questionTextDiv)
+        .with(renderTag(params));
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -29,11 +29,6 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return true;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -17,7 +17,7 @@ import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders a checkbox question. */
-public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
+public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   @Override
   public String getReferenceClass() {
@@ -29,7 +29,12 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return true;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
     Tag checkboxQuestionFormContent =
@@ -52,7 +57,7 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRenderer {
                                 option,
                                 multiOptionQuestion.optionIsSelected(option))));
 
-    return renderInternal(params.messages(), checkboxQuestionFormContent);
+    return checkboxQuestionFormContent;
   }
 
   private Tag renderCheckboxOption(

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -12,7 +12,7 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 import views.style.Styles;
 
-public class CurrencyQuestionRenderer extends ApplicantQuestionRenderer {
+public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public CurrencyQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -24,7 +24,12 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 
     FieldWithLabel currencyField =
@@ -58,6 +63,6 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRenderer {
     Tag currencyQuestionFormContent =
         div().withClasses(Styles.FLEX).with(dollarSign).with(currencyField.getContainer());
 
-    return renderInternal(params.messages(), currencyQuestionFormContent, false);
+    return currencyQuestionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -24,11 +24,6 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
@@ -21,11 +21,6 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     DateQuestion dateQuestion = question.createDateQuestion();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DateQuestionRenderer.java
@@ -9,7 +9,7 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 
 /** Renders a date question. */
-public class DateQuestionRenderer extends ApplicantQuestionRenderer {
+public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public DateQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -21,7 +21,12 @@ public class DateQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =
@@ -34,6 +39,6 @@ public class DateQuestionRenderer extends ApplicantQuestionRenderer {
     }
     Tag dateQuestionFormContent = dateField.getContainer();
 
-    return renderInternal(params.messages(), dateQuestionFormContent, false);
+    return dateQuestionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -13,7 +13,7 @@ import services.question.LocalizedQuestionOption;
 import views.components.SelectWithLabel;
 
 /** Renders a dropdown question. */
-public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
+public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public DropdownQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -25,7 +25,12 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return true;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 
@@ -49,6 +54,6 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRenderer {
 
     Tag dropdownQuestionFormContent = div().with(select.getContainer());
 
-    return renderInternal(params.messages(), dropdownQuestionFormContent);
+    return dropdownQuestionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -25,11 +25,6 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return true;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
@@ -19,11 +19,6 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 
@@ -31,7 +26,7 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.email()
             .setFieldName(emailQuestion.getEmailPath().toString())
             .setValue(emailQuestion.getEmailValue().orElse(""))
-            .setFieldErrors(params.messages(), emailQuestion.getQuestionErrors())
+            .setFieldErrors(params.messages(), emailQuestion.getAllTypeSpecificErrors())
             .setScreenReaderText(question.getQuestionText())
             .getContainer();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EmailQuestionRenderer.java
@@ -7,7 +7,7 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 
 /** Renders an email question. */
-public class EmailQuestionRenderer extends ApplicantQuestionRenderer {
+public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public EmailQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -19,7 +19,12 @@ public class EmailQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 
     Tag questionFormContent =
@@ -30,6 +35,6 @@ public class EmailQuestionRenderer extends ApplicantQuestionRenderer {
             .setScreenReaderText(question.getQuestionText())
             .getContainer();
 
-    return renderInternal(params.messages(), questionFormContent, false);
+    return questionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -50,11 +50,6 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
@@ -77,7 +72,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
             .withClasses(
                 ReferenceClasses.ENUMERATOR_ERROR,
                 BaseStyles.FORM_ERROR_TEXT_BASE,
-                enumeratorQuestion.getQuestionErrors().isEmpty() ? Styles.HIDDEN : "");
+                enumeratorQuestion.getAllTypeSpecificErrors().isEmpty() ? Styles.HIDDEN : "");
 
     Tag enumeratorQuestionFormContent =
         div()

--- a/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -25,7 +25,7 @@ import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders an enumerator question. */
-public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
+public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   private static final String ENUMERATOR_FIELDS_ID = "enumerator-fields";
   private static final String ADD_ELEMENT_BUTTON_ID = "enumerator-field-add-button";
@@ -50,7 +50,12 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();
@@ -91,7 +96,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRenderer {
                         ApplicantStyles.BUTTON_ENUMERATOR_ADD_ENTITY,
                         StyleUtils.disabled(Styles.BG_GRAY_200, Styles.TEXT_GRAY_400)));
 
-    return renderInternal(messages, enumeratorQuestionFormContent, false);
+    return enumeratorQuestionFormContent;
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -34,7 +34,7 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
     return FieldWithLabel.input()
         .setFieldName(fileuploadQuestion.getFileKeyPath().toString())
         .setValue(value)
-        .setFieldErrors(params.messages(), fileuploadQuestion.getQuestionErrors())
+        .setFieldErrors(params.messages(), fileuploadQuestion.getAllTypeSpecificErrors())
         .getContainer();
   }
 
@@ -43,11 +43,6 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
     super(question);
     this.fileuploadQuestion = question.createFileUploadQuestion();
     this.fileUploadViewStrategy = fileUploadViewStrategy;
-  }
-
-  @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return true;
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -18,7 +18,7 @@ import views.style.ReferenceClasses;
  * <p>A file upload question requires a different form. See {@code
  * views.applicant.ApplicantProgramBlockEditView#renderFileUploadBlockSubmitForms}.
  */
-public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
+public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   private static final String IMAGES_AND_PDF = "image/*,.pdf";
 
   private final FileUploadViewStrategy fileUploadViewStrategy;
@@ -46,8 +46,13 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
-    return renderInternal(params.messages(), fileUploadFields(params));
+  protected boolean shouldDisplayQuestionErrors() {
+      return true;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+    return fileUploadFields(params);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
@@ -16,10 +16,6 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   public String getReferenceClass() {
     return "cf-question-id";
   }
-  @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
 
   @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
@@ -29,7 +25,7 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.input()
             .setFieldName(idQuestion.getIdPath().toString())
             .setValue(idQuestion.getIdValue().orElse(""))
-            .setFieldErrors(params.messages(), idQuestion.getQuestionErrors())
+            .setFieldErrors(params.messages(), idQuestion.getAllTypeSpecificErrors())
             .setScreenReaderText(question.getQuestionText())
             .getContainer();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/IdQuestionRenderer.java
@@ -6,7 +6,7 @@ import services.applicant.question.IdQuestion;
 import views.components.FieldWithLabel;
 
 /** Renders an id question. */
-public class IdQuestionRenderer extends ApplicantQuestionRenderer {
+public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public IdQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -16,9 +16,13 @@ public class IdQuestionRenderer extends ApplicantQuestionRenderer {
   public String getReferenceClass() {
     return "cf-question-id";
   }
+  @Override
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     IdQuestion idQuestion = question.createIdQuestion();
 
     Tag questionFormContent =
@@ -29,6 +33,6 @@ public class IdQuestionRenderer extends ApplicantQuestionRenderer {
             .setScreenReaderText(question.getQuestionText())
             .getContainer();
 
-    return renderInternal(params.messages(), questionFormContent, false);
+    return questionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
@@ -23,11 +23,6 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return true;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
@@ -11,7 +11,7 @@ import views.components.FieldWithLabel;
 import views.style.ReferenceClasses;
 
 /** Renders a name question. */
-public class NameQuestionRenderer extends ApplicantQuestionRenderer {
+public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public NameQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -23,7 +23,12 @@ public class NameQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return true;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 
@@ -55,6 +60,6 @@ public class NameQuestionRenderer extends ApplicantQuestionRenderer {
                     .addReferenceClass(ReferenceClasses.NAME_LAST)
                     .getContainer());
 
-    return renderInternal(messages, nameQuestionFormContent);
+    return nameQuestionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
@@ -12,7 +12,7 @@ import services.applicant.question.NumberQuestion;
 import views.components.FieldWithLabel;
 
 /** Renders a number question. */
-public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
+public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public NumberQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -24,7 +24,12 @@ public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =
@@ -47,6 +52,6 @@ public class NumberQuestionRenderer extends ApplicantQuestionRenderer {
 
     Tag numberQuestionFormContent = div().with(numberField.getContainer());
 
-    return renderInternal(params.messages(), numberQuestionFormContent, false);
+    return numberQuestionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NumberQuestionRenderer.java
@@ -24,11 +24,6 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -17,7 +17,7 @@ import views.style.StyleUtils;
 import views.style.Styles;
 
 /** Renders a radio button question. */
-public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
+public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public RadioButtonQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -29,7 +29,12 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return true;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
     Tag radioQuestionFormContent =
@@ -44,7 +49,7 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRenderer {
                                 option,
                                 singleOptionQuestion.optionIsSelected(option))));
 
-    return renderInternal(params.messages(), radioQuestionFormContent);
+    return radioQuestionFormContent;
   }
 
   private Tag renderRadioOption(

--- a/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -29,11 +29,6 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return true;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/StaticContentQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/StaticContentQuestionRenderer.java
@@ -1,5 +1,6 @@
 package views.questiontypes;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
 
 import j2html.tags.ContainerTag;
@@ -10,10 +11,11 @@ import views.style.ReferenceClasses;
 import views.style.Styles;
 
 /** This renders the question text as formatted text. */
-public class StaticContentQuestionRenderer extends ApplicantQuestionRenderer {
+public class StaticContentQuestionRenderer implements ApplicantQuestionRenderer {
+  private final ApplicantQuestion question;
 
   public StaticContentQuestionRenderer(ApplicantQuestion question) {
-    super(question);
+    this.question = checkNotNull(question);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -18,11 +18,6 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected boolean shouldDisplayQuestionErrors() {
-      return false;
-  }
-
-  @Override
   protected Tag renderTag(ApplicantQuestionRendererParams params) {
     TextQuestion textQuestion = question.createTextQuestion();
 
@@ -30,7 +25,7 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
         FieldWithLabel.input()
             .setFieldName(textQuestion.getTextPath().toString())
             .setValue(textQuestion.getTextValue().orElse(""))
-            .setFieldErrors(params.messages(), textQuestion.getQuestionErrors())
+            .setFieldErrors(params.messages(), textQuestion.getAllTypeSpecificErrors())
             .setScreenReaderText(question.getQuestionText())
             .getContainer();
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/TextQuestionRenderer.java
@@ -6,7 +6,7 @@ import services.applicant.question.TextQuestion;
 import views.components.FieldWithLabel;
 
 /** Renders a text question. */
-public class TextQuestionRenderer extends ApplicantQuestionRenderer {
+public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
 
   public TextQuestionRenderer(ApplicantQuestion question) {
     super(question);
@@ -18,7 +18,12 @@ public class TextQuestionRenderer extends ApplicantQuestionRenderer {
   }
 
   @Override
-  public Tag render(ApplicantQuestionRendererParams params) {
+  protected boolean shouldDisplayQuestionErrors() {
+      return false;
+  }
+
+  @Override
+  protected Tag renderTag(ApplicantQuestionRendererParams params) {
     TextQuestion textQuestion = question.createTextQuestion();
 
     Tag questionFormContent =
@@ -29,6 +34,6 @@ public class TextQuestionRenderer extends ApplicantQuestionRenderer {
             .setScreenReaderText(question.getQuestionText())
             .getContainer();
 
-    return renderInternal(params.messages(), questionFormContent, false);
+    return questionFormContent;
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/EnumeratorQuestionTest.java
@@ -91,9 +91,9 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).containsExactly(value);
-    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
-    assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
-    assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
+    assertThat(enumeratorQuestion.getQuestionErrors().isEmpty()).isTrue();
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors()).hasSize(1);
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().asList().get(0).getMessage(messages))
         .isEqualTo("Please enter a value for each line.");
   }
 
@@ -110,9 +110,9 @@ public class EnumeratorQuestionTest extends ResetPostgres {
 
     assertThat(enumeratorQuestion.isAnswered()).isTrue();
     assertThat(enumeratorQuestion.getEntityNames()).containsExactly("hello", "hello");
-    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
-    assertThat(enumeratorQuestion.getQuestionErrors()).hasSize(1);
-    assertThat(enumeratorQuestion.getQuestionErrors().asList().get(0).getMessage(messages))
+    assertThat(enumeratorQuestion.getQuestionErrors().isEmpty()).isTrue();
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors()).hasSize(1);
+    assertThat(enumeratorQuestion.getAllTypeSpecificErrors().asList().get(0).getMessage(messages))
         .isEqualTo("Please enter a unique value for each line.");
   }
 

--- a/universal-application-tool-0.0.1/test/services/applicant/question/IdQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/IdQuestionTest.java
@@ -115,7 +115,8 @@ public class IdQuestionTest extends ResetPostgres {
     }
     assertThat(idQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(idQuestion.getAllTypeSpecificErrors()).hasSize(1);
-    String errorMessage = idQuestion.getAllTypeSpecificErrors().iterator().next().getMessage(messages);
+    String errorMessage =
+        idQuestion.getAllTypeSpecificErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/IdQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/IdQuestionTest.java
@@ -113,9 +113,9 @@ public class IdQuestionTest extends ResetPostgres {
     if (idQuestion.getIdValue().isPresent()) {
       assertThat(idQuestion.getIdValue().get()).isEqualTo(value);
     }
-    assertThat(idQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
-    assertThat(idQuestion.getQuestionErrors()).hasSize(1);
-    String errorMessage = idQuestion.getQuestionErrors().iterator().next().getMessage(messages);
+    assertThat(idQuestion.getQuestionErrors().isEmpty()).isTrue();
+    assertThat(idQuestion.getAllTypeSpecificErrors()).hasSize(1);
+    String errorMessage = idQuestion.getAllTypeSpecificErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
@@ -116,7 +116,8 @@ public class TextQuestionTest extends ResetPostgres {
     }
     assertThat(textQuestion.getQuestionErrors().isEmpty()).isTrue();
     assertThat(textQuestion.getAllTypeSpecificErrors()).hasSize(1);
-    String errorMessage = textQuestion.getAllTypeSpecificErrors().iterator().next().getMessage(messages);
+    String errorMessage =
+        textQuestion.getAllTypeSpecificErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/question/TextQuestionTest.java
@@ -114,9 +114,9 @@ public class TextQuestionTest extends ResetPostgres {
     if (textQuestion.getTextValue().isPresent()) {
       assertThat(textQuestion.getTextValue().get()).isEqualTo(value);
     }
-    assertThat(textQuestion.getAllTypeSpecificErrors().isEmpty()).isTrue();
-    assertThat(textQuestion.getQuestionErrors()).hasSize(1);
-    String errorMessage = textQuestion.getQuestionErrors().iterator().next().getMessage(messages);
+    assertThat(textQuestion.getQuestionErrors().isEmpty()).isTrue();
+    assertThat(textQuestion.getAllTypeSpecificErrors()).hasSize(1);
+    String errorMessage = textQuestion.getAllTypeSpecificErrors().iterator().next().getMessage(messages);
     assertThat(errorMessage).isEqualTo(expectedErrorMessage);
   }
 }


### PR DESCRIPTION
### Description
Inverting ApplicantQuestionRenderer pattern from having implementations call renderInternal, which creates the wrapping div to instead have them implement renderTag.

Why? Simpler to ensure all input-providing question types are wrapped in the same div.

ApplicantQuestionRenderer was converted to an interface since static questions don't render with any input values.

For consistency, also switched error validation for a few question types from `getQuestionErrors` to `getAllTypeSpecificErrors`. The former errors are shown above any specific field, while the latter are shown for specific fields.

Noticed this as part of #1944, since server-side rendering of errors will likely be updated for various question types.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
