### PR TITLE
Re-add the missing temp adfs-client-id 

### DIFF
--- a/cloud/azure/bin/setup-keyvault
+++ b/cloud/azure/bin/setup-keyvault
@@ -72,6 +72,15 @@ else
     "${TEMPORARY_SECRET}"
 fi
 
+if key_vault::has_secret "${vault_name}" "${ADFS_CLIENT_ID}"; then
+  echo "Key ${ADFS_CLIENT_ID} exists in the secret store"
+else
+  key_vault::add_secret \
+    "${vault_name}" \
+    "${ADFS_CLIENT_ID}" \
+    "${TEMPORARY_SECRET}"
+fi
+
 if key_vault::has_secret "${vault_name}" "${ADFS_DISCOVERY_URI}"; then
   echo "Key ${ADFS_DISCOVERY_URI} exists in the secret store"
 else


### PR DESCRIPTION
### Description
Accidentally removed the temporary secret generation of "adfs-client-id" in  #2280

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
