### PR TITLE
Use CDN to load azure blob browser lib

### DIFF
--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -36,7 +36,7 @@ services:
       - 8033:3380
 
   civiform:
-    image: civiform
+    image: civiform-dev
     restart: always
     container_name: civiform-test
     links:

--- a/browser-test/src/dev_file_upload.test.ts
+++ b/browser-test/src/dev_file_upload.test.ts
@@ -13,7 +13,7 @@ describe('the dev file upload page', () => {
     expect(await page.textContent('h1')).toContain('Dev file upload')
 
     await page.setInputFiles('input[type=file]', {
-      name: 'file.txt',
+      name: 'my-test-file.txt',
       mimeType: 'text/plain',
       buffer: Buffer.from('this is test'),
     })
@@ -22,7 +22,7 @@ describe('the dev file upload page', () => {
     await waitForPageJsLoad(page)
 
     expect(await page.textContent('h1')).toContain('Dev file upload')
-    expect(await page.content()).toContain('dev/file.txt')
+    expect(await page.textContent('table')).toContain('my-test-file.txt')
 
     await endSession(browser)
   })

--- a/universal-application-tool-0.0.1/app/views/AzureFileUploadViewStrategy.java
+++ b/universal-application-tool-0.0.1/app/views/AzureFileUploadViewStrategy.java
@@ -105,7 +105,7 @@ public class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
     return div(formTag, skipForms, buttons)
         .withId("azure-upload-form-component")
         .with(
-            footer(viewUtils.makeWebJarsTag(WebJarJsPaths.AZURE_STORAGE_BLOB)),
+            footer(viewUtils.makeAzureBlobStoreScriptTag()),
             footer(viewUtils.makeLocalJsTag("azure_upload")));
   }
 

--- a/universal-application-tool-0.0.1/app/views/ViewUtils.java
+++ b/universal-application-tool-0.0.1/app/views/ViewUtils.java
@@ -25,7 +25,9 @@ public final class ViewUtils {
   public Tag makeAzureBlobStoreScriptTag() {
     return script()
         .withSrc("https://cdn.jsdelivr.net/npm/@azure/storage-blob@10.5.0")
-        .withType("text/javascript");
+        .withType("text/javascript")
+        .attr("crossorigin", "anonymous")
+        .attr("integrity", "sha256-VFdCcG0JBuOTN0p15rwVT5EIuL7bzWMYi4aD6KeDqus=");
   }
 
   /**

--- a/universal-application-tool-0.0.1/app/views/ViewUtils.java
+++ b/universal-application-tool-0.0.1/app/views/ViewUtils.java
@@ -19,6 +19,16 @@ public final class ViewUtils {
   }
 
   /**
+   * Generates an HTML script tag for loading the Azure Blob Storage client library from the
+   * jsdelivr.net CDN.
+   */
+  public Tag makeAzureBlobStoreScriptTag() {
+    return script()
+        .withSrc("https://cdn.jsdelivr.net/npm/@azure/storage-blob@10.5.0")
+        .withType("text/javascript");
+  }
+
+  /**
    * Generates an HTML script tag for loading the javascript file found at
    * public/javascripts/[filename].js.
    */

--- a/universal-application-tool-0.0.1/app/views/ViewUtils.java
+++ b/universal-application-tool-0.0.1/app/views/ViewUtils.java
@@ -20,8 +20,7 @@ public final class ViewUtils {
 
   /**
    * Generates an HTML script tag for loading the Azure Blob Storage client library from the
-   * jsdelivr.net CDN.
-   * TOOD(https://github.com/seattle-uat/civiform/issues/2349): Stop using this.
+   * jsdelivr.net CDN. TOOD(https://github.com/seattle-uat/civiform/issues/2349): Stop using this.
    */
   public Tag makeAzureBlobStoreScriptTag() {
     return script()

--- a/universal-application-tool-0.0.1/app/views/ViewUtils.java
+++ b/universal-application-tool-0.0.1/app/views/ViewUtils.java
@@ -21,6 +21,7 @@ public final class ViewUtils {
   /**
    * Generates an HTML script tag for loading the Azure Blob Storage client library from the
    * jsdelivr.net CDN.
+   * TOOD(https://github.com/seattle-uat/civiform/issues/2349): Stop using this.
    */
   public Tag makeAzureBlobStoreScriptTag() {
     return script()

--- a/universal-application-tool-0.0.1/app/views/dev/AzureStorageDevViewStrategy.java
+++ b/universal-application-tool-0.0.1/app/views/dev/AzureStorageDevViewStrategy.java
@@ -22,7 +22,6 @@ import services.cloud.StorageUploadRequest;
 import services.cloud.azure.BlobStorageUploadRequest;
 import views.HtmlBundle;
 import views.ViewUtils;
-import views.WebJarJsPaths;
 
 /** Strategy class for creating a file upload form for Azure. */
 public class AzureStorageDevViewStrategy implements CloudStorageDevViewStrategy {
@@ -44,9 +43,8 @@ public class AzureStorageDevViewStrategy implements CloudStorageDevViewStrategy 
               + " upload request type.");
     }
     BlobStorageUploadRequest request = (BlobStorageUploadRequest) storageUploadRequest;
-    bundle.addFooterScripts(
-        viewUtils.makeWebJarsTag(/* assetsRoute= */ WebJarJsPaths.AZURE_STORAGE_BLOB));
-    bundle.addFooterScripts(viewUtils.makeLocalJsTag(/* filename= */ "azure_upload"));
+
+    bundle.addFooterScripts(viewUtils.makeAzureBlobStoreScriptTag());
 
     ContainerTag formTag =
         form()

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -139,9 +139,6 @@ lazy val excludeTailwindGeneration = Seq(watchSources := {
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
 
 resolvers += "Shibboleth" at "https://build.shibboleth.net/nexus/content/groups/public"
-libraryDependencies ++= Seq(
-  "org.webjars.npm" % "azure__storage-blob" % "10.5.0"
-)
 dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2",
   "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2",


### PR DESCRIPTION
We've been using https://webjars.org to load javascript libraries (just one so far) but the azure blob storage library specifically causes a Java compilation error on the latest patch version of Java 11.

This change is to unblock upgrading to Java 11.0.14 [while we figure out how to resolve the webjar problem](https://github.com/webjars/webjars/issues/1967).

Unblocks https://github.com/seattle-uat/civiform/pull/2316, https://github.com/seattle-uat/civiform/issues/2315