### PR TITLE
More validation of the multi-select question type

### DIFF
--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -237,13 +237,17 @@ public abstract class QuestionDefinition {
     if (getQuestionType().isMultiOptionType()) {
       MultiOptionQuestionDefinition multiOptionQuestionDefinition =
           (MultiOptionQuestionDefinition) this;
+
       if (multiOptionQuestionDefinition.getOptions().isEmpty()) {
         errors.add(CiviFormError.of("Multi-option questions must have at least one option"));
       }
+
       if (multiOptionQuestionDefinition.getOptions().stream()
           .anyMatch(option -> option.optionText().hasEmptyTranslation())) {
         errors.add(CiviFormError.of("Multi-option questions cannot have blank options"));
       }
+
+      int numOptions = multiOptionQuestionDefinition.getOptions().size();
       int numUniqueOptionDefaultValues =
           multiOptionQuestionDefinition.getOptions().stream()
               .map(QuestionOption::optionText)
@@ -251,10 +255,10 @@ public abstract class QuestionDefinition {
               .distinct()
               .mapToInt(s -> 1)
               .sum();
-      if (numUniqueOptionDefaultValues != multiOptionQuestionDefinition.getOptions().size()) {
+      if (numUniqueOptionDefaultValues != numOptions) {
         errors.add(CiviFormError.of("Multi-option question options must be unique"));
       }
-      int numOptions = multiOptionQuestionDefinition.getOptions().size();
+
       OptionalInt minChoicesRequired =
           multiOptionQuestionDefinition.getMultiOptionValidationPredicates().minChoicesRequired();
       OptionalInt maxChoicesAllowed =
@@ -263,26 +267,31 @@ public abstract class QuestionDefinition {
         if (minChoicesRequired.getAsInt() < 0) {
           errors.add(CiviFormError.of("Minimum number of choices required cannot be negative"));
         }
+
         if (minChoicesRequired.getAsInt() > numOptions) {
           errors.add(
               CiviFormError.of(
                   "Minimum number of choices required cannot exceed the number of options"));
         }
       }
+
       if (maxChoicesAllowed.isPresent()) {
         if (maxChoicesAllowed.getAsInt() < 0) {
           errors.add(CiviFormError.of("Maximum number of choices allowed cannot be negative"));
         }
+
         if (maxChoicesAllowed.getAsInt() > numOptions) {
           errors.add(
               CiviFormError.of(
                   "Maximum number of choices allowed cannot exceed the number of options"));
         }
       }
+
       if (minChoicesRequired.isPresent() && maxChoicesAllowed.isPresent()) {
         if (minChoicesRequired.getAsInt() == 0 && maxChoicesAllowed.getAsInt() == 0) {
           errors.add(CiviFormError.of("Cannot require exactly 0 choices"));
         }
+
         if (minChoicesRequired.getAsInt() > maxChoicesAllowed.getAsInt()) {
           errors.add(
               CiviFormError.of(

--- a/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/types/QuestionDefinition.java
@@ -255,14 +255,18 @@ public abstract class QuestionDefinition {
         errors.add(CiviFormError.of("Multi-option question options must be unique"));
       }
       int numOptions = multiOptionQuestionDefinition.getOptions().size();
-      OptionalInt minChoicesRequired = multiOptionQuestionDefinition.getMultiOptionValidationPredicates().minChoicesRequired();
-      OptionalInt maxChoicesAllowed = multiOptionQuestionDefinition.getMultiOptionValidationPredicates().maxChoicesAllowed();
+      OptionalInt minChoicesRequired =
+          multiOptionQuestionDefinition.getMultiOptionValidationPredicates().minChoicesRequired();
+      OptionalInt maxChoicesAllowed =
+          multiOptionQuestionDefinition.getMultiOptionValidationPredicates().maxChoicesAllowed();
       if (minChoicesRequired.isPresent()) {
         if (minChoicesRequired.getAsInt() < 0) {
           errors.add(CiviFormError.of("Minimum number of choices required cannot be negative"));
         }
         if (minChoicesRequired.getAsInt() > numOptions) {
-          errors.add(CiviFormError.of("Minimum number of choices required cannot exceed the number of options"));
+          errors.add(
+              CiviFormError.of(
+                  "Minimum number of choices required cannot exceed the number of options"));
         }
       }
       if (maxChoicesAllowed.isPresent()) {
@@ -270,7 +274,9 @@ public abstract class QuestionDefinition {
           errors.add(CiviFormError.of("Maximum number of choices allowed cannot be negative"));
         }
         if (maxChoicesAllowed.getAsInt() > numOptions) {
-          errors.add(CiviFormError.of("Maximum number of choices allowed cannot exceed the number of options"));
+          errors.add(
+              CiviFormError.of(
+                  "Maximum number of choices allowed cannot exceed the number of options"));
         }
       }
       if (minChoicesRequired.isPresent() && maxChoicesAllowed.isPresent()) {
@@ -278,7 +284,10 @@ public abstract class QuestionDefinition {
           errors.add(CiviFormError.of("Cannot require exactly 0 choices"));
         }
         if (minChoicesRequired.getAsInt() > maxChoicesAllowed.getAsInt()) {
-          errors.add(CiviFormError.of("Minimum number of choices required must be less than or equal to the maximum choices allowed"));
+          errors.add(
+              CiviFormError.of(
+                  "Minimum number of choices required must be less than or equal to the maximum"
+                      + " choices allowed"));
         }
       }
     }

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -19,6 +19,7 @@ import forms.TextQuestionForm;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.Optional;
+import java.util.OptionalLong;
 import play.i18n.Messages;
 import services.LocalizedStrings;
 import services.MessageKey;
@@ -263,12 +264,18 @@ public class QuestionConfig {
             .setId("multi-select-min-choices-input")
             .setFieldName("minChoicesRequired")
             .setLabelText("Minimum number of choices required")
+            // Negative numbers aren't allowed. Force the admin to provide
+            // a positive number.
+            .setMin(OptionalLong.of(0L))
             .setValue(multiOptionForm.getMinChoicesRequired())
             .getContainer(),
         FieldWithLabel.number()
             .setId("multi-select-max-choices-input")
             .setFieldName("maxChoicesAllowed")
             .setLabelText("Maximum number of choices allowed")
+            // Negative numbers aren't allowed. Force the admin to provide
+            // a positive number.
+            .setMin(OptionalLong.of(0L))
             .setValue(multiOptionForm.getMaxChoicesAllowed())
             .getContainer());
     return this;

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionConfig.java
@@ -189,7 +189,7 @@ public class QuestionConfig {
    * along with a button to remove the option.
    */
   public static ContainerTag multiOptionQuestionFieldTemplate(Messages messages) {
-    return multiOptionQuestionField(Optional.empty(), messages, true);
+    return multiOptionQuestionField(Optional.empty(), messages, /* isForNewOption= */ true);
   }
 
   /**
@@ -251,7 +251,7 @@ public class QuestionConfig {
                       multiOptionQuestionForm.getOptions().get(i),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              false));
+              /* isForNewOption= */ false));
       optionIndex++;
     }
     for (String newOption : multiOptionQuestionForm.getNewOptions()) {
@@ -261,7 +261,7 @@ public class QuestionConfig {
                   LocalizedQuestionOption.create(
                       -1, optionIndex, newOption, LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              true));
+              /* isForNewOption= */ true));
       optionIndex++;
     }
 

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -49,6 +49,9 @@ public final class QuestionEditView extends BaseHtmlView {
   private static final String QUESTION_NAME_FIELD = "questionName";
   private static final String QUESTION_ENUMERATOR_FIELD = "enumeratorId";
 
+  // Setting a value of 0 causes the toast to be displayed indefinitely.
+  private static final int ERROR_TOAST_DURATION = 0;
+
   @Inject
   public QuestionEditView(
       AdminLayout layout, MessagesApi messagesApi, FileUploadViewStrategy fileUploadViewStrategy) {
@@ -94,7 +97,10 @@ public final class QuestionEditView extends BaseHtmlView {
                     .with(makeCsrfTokenInputTag(request)));
 
     if (message.isPresent()) {
-      formContent.with(ToastMessage.error(message.get()).setDismissible(false).getContainerTag());
+      formContent.with(ToastMessage.error(message.get())
+        .setDismissible(true)
+        .setDuration(ERROR_TOAST_DURATION)
+        .getContainerTag());
     }
 
     return renderWithPreview(formContent, questionType, title);
@@ -143,7 +149,10 @@ public final class QuestionEditView extends BaseHtmlView {
                     .with(makeCsrfTokenInputTag(request)));
 
     if (message.isPresent()) {
-      formContent.with(ToastMessage.error(message.get()).setDismissible(false).getContainerTag());
+      formContent.with(ToastMessage.error(message.get())
+        .setDismissible(true)
+        .setDuration(ERROR_TOAST_DURATION)
+        .getContainerTag());
     }
 
     return renderWithPreview(formContent, questionType, title);

--- a/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/questions/QuestionEditView.java
@@ -97,10 +97,11 @@ public final class QuestionEditView extends BaseHtmlView {
                     .with(makeCsrfTokenInputTag(request)));
 
     if (message.isPresent()) {
-      formContent.with(ToastMessage.error(message.get())
-        .setDismissible(true)
-        .setDuration(ERROR_TOAST_DURATION)
-        .getContainerTag());
+      formContent.with(
+          ToastMessage.error(message.get())
+              .setDismissible(true)
+              .setDuration(ERROR_TOAST_DURATION)
+              .getContainerTag());
     }
 
     return renderWithPreview(formContent, questionType, title);
@@ -149,10 +150,11 @@ public final class QuestionEditView extends BaseHtmlView {
                     .with(makeCsrfTokenInputTag(request)));
 
     if (message.isPresent()) {
-      formContent.with(ToastMessage.error(message.get())
-        .setDismissible(true)
-        .setDuration(ERROR_TOAST_DURATION)
-        .getContainerTag());
+      formContent.with(
+          ToastMessage.error(message.get())
+              .setDismissible(true)
+              .setDuration(ERROR_TOAST_DURATION)
+              .getContainerTag());
     }
 
     return renderWithPreview(formContent, questionType, title);
@@ -218,7 +220,7 @@ public final class QuestionEditView extends BaseHtmlView {
     ContainerTag multiOptionQuestionField =
         div()
             .with(
-                QuestionConfig.multiOptionQuestionField(Optional.empty(), messages)
+                QuestionConfig.multiOptionQuestionFieldTemplate(messages)
                     .withId("multi-option-question-answer-template")
                     // Add "hidden" to other classes, so that the template is not shown
                     .withClasses(

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalInt;
 import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -460,6 +463,54 @@ public class QuestionDefinitionTest {
             MultiOptionQuestionDefinition.MultiOptionValidationPredicates.create());
     assertThat(question.validate())
         .containsOnly(CiviFormError.of("Multi-option question options must be unique"));
+  }
+
+  private static ImmutableList<Object[]> getMultiOptionQuestionValidationTestData() {
+    return ImmutableList.of(
+      // Valid cases.
+      new Object[] {OptionalInt.empty(), OptionalInt.empty(), Optional.<String>empty()},
+      new Object[] {OptionalInt.of(1), OptionalInt.empty(), Optional.<String>empty()},
+      new Object[] {OptionalInt.empty(), OptionalInt.of(1), Optional.<String>empty()},
+      new Object[] {OptionalInt.of(1), OptionalInt.of(2), Optional.<String>empty()},
+      new Object[] {OptionalInt.of(1), OptionalInt.of(1), Optional.<String>empty()},
+
+      // Edge cases.
+      new Object[] {OptionalInt.of(-1), OptionalInt.empty(), Optional.<String>of("Minimum number of choices required cannot be negative")},
+      new Object[] {OptionalInt.empty(), OptionalInt.of(-1), Optional.<String>of("Maximum number of choices allowed cannot be negative")},
+      new Object[] {OptionalInt.of(2), OptionalInt.of(1), Optional.<String>of("Minimum number of choices required must be less than or equal to the maximum choices allowed")},
+      new Object[] {OptionalInt.of(0), OptionalInt.of(0), Optional.<String>of("Cannot require exactly 0 choices")},
+      // Note: In the test code, we configure two options.
+      new Object[] {OptionalInt.empty(), OptionalInt.of(3), Optional.<String>of("Minimum number of choices required cannot exceed the number of options")},
+      new Object[] {OptionalInt.of(3), OptionalInt.empty(), Optional.<String>of("Maximum number of choices allowed cannot exceed the number of options")}
+    );
+  }
+
+  @Test
+  @Parameters(method = "getMultiOptionQuestionValidationTestData")
+  public void validate_multiOptionQuestion_validationConstraints(
+    OptionalInt minChoicesRequired, OptionalInt maxChoicesAllowed, Optional<String> wantErrorMessage) {
+      QuestionDefinition question =
+        new CheckboxQuestionDefinition(
+            "test",
+            Optional.empty(),
+            "test",
+            LocalizedStrings.withDefaultValue("test"),
+            LocalizedStrings.empty(),
+            ImmutableList.of(
+                QuestionOption.create(1L, LocalizedStrings.withDefaultValue("a")),
+                QuestionOption.create(2L, LocalizedStrings.withDefaultValue("b"))),
+            MultiOptionQuestionDefinition.MultiOptionValidationPredicates.builder()
+                .setMinChoicesRequired(minChoicesRequired)
+                .setMaxChoicesAllowed(maxChoicesAllowed)
+                .build());
+    
+    ImmutableSet<CiviFormError> errors = question.validate();
+    if (wantErrorMessage.isEmpty()) {
+      assertThat(errors).isEmpty();
+    } else {
+      assertThat(question.validate())
+          .containsOnly(CiviFormError.of(wantErrorMessage.get()));
+    }
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/types/QuestionDefinitionTest.java
@@ -467,29 +467,58 @@ public class QuestionDefinitionTest {
 
   private static ImmutableList<Object[]> getMultiOptionQuestionValidationTestData() {
     return ImmutableList.of(
-      // Valid cases.
-      new Object[] {OptionalInt.empty(), OptionalInt.empty(), Optional.<String>empty()},
-      new Object[] {OptionalInt.of(1), OptionalInt.empty(), Optional.<String>empty()},
-      new Object[] {OptionalInt.empty(), OptionalInt.of(1), Optional.<String>empty()},
-      new Object[] {OptionalInt.of(1), OptionalInt.of(2), Optional.<String>empty()},
-      new Object[] {OptionalInt.of(1), OptionalInt.of(1), Optional.<String>empty()},
+        // Valid cases.
+        new Object[] {OptionalInt.empty(), OptionalInt.empty(), Optional.<String>empty()},
+        new Object[] {OptionalInt.of(1), OptionalInt.empty(), Optional.<String>empty()},
+        new Object[] {OptionalInt.empty(), OptionalInt.of(1), Optional.<String>empty()},
+        new Object[] {OptionalInt.of(1), OptionalInt.of(2), Optional.<String>empty()},
+        new Object[] {OptionalInt.of(1), OptionalInt.of(1), Optional.<String>empty()},
 
-      // Edge cases.
-      new Object[] {OptionalInt.of(-1), OptionalInt.empty(), Optional.<String>of("Minimum number of choices required cannot be negative")},
-      new Object[] {OptionalInt.empty(), OptionalInt.of(-1), Optional.<String>of("Maximum number of choices allowed cannot be negative")},
-      new Object[] {OptionalInt.of(2), OptionalInt.of(1), Optional.<String>of("Minimum number of choices required must be less than or equal to the maximum choices allowed")},
-      new Object[] {OptionalInt.of(0), OptionalInt.of(0), Optional.<String>of("Cannot require exactly 0 choices")},
-      // Note: In the test code, we configure two options.
-      new Object[] {OptionalInt.empty(), OptionalInt.of(3), Optional.<String>of("Minimum number of choices required cannot exceed the number of options")},
-      new Object[] {OptionalInt.of(3), OptionalInt.empty(), Optional.<String>of("Maximum number of choices allowed cannot exceed the number of options")}
-    );
+        // Edge cases.
+        new Object[] {
+          OptionalInt.of(-1),
+          OptionalInt.empty(),
+          Optional.<String>of("Minimum number of choices required cannot be negative")
+        },
+        new Object[] {
+          OptionalInt.empty(),
+          OptionalInt.of(-1),
+          Optional.<String>of("Maximum number of choices allowed cannot be negative")
+        },
+        new Object[] {
+          OptionalInt.of(2),
+          OptionalInt.of(1),
+          Optional.<String>of(
+              "Minimum number of choices required must be less than or equal to the maximum"
+                  + " choices allowed")
+        },
+        new Object[] {
+          OptionalInt.of(0),
+          OptionalInt.of(0),
+          Optional.<String>of("Cannot require exactly 0 choices")
+        },
+        // Note: In the test code, we configure two options.
+        new Object[] {
+          OptionalInt.empty(),
+          OptionalInt.of(3),
+          Optional.<String>of(
+              "Maximum number of choices allowed cannot exceed the number of options")
+        },
+        new Object[] {
+          OptionalInt.of(3),
+          OptionalInt.empty(),
+          Optional.<String>of(
+              "Minimum number of choices required cannot exceed the number of options")
+        });
   }
 
   @Test
   @Parameters(method = "getMultiOptionQuestionValidationTestData")
   public void validate_multiOptionQuestion_validationConstraints(
-    OptionalInt minChoicesRequired, OptionalInt maxChoicesAllowed, Optional<String> wantErrorMessage) {
-      QuestionDefinition question =
+      OptionalInt minChoicesRequired,
+      OptionalInt maxChoicesAllowed,
+      Optional<String> wantErrorMessage) {
+    QuestionDefinition question =
         new CheckboxQuestionDefinition(
             "test",
             Optional.empty(),
@@ -503,13 +532,12 @@ public class QuestionDefinitionTest {
                 .setMinChoicesRequired(minChoicesRequired)
                 .setMaxChoicesAllowed(maxChoicesAllowed)
                 .build());
-    
+
     ImmutableSet<CiviFormError> errors = question.validate();
     if (wantErrorMessage.isEmpty()) {
       assertThat(errors).isEmpty();
     } else {
-      assertThat(question.validate())
-          .containsOnly(CiviFormError.of(wantErrorMessage.get()));
+      assertThat(question.validate()).containsOnly(CiviFormError.of(wantErrorMessage.get()));
     }
   }
 

--- a/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
+++ b/universal-application-tool-0.0.1/test/views/admin/question/QuestionConfigTest.java
@@ -4,6 +4,7 @@ import static j2html.TagCreator.div;
 import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.stubMessagesApi;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import forms.AddressQuestionForm;
 import forms.CheckboxQuestionForm;
@@ -75,5 +76,20 @@ public class QuestionConfigTest {
 
     assertThat(QuestionConfig.buildQuestionConfig(new NameQuestionForm(), messages))
         .isEqualTo(DEFAULT_CONFIG);
+  }
+
+  @Test
+  public void checkboxForm_preservesNewOptions() {
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("existing-option-a", "existing-option-b"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setNewOptions(ImmutableList.of("new-option-c", "new-option-d"));
+
+    String result = QuestionConfig.buildQuestionConfig(form, messages).renderFormatted();
+
+    assertThat(result).contains("existing-option-a");
+    assertThat(result).contains("existing-option-b");
+    assertThat(result).contains("new-option-c");
+    assertThat(result).contains("new-option-d");
   }
 }


### PR DESCRIPTION
### Description
Questions that allow multiple selections (e.g. checkbox) presently allow configuration of the minimum / maximum number of selectable choices where:
  1) Negative inputs are allowed
  2) Minimum number of selections can be greater than the maximum number of selections
  3) Minimum / maximum selections can be greater than the number of choices

This adds additional error validation / tests for this and makes a few additional improvements I noticed while testing the issue:
  * Toasts with the validation errors were disappearing after 3 seconds (the default behavior). Now we show it indefinitely (but still dismissable) under the assumption that the admin will dismiss the toast after fixing the errors or resubmitting the form.
  * When a validation error occurred, any newly added choices for the multi-select were lost. This would have been frustrating if the admin had added many new choices and had to retype them all again if, for instance, a single blank value was accidentally added during configuration. Added a unit test for this.

Perhaps for a separate PR: When a toast is shown with multiple validation errors, they're shown as a series of sentences. An alternative may be to display them as a <ul> so it's easier to see that they're distinct errors. If desirable, I'm happy to file a separate issue for this.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1890
