### PR TITLE
Create base class for applicant Question to reduce duplicate implementation of isAnswered

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -192,8 +192,7 @@ public final class Block {
   /** A block is answered if all of its {@link ApplicantQuestion}s {@link Question#isAnswered()}. */
   private boolean isAnswered() {
     return getQuestions().stream()
-        .map(ApplicantQuestion::errorsPresenter)
-        .allMatch(Question::isAnswered);
+        .allMatch(ApplicantQuestion::isAnswered);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -191,8 +191,7 @@ public final class Block {
 
   /** A block is answered if all of its {@link ApplicantQuestion}s {@link Question#isAnswered()}. */
   private boolean isAnswered() {
-    return getQuestions().stream()
-        .allMatch(ApplicantQuestion::isAnswered);
+    return getQuestions().stream().allMatch(ApplicantQuestion::isAnswered);
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/AddressQuestion.java
@@ -17,11 +17,10 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class AddressQuestion implements Question {
+public class AddressQuestion extends QuestionImpl {
   private static final String PO_BOX_REGEX =
       "(?i)(.*(P(OST|.)?\\s*((O(FF(ICE)?)?)?.?\\s*(B(IN|OX|.?)))+)).*";
 
-  private final ApplicantQuestion applicantQuestion;
   private Optional<String> streetValue;
   private Optional<String> line2Value;
   private Optional<String> cityValue;
@@ -29,8 +28,12 @@ public class AddressQuestion implements Question {
   private Optional<String> zipValue;
 
   public AddressQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.ADDRESS);
   }
 
   @Override
@@ -180,18 +183,7 @@ public class AddressQuestion implements Question {
     return zipValue;
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.ADDRESS)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not an ADDRESS question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public AddressQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (AddressQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 
@@ -213,36 +205,6 @@ public class AddressQuestion implements Question {
 
   public Path getZipPath() {
     return applicantQuestion.getContextualizedPath().join(Scalar.ZIP);
-  }
-
-  private boolean isStreetAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getStreetPath());
-  }
-
-  private boolean isLine2Answered() {
-    return applicantQuestion.getApplicantData().hasPath(getLine2Path());
-  }
-
-  private boolean isCityAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getCityPath());
-  }
-
-  private boolean isStateAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getStatePath());
-  }
-
-  private boolean isZipAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getZipPath());
-  }
-
-  /** Returns true if any field is answered. Returns false if all are not. */
-  @Override
-  public boolean isAnswered() {
-    return isStreetAnswered()
-        || isLine2Answered()
-        || isCityAnswered()
-        || isStateAnswered()
-        || isZipAnswered();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -120,8 +120,7 @@ public class ApplicantQuestion {
       // If there aren't any paths, consider the question answered
       return true;
     }
-    return questionPaths.stream()
-        .anyMatch(p -> getApplicantData().hasPath(p));
+    return questionPaths.stream().anyMatch(p -> getApplicantData().hasPath(p));
   }
 
   /** Returns true if this question was most recently updated in this program. */

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -2,6 +2,7 @@ package services.applicant.question;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
@@ -98,7 +99,7 @@ public class ApplicantQuestion {
    *     program specified.
    */
   public boolean isAnsweredOrSkippedOptionalInProgram() {
-    return errorsPresenter().isAnswered() || (isOptional() && wasRecentlyUpdatedInThisProgram());
+    return isAnswered() || (isOptional() && wasRecentlyUpdatedInThisProgram());
   }
 
   /**
@@ -106,7 +107,21 @@ public class ApplicantQuestion {
    * the current program.
    */
   public boolean isRequiredButWasSkippedInCurrentProgram() {
-    return !isOptional() && !errorsPresenter().isAnswered() && wasRecentlyUpdatedInThisProgram();
+    return !isOptional() && !isAnswered() && wasRecentlyUpdatedInThisProgram();
+  }
+
+  public boolean isAnswered() {
+    if (getType() == QuestionType.ENUMERATOR) {
+      // This is answered if the the path to the enumerator question answer array exists.
+      return getApplicantData().hasPath(getContextualizedPath().atIndex(0));
+    }
+    ImmutableList<Path> questionPaths = errorsPresenter().getAllPaths();
+    if (questionPaths.isEmpty()) {
+      // If there aren't any paths, consider the question answered
+      return true;
+    }
+    return questionPaths.stream()
+        .anyMatch(p -> getApplicantData().hasPath(p));
   }
 
   /** Returns true if this question was most recently updated in this program. */

--- a/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/ApplicantQuestion.java
@@ -2,7 +2,6 @@ package services.applicant.question;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
@@ -111,16 +110,7 @@ public class ApplicantQuestion {
   }
 
   public boolean isAnswered() {
-    if (getType() == QuestionType.ENUMERATOR) {
-      // This is answered if the the path to the enumerator question answer array exists.
-      return getApplicantData().hasPath(getContextualizedPath().atIndex(0));
-    }
-    ImmutableList<Path> questionPaths = errorsPresenter().getAllPaths();
-    if (questionPaths.isEmpty()) {
-      // If there aren't any paths, consider the question answered
-      return true;
-    }
-    return questionPaths.stream().anyMatch(p -> getApplicantData().hasPath(p));
+    return errorsPresenter().isAnswered();
   }
 
   /** Returns true if this question was most recently updated in this program. */

--- a/universal-application-tool-0.0.1/app/services/applicant/question/CurrencyQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/CurrencyQuestion.java
@@ -14,16 +14,19 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class CurrencyQuestion implements Question {
+public class CurrencyQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   // Stores the value, loading and caching it on first access.
   private Optional<Optional<Currency>> currencyCache;
 
   public CurrencyQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
+    super(applicantQuestion);
     this.currencyCache = Optional.empty();
-    assertQuestionType();
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.CURRENCY);
   }
 
   @Override
@@ -42,11 +45,6 @@ public class CurrencyQuestion implements Question {
     return ImmutableSet.of();
   }
 
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getCurrencyPath());
-  }
-
   public Optional<Currency> getValue() {
     if (currencyCache.isEmpty()) {
       currencyCache =
@@ -56,18 +54,7 @@ public class CurrencyQuestion implements Question {
     return currencyCache.get();
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.CURRENCY)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a CURRENCY question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public CurrencyQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (CurrencyQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/DateQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/DateQuestion.java
@@ -15,17 +15,19 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class DateQuestion implements Question {
-
-  private final ApplicantQuestion applicantQuestion;
+public class DateQuestion extends QuestionImpl {
 
   private Optional<LocalDate> dateValue;
 
   public DateQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
   }
 
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.DATE);
+  }
+  
   @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     return ImmutableSet.of();
@@ -40,11 +42,6 @@ public class DateQuestion implements Question {
   @Override
   public ImmutableList<Path> getAllPaths() {
     return ImmutableList.of(getDatePath());
-  }
-
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getDatePath());
   }
 
   public Path getDatePath() {
@@ -69,17 +66,6 @@ public class DateQuestion implements Question {
   }
 
   public DateQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (DateQuestionDefinition) applicantQuestion.getQuestionDefinition();
-  }
-
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.DATE)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a DATE question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/DateQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/DateQuestion.java
@@ -27,7 +27,7 @@ public class DateQuestion extends QuestionImpl {
   protected ImmutableSet<QuestionType> validQuestionTypes() {
     return ImmutableSet.of(QuestionType.DATE);
   }
-  
+
   @Override
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
     return ImmutableSet.of();

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EmailQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EmailQuestion.java
@@ -13,14 +13,17 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class EmailQuestion implements Question {
+public class EmailQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   private Optional<String> emailValue;
 
   public EmailQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.EMAIL);
   }
 
   @Override
@@ -32,11 +35,6 @@ public class EmailQuestion implements Question {
   public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     // TODO: Need to add some Email specific validation.
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getEmailPath());
   }
 
   @Override
@@ -64,17 +62,6 @@ public class EmailQuestion implements Question {
   }
 
   public EmailQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (EmailQuestionDefinition) applicantQuestion.getQuestionDefinition();
-  }
-
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.EMAIL)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not an Email question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -26,6 +26,14 @@ public class EnumeratorQuestion extends QuestionImpl {
   }
 
   @Override
+  public boolean isAnswered() {
+    // This is answered if the the path to the enumerator question answer array exists.
+    return applicantQuestion
+        .getApplicantData()
+        .hasPath(applicantQuestion.getContextualizedPath().atIndex(0));
+  }
+
+  @Override
   public ImmutableList<Path> getAllPaths() {
     // Not intended to return the leaf question paths.
     return ImmutableList.of();

--- a/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/EnumeratorQuestion.java
@@ -14,13 +14,15 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class EnumeratorQuestion implements Question {
-
-  private final ApplicantQuestion applicantQuestion;
+public class EnumeratorQuestion extends QuestionImpl {
 
   public EnumeratorQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.ENUMERATOR);
   }
 
   @Override
@@ -59,27 +61,8 @@ public class EnumeratorQuestion implements Question {
     return ValidationErrorMessage.create(MessageKey.ENUMERATOR_VALIDATION_DUPLICATE_ENTITY_NAME);
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.ENUMERATOR)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a ENUMERATOR question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public EnumeratorQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (EnumeratorQuestionDefinition) applicantQuestion.getQuestionDefinition();
-  }
-
-  /** This is answered if the the path to the enumerator question answer array exists. */
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion
-        .getApplicantData()
-        .hasPath(applicantQuestion.getContextualizedPath().atIndex(0));
   }
 
   /** Return the repeated entity names associated with this enumerator question. */

--- a/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
@@ -41,13 +41,21 @@ public class FileUploadQuestion extends QuestionImpl {
 
   @Override
   public ImmutableList<Path> getAllPaths() {
-    return ImmutableList.of(getFileKeyPath());
+    return ImmutableList.of();
   }
 
   @Override
   public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     // There are no inherent requirements in a file upload question.
     return ImmutableSet.of();
+  }
+
+  @Override
+  public boolean isAnswered() {
+    // TODO(#1944): Consider adding getFileKeyPath to getAllPaths.
+    // Adding it currently would cause the value to start being exported
+    // by the demographics exporter.
+    return applicantQuestion.getApplicantData().hasPath(getFileKeyPath());
   }
 
   public ValidationErrorMessage fileRequiredMessage() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/FileUploadQuestion.java
@@ -14,9 +14,8 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class FileUploadQuestion implements Question {
+public class FileUploadQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   // This value is serving double duty as a singleton load of the value.
   // This value is an optional of an optional because not all questions are file upload questions,
   // and if they are this value could still not be set.
@@ -24,10 +23,14 @@ public class FileUploadQuestion implements Question {
   private Optional<Optional<String>> originalFileNameValueCache;
 
   public FileUploadQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
+    super(applicantQuestion);
     this.fileKeyValueCache = Optional.empty();
     this.originalFileNameValueCache = Optional.empty();
-    assertQuestionType();
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.FILEUPLOAD);
   }
 
   @Override
@@ -38,19 +41,13 @@ public class FileUploadQuestion implements Question {
 
   @Override
   public ImmutableList<Path> getAllPaths() {
-    // We can't predict ahead of time what the path will be.
-    return ImmutableList.of();
+    return ImmutableList.of(getFileKeyPath());
   }
 
   @Override
   public ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors() {
     // There are no inherent requirements in a file upload question.
     return ImmutableSet.of();
-  }
-
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getFileKeyPath());
   }
 
   public ValidationErrorMessage fileRequiredMessage() {
@@ -79,18 +76,7 @@ public class FileUploadQuestion implements Question {
     return originalFileNameValueCache.get();
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.FILEUPLOAD)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a FILEUPLOAD question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public FileUploadQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (FileUploadQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/IdQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/IdQuestion.java
@@ -15,14 +15,17 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class IdQuestion implements Question {
+public class IdQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   private Optional<String> idValue;
 
   public IdQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.ID);
   }
 
   @Override
@@ -67,11 +70,6 @@ public class IdQuestion implements Question {
     return errors.build();
   }
 
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getIdPath());
-  }
-
   public Optional<String> getIdValue() {
     if (idValue != null) {
       return idValue;
@@ -80,18 +78,7 @@ public class IdQuestion implements Question {
     return idValue;
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.ID)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not an Id question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public IdQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (IdQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
@@ -12,6 +12,7 @@ import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionType;
 
 /**
  * Represents a multi-select question in the context of a specific applicant.
@@ -21,14 +22,18 @@ import services.question.types.MultiOptionQuestionDefinition;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class MultiSelectQuestion implements Question {
+public class MultiSelectQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   private Optional<ImmutableList<LocalizedQuestionOption>> selectedOptionsValue;
 
   public MultiSelectQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(
+      QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
   }
 
   @Override
@@ -77,11 +82,6 @@ public class MultiSelectQuestion implements Question {
     return ImmutableList.of(getSelectionPath());
   }
 
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getSelectionPath());
-  }
-
   /** Get the selected options in the applicant's preferred locale. */
   public Optional<ImmutableList<LocalizedQuestionOption>> getSelectedOptionsValue() {
     if (selectedOptionsValue == null) {
@@ -114,18 +114,7 @@ public class MultiSelectQuestion implements Question {
         && getSelectedOptionsValue().get().contains(option);
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().isMultiOptionType()) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a multi-option question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public MultiOptionQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (MultiOptionQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/MultiSelectQuestion.java
@@ -32,8 +32,7 @@ public class MultiSelectQuestion extends QuestionImpl {
 
   @Override
   protected ImmutableSet<QuestionType> validQuestionTypes() {
-    return ImmutableSet.of(
-      QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
+    return ImmutableSet.of(QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NameQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NameQuestion.java
@@ -16,16 +16,19 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class NameQuestion implements Question {
+public class NameQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   private Optional<String> firstNameValue;
   private Optional<String> middleNameValue;
   private Optional<String> lastNameValue;
 
   public NameQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.NAME);
   }
 
   @Override
@@ -102,18 +105,7 @@ public class NameQuestion implements Question {
     return lastNameValue;
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.NAME)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a NAME question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public NameQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (NameQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 
@@ -127,26 +119,6 @@ public class NameQuestion implements Question {
 
   public Path getLastNamePath() {
     return applicantQuestion.getContextualizedPath().join(Scalar.LAST_NAME);
-  }
-
-  private boolean isFirstNameAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getFirstNamePath());
-  }
-
-  private boolean isMiddleNameAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getMiddleNamePath());
-  }
-
-  private boolean isLastNameAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getLastNamePath());
-  }
-
-  /**
-   * Returns true if any one of the name fields is answered. Returns false if all are not answered.
-   */
-  @Override
-  public boolean isAnswered() {
-    return isFirstNameAnswered() || isMiddleNameAnswered() || isLastNameAnswered();
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -14,14 +14,17 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class NumberQuestion implements Question {
-
-  private final ApplicantQuestion applicantQuestion;
+public class NumberQuestion extends QuestionImpl {
+  
   private Optional<Long> numberValue;
 
   public NumberQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.NUMBER);
   }
 
   @Override
@@ -71,11 +74,6 @@ public class NumberQuestion implements Question {
     return ImmutableSet.of();
   }
 
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getNumberPath());
-  }
-
   public Optional<Long> getNumberValue() {
     if (numberValue != null) {
       return numberValue;
@@ -86,18 +84,7 @@ public class NumberQuestion implements Question {
     return numberValue;
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.NUMBER)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a NUMBER question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public NumberQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (NumberQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/NumberQuestion.java
@@ -15,7 +15,7 @@ import services.question.types.QuestionType;
  * <p>See {@link ApplicantQuestion} for details.
  */
 public class NumberQuestion extends QuestionImpl {
-  
+
   private Optional<Long> numberValue;
 
   public NumberQuestion(ApplicantQuestion applicantQuestion) {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Question.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Question.java
@@ -29,6 +29,12 @@ public interface Question {
   ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors();
 
   /**
+   * Returns true any part of the question has been answered by the applicant. Blank answers should
+   * not count. If a question is not answered, it should not have errors associated with it.
+   */
+  boolean isAnswered();
+
+  /**
    * Returns the answer as a text string.
    *
    * <p>This is the canonical representation to users in static contexts such as the review page and

--- a/universal-application-tool-0.0.1/app/services/applicant/question/Question.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/Question.java
@@ -29,12 +29,6 @@ public interface Question {
   ImmutableSet<ValidationErrorMessage> getAllTypeSpecificErrors();
 
   /**
-   * Returns true any part of the question has been answered by the applicant. Blank answers should
-   * not count. In general, if a question is not answered, it cannot have errors associated with it.
-   */
-  boolean isAnswered();
-
-  /**
    * Returns the answer as a text string.
    *
    * <p>This is the canonical representation to users in static contexts such as the review page and

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -32,8 +32,8 @@ abstract class QuestionImpl implements Question {
 
   /**
    * A question is considered answered if the applicant data has been set for any of the paths
-   * associated with the question. If the applicant data does not contain the question's path,
-   * then it will be considered unanswered.
+   * associated with the question. If the applicant data does not contain the question's path, then
+   * it will be considered unanswered.
    */
   @Override
   public boolean isAnswered() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -21,7 +21,8 @@ abstract class QuestionImpl implements Question {
 
   protected abstract ImmutableSet<QuestionType> validQuestionTypes();
 
-  protected final boolean isAnswered() {
-    return applicantQuestion.isAnswered();
+  @Override
+  public boolean isAnswered() {
+    return getAllPaths().stream().anyMatch(p -> applicantQuestion.getApplicantData().hasPath(p));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -4,11 +4,15 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import services.question.types.QuestionType;
 
+/**
+ * Abstract implementation for the {@link Question} interface. Subclasses are expected to implement
+ * the majority of the interface methods. Common logic is pulled up to this class for code sharing.
+ */
 abstract class QuestionImpl implements Question {
   protected final ApplicantQuestion applicantQuestion;
 
   public QuestionImpl(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
+    this.applicantQuestion = Preconditinos.checkNotNull(applicantQuestion);
     if (!validQuestionTypes().contains(applicantQuestion.getType())) {
       throw new RuntimeException(
           String.format(
@@ -19,8 +23,17 @@ abstract class QuestionImpl implements Question {
     }
   }
 
+  /**
+   * The set of acceptable question types for the {@link ApplicantQuestion} provided in the
+   * constructor. This is used for validation purposes.
+   */
   protected abstract ImmutableSet<QuestionType> validQuestionTypes();
 
+  /**
+   * A question is considered answered if the applicant data has been set for any of the paths
+   * associated with the question. If a question type contains no paths, then it will be considered
+   * as not answered.
+   */
   @Override
   public boolean isAnswered() {
     return getAllPaths().stream().anyMatch(p -> applicantQuestion.getApplicantData().hasPath(p));

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -32,8 +32,8 @@ abstract class QuestionImpl implements Question {
 
   /**
    * A question is considered answered if the applicant data has been set for any of the paths
-   * associated with the question. If a question type contains no paths, then it will be considered
-   * as not answered.
+   * associated with the question. If the applicant data does not contain the question's path,
+   * then it will be considered unanswered.
    */
   @Override
   public boolean isAnswered() {

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -1,0 +1,27 @@
+package services.applicant.question;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import services.question.types.QuestionType;
+
+abstract class QuestionImpl implements Question {
+  protected final ApplicantQuestion applicantQuestion;
+
+  public QuestionImpl(ApplicantQuestion applicantQuestion) {
+    this.applicantQuestion = applicantQuestion;
+    if (!validQuestionTypes().contains(applicantQuestion.getType())) {
+      throw new RuntimeException(
+        String.format(
+              "Question is not a question of the following types: [%s]: %s (type: %s)",
+              Joiner.on(", ").join(validQuestionTypes().stream().toArray()),
+              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
+              applicantQuestion.getQuestionDefinition().getQuestionType()));
+    }
+  }
+
+  protected abstract ImmutableSet<QuestionType> validQuestionTypes();
+
+  protected final boolean isAnswered() {
+    return applicantQuestion.isAnswered();
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -1,6 +1,7 @@
 package services.applicant.question;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import services.question.types.QuestionType;
 
@@ -12,7 +13,7 @@ abstract class QuestionImpl implements Question {
   protected final ApplicantQuestion applicantQuestion;
 
   public QuestionImpl(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = Preconditinos.checkNotNull(applicantQuestion);
+    this.applicantQuestion = Preconditions.checkNotNull(applicantQuestion);
     if (!validQuestionTypes().contains(applicantQuestion.getType())) {
       throw new RuntimeException(
           String.format(

--- a/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/QuestionImpl.java
@@ -11,7 +11,7 @@ abstract class QuestionImpl implements Question {
     this.applicantQuestion = applicantQuestion;
     if (!validQuestionTypes().contains(applicantQuestion.getType())) {
       throw new RuntimeException(
-        String.format(
+          String.format(
               "Question is not a question of the following types: [%s]: %s (type: %s)",
               Joiner.on(", ").join(validQuestionTypes().stream().toArray()),
               applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),

--- a/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
@@ -29,8 +29,7 @@ public class SingleSelectQuestion extends QuestionImpl {
 
   @Override
   protected ImmutableSet<QuestionType> validQuestionTypes() {
-    return ImmutableSet.of(
-      QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
+    return ImmutableSet.of(QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/SingleSelectQuestion.java
@@ -8,6 +8,7 @@ import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionType;
 
 /**
  * Represents a single-select question in the context of a specific applicant.
@@ -16,16 +17,20 @@ import services.question.types.MultiOptionQuestionDefinition;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class SingleSelectQuestion implements Question {
+public class SingleSelectQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   // Stores the value, loading and caching it on first access.
   private Optional<Optional<LocalizedQuestionOption>> selectedOptionValueCache;
 
   public SingleSelectQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
+    super(applicantQuestion);
     selectedOptionValueCache = Optional.empty();
-    assertQuestionType();
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(
+      QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
   }
 
   @Override
@@ -77,18 +82,7 @@ public class SingleSelectQuestion implements Question {
         .findFirst();
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().isMultiOptionType()) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a multi-option question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public MultiOptionQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (MultiOptionQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 
@@ -108,11 +102,6 @@ public class SingleSelectQuestion implements Question {
   /** Get options in the specified locale. */
   public ImmutableList<LocalizedQuestionOption> getOptions(Locale locale) {
     return getQuestionDefinition().getOptionsForLocaleOrDefault(locale);
-  }
-
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getSelectionPath());
   }
 
   @Override

--- a/universal-application-tool-0.0.1/app/services/applicant/question/StaticContentQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/StaticContentQuestion.java
@@ -14,23 +14,15 @@ import services.question.types.QuestionType;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class StaticContentQuestion implements Question {
-
-  private final ApplicantQuestion applicantQuestion;
+public class StaticContentQuestion extends QuestionImpl {
 
   public StaticContentQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.STATIC)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a STATIC question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.STATIC);
   }
 
   @Override
@@ -44,21 +36,12 @@ public class StaticContentQuestion implements Question {
   }
 
   @Override
-  public boolean isAnswered() {
-    return true;
-  }
-
-  @Override
   public String getAnswerString() {
     return "";
   }
 
   @Override
   public ImmutableList<Path> getAllPaths() {
-    return ImmutableList.of(getPath());
-  }
-
-  public Path getPath() {
-    return applicantQuestion.getContextualizedPath();
+    return ImmutableList.of();
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/StaticContentQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/StaticContentQuestion.java
@@ -36,6 +36,11 @@ public class StaticContentQuestion extends QuestionImpl {
   }
 
   @Override
+  public boolean isAnswered() {
+    return true;
+  }
+
+  @Override
   public String getAnswerString() {
     return "";
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/question/TextQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/question/TextQuestion.java
@@ -14,14 +14,17 @@ import services.question.types.TextQuestionDefinition;
  *
  * <p>See {@link ApplicantQuestion} for details.
  */
-public class TextQuestion implements Question {
+public class TextQuestion extends QuestionImpl {
 
-  private final ApplicantQuestion applicantQuestion;
   private Optional<String> textValue;
 
   public TextQuestion(ApplicantQuestion applicantQuestion) {
-    this.applicantQuestion = applicantQuestion;
-    assertQuestionType();
+    super(applicantQuestion);
+  }
+
+  @Override
+  protected ImmutableSet<QuestionType> validQuestionTypes() {
+    return ImmutableSet.of(QuestionType.TEXT);
   }
 
   @Override
@@ -61,11 +64,6 @@ public class TextQuestion implements Question {
     return errors.build();
   }
 
-  @Override
-  public boolean isAnswered() {
-    return applicantQuestion.getApplicantData().hasPath(getTextPath());
-  }
-
   public Optional<String> getTextValue() {
     if (textValue != null) {
       return textValue;
@@ -74,18 +72,7 @@ public class TextQuestion implements Question {
     return textValue;
   }
 
-  public void assertQuestionType() {
-    if (!applicantQuestion.getType().equals(QuestionType.TEXT)) {
-      throw new RuntimeException(
-          String.format(
-              "Question is not a TEXT question: %s (type: %s)",
-              applicantQuestion.getQuestionDefinition().getQuestionPathSegment(),
-              applicantQuestion.getQuestionDefinition().getQuestionType()));
-    }
-  }
-
   public TextQuestionDefinition getQuestionDefinition() {
-    assertQuestionType();
     return (TextQuestionDefinition) applicantQuestion.getQuestionDefinition();
   }
 

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -241,8 +241,9 @@ public class ExporterService {
 
     // Add columns for each path to an answer.
     for (AnswerData answerData : answerDataList) {
-      if (answerData.questionDefinition().isEnumerator()) {
-        continue; // Do not include Enumerator answers in CSVs.
+      if (answerData.questionDefinition().isEnumerator() ||
+          answerData.questionDefinition().getQuestionType() == QuestionType.FILEUPLOAD) {
+        continue; // Do not include Enumerator or file upload answers in CSVs.
       }
       for (Path path : answerData.scalarAnswersInDefaultLocale().keySet()) {
         columnsBuilder.add(

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -241,8 +241,8 @@ public class ExporterService {
 
     // Add columns for each path to an answer.
     for (AnswerData answerData : answerDataList) {
-      if (answerData.questionDefinition().isEnumerator() ||
-          answerData.questionDefinition().getQuestionType() == QuestionType.FILEUPLOAD) {
+      if (answerData.questionDefinition().isEnumerator()
+          || answerData.questionDefinition().getQuestionType() == QuestionType.FILEUPLOAD) {
         continue; // Do not include Enumerator or file upload answers in CSVs.
       }
       for (Path path : answerData.scalarAnswersInDefaultLocale().keySet()) {

--- a/universal-application-tool-0.0.1/app/services/export/ExporterService.java
+++ b/universal-application-tool-0.0.1/app/services/export/ExporterService.java
@@ -241,9 +241,8 @@ public class ExporterService {
 
     // Add columns for each path to an answer.
     for (AnswerData answerData : answerDataList) {
-      if (answerData.questionDefinition().isEnumerator()
-          || answerData.questionDefinition().getQuestionType() == QuestionType.FILEUPLOAD) {
-        continue; // Do not include Enumerator or file upload answers in CSVs.
+      if (answerData.questionDefinition().isEnumerator()) {
+        continue; // Do not include Enumerator answers in CSVs.
       }
       for (Path path : answerData.scalarAnswersInDefaultLocale().keySet()) {
         columnsBuilder.add(


### PR DESCRIPTION
### Description
Introducing a base class for this since the majority of question types implement this as confirming that a value exists for any of the paths returned by `getAllPaths`. This also allowed for consolidating similar implementations of `assertQuestionType`. 

Noticed this as part of Issue #1944, since server-side rendering of errors will likely be updated for various question types.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
