### PR TITLE
Add a check for the visibility of repeated entity's parents

### DIFF
--- a/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramServiceImpl.java
@@ -272,6 +272,7 @@ public class ReadOnlyApplicantProgramServiceImpl implements ReadOnlyApplicantPro
 
   private boolean showBlock(Block block) {
     if (block.getRepeatedEntity().isPresent()) {
+      // In repeated blocks, test if this block's parent's are visible.
       ImmutableList<PredicateDefinition> nestedVisibility =
           block.getRepeatedEntity().get().nestedVisibility();
       for (int i = 0; i < nestedVisibility.size(); i++) {

--- a/server/app/services/applicant/RepeatedEntity.java
+++ b/server/app/services/applicant/RepeatedEntity.java
@@ -117,7 +117,8 @@ public abstract class RepeatedEntity {
   public ImmutableList<PredicateDefinition> nestedVisibility() {
     return Stream.concat(
             parent()
-                .map(p -> p.nestedVisibility())
+            .map(
+                PredicateDefinition::nestedVisibility)
                 .orElse(ImmutableList.<PredicateDefinition>of())
                 .stream(),
             this.visibility().stream())

--- a/server/app/services/applicant/RepeatedEntity.java
+++ b/server/app/services/applicant/RepeatedEntity.java
@@ -127,9 +127,11 @@ public abstract class RepeatedEntity {
   /**
    * Contextualize the text with repeated entity names.
    *
-   * <p>Replaces "\$this" with this repeated entity's name. "\$this.parent" and
-   * "\$this.parent.parent" (ad infinitum) are replaced with the names of theUserRepository.java:89
-   * ancestors of this repeated entity.
+   * <p>
+   * Replaces "\$this" with this repeated entity's name. "\$this.parent" and
+   * "\$this.parent.parent" (ad infinitum) are replaced with the names of the
+   * ancestors of this
+   * repeated entity.
    */
   public String contextualize(String text) {
     return contextualize(text, REPLACEMENT_STRING);

--- a/server/app/services/applicant/RepeatedEntity.java
+++ b/server/app/services/applicant/RepeatedEntity.java
@@ -117,8 +117,7 @@ public abstract class RepeatedEntity {
   public ImmutableList<PredicateDefinition> nestedVisibility() {
     return Stream.concat(
             parent()
-            .map(
-                PredicateDefinition::nestedVisibility)
+                .map(RepeatedEntity::nestedVisibility)
                 .orElse(ImmutableList.<PredicateDefinition>of())
                 .stream(),
             this.visibility().stream())
@@ -128,10 +127,8 @@ public abstract class RepeatedEntity {
   /**
    * Contextualize the text with repeated entity names.
    *
-   * <p>
-   * Replaces "\$this" with this repeated entity's name. "\$this.parent" and
-   * "\$this.parent.parent" (ad infinitum) are replaced with the names of the
-   * ancestors of this
+   * <p>Replaces "\$this" with this repeated entity's name. "\$this.parent" and
+   * "\$this.parent.parent" (ad infinitum) are replaced with the names of the ancestors of this
    * repeated entity.
    */
   public String contextualize(String text) {

--- a/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
+++ b/server/test/services/applicant/predicate/JsonPathPredicateGeneratorTest.java
@@ -109,7 +109,7 @@ public class JsonPathPredicateGeneratorTest {
         applicantEnumerator.getContextualizedPath(), ImmutableList.of("Xylia"));
 
     ImmutableList<RepeatedEntity> repeatedEntities =
-        RepeatedEntity.createRepeatedEntities(enumerator, applicantData);
+        RepeatedEntity.createRepeatedEntities(enumerator, Optional.empty(), applicantData);
     Optional<RepeatedEntity> repeatedEntity = repeatedEntities.stream().findFirst();
 
     // The block repeated entity context is the one for the repeated name question.
@@ -152,7 +152,7 @@ public class JsonPathPredicateGeneratorTest {
 
     // Just use a repeated entity for the first (index 0) entity.
     ImmutableList<RepeatedEntity> repeatedEntities =
-        RepeatedEntity.createRepeatedEntities(enumerator, applicantData);
+        RepeatedEntity.createRepeatedEntities(enumerator, Optional.empty(), applicantData);
     Optional<RepeatedEntity> repeatedEntity = repeatedEntities.stream().findFirst();
 
     generator =
@@ -196,7 +196,7 @@ public class JsonPathPredicateGeneratorTest {
     // Context for index 1 ('Alice')
     Optional<RepeatedEntity> topLevelRepeatedEntity =
         RepeatedEntity.createRepeatedEntities(
-                (EnumeratorQuestionDefinition) topLevelEnumerator, applicantData)
+                (EnumeratorQuestionDefinition) topLevelEnumerator, Optional.empty(), applicantData)
             .reverse()
             .stream()
             .findFirst();
@@ -210,7 +210,7 @@ public class JsonPathPredicateGeneratorTest {
         topLevelRepeatedEntity
             .get()
             .createNestedRepeatedEntities(
-                (EnumeratorQuestionDefinition) nestedEnumerator, applicantData)
+                (EnumeratorQuestionDefinition) nestedEnumerator, Optional.empty(), applicantData)
             .stream()
             .findFirst();
 
@@ -255,7 +255,7 @@ public class JsonPathPredicateGeneratorTest {
     // Context for 'Alice'
     Optional<RepeatedEntity> currentContext =
         RepeatedEntity.createRepeatedEntities(
-                (EnumeratorQuestionDefinition) topLevelEnumerator, applicantData)
+                (EnumeratorQuestionDefinition) topLevelEnumerator, Optional.empty(), applicantData)
             .reverse()
             .stream()
             .findFirst();

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -254,6 +254,7 @@ public class ApplicantQuestionTest {
         RepeatedEntity.createRepeatedEntities(
                 (EnumeratorQuestionDefinition)
                     testQuestionBank.applicantHouseholdMembers().getQuestionDefinition(),
+                Optional.empty(),
                 applicantData)
             .get(0);
     RepeatedEntity jonCo =
@@ -261,6 +262,7 @@ public class ApplicantQuestionTest {
             .createNestedRepeatedEntities(
                 (EnumeratorQuestionDefinition)
                     testQuestionBank.applicantHouseholdMemberJobs().getQuestionDefinition(),
+                Optional.empty(),
                 applicantData)
             .get(0);
 


### PR DESCRIPTION
### Description
When assembling a program, pass a repeated entity's block's visibility to the entity.  Then when testing if a repeated entity block is visible, test all its parent's conditions as well.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1886
