### PR TITLE
Updating dangling reference to universal-application-tool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,6 @@ formatter.Dockerfile
 infra
 prod.Dockerfile
 test-support
-universal-application-tool-0.0.1/target
-universal-application-tool-0.0.1/project/project
-universal-application-tool-0.0.1/project/target
+server/target
+server/project/project
+server/project/target


### PR DESCRIPTION
### Description
We have a reference to universal-application-tool in our `.dockerignore` file. This performs the same rename as in https://github.com/seattle-uat/civiform/pull/2360.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
