### PR TITLE
Check for existence of S3 bucket prior to creating it in localstack.

### DIFF
--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -5,9 +5,16 @@
 source bin/lib.sh
 source bin/localstack/lib.sh
 
+BUCKET_NAME="civiform-local-s3"
+
+check_bucket="s3api get-bucket-location
+  --bucket ${BUCKET_NAME}"
+
 create_s3_bucket="s3api create-bucket
-  --bucket civiform-local-s3
+  --bucket ${BUCKET_NAME}
   --region us-west-2
   --create-bucket-configuration LocationConstraint=us-west-2"
 
-localstack::run_command "${create_s3_bucket}"
+# We first check to see if the desired bucket already exists
+# prior to trying to create it.
+localstack::run_command "${check_bucket}" || localstack::run_command "${create_s3_bucket}"

--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -16,4 +16,5 @@ create_s3_bucket="s3api create-bucket
 
 # We first check to see if the desired bucket already exists
 # prior to trying to create it.
-localstack::run_command "${check_bucket}" || localstack::run_command "${create_s3_bucket}"
+localstack::run_command "${check_bucket}" \
+  || localstack::run_command "${create_s3_bucket}"

--- a/bin/localstack/mk-s3
+++ b/bin/localstack/mk-s3
@@ -7,8 +7,7 @@ source bin/localstack/lib.sh
 
 BUCKET_NAME="civiform-local-s3"
 
-check_bucket="s3api get-bucket-location
-  --bucket ${BUCKET_NAME}"
+check_bucket="s3api get-bucket-location --bucket ${BUCKET_NAME}"
 
 create_s3_bucket="s3api create-bucket
   --bucket ${BUCKET_NAME}


### PR DESCRIPTION
### Description

Now that we potentially reuse the same Docker container for `bin/run-dev`, it's possible that the S3 bucket might already exist in the `localstack` container. This leads to the following error:

`An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: Your previous request to create the named bucket succeeded and you already own it.`

Per @kmcnellis, we can simply check for the existence of the bucket prior to trying to create it.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
