### PR TITLE
Remove bintray resolver

### DIFF
--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -137,7 +137,7 @@ lazy val excludeTailwindGeneration = Seq(watchSources := {
 })
 
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
-resolvers += Resolver.bintrayRepo("webjars", "maven")
+
 resolvers += "Shibboleth" at "https://build.shibboleth.net/nexus/content/groups/public"
 libraryDependencies ++= Seq(
   "org.webjars.npm" % "azure__storage-blob" % "10.5.0"


### PR DESCRIPTION
bintray.com is not maintained and getting turned down. it doesn't appear we actually need it for resolving dependencies anyway.

fixes https://github.com/seattle-uat/civiform/issues/2250