### PR TITLE
Updates to make VSCode work by default with Metals.

### DIFF
--- a/bin/vscode-setup
+++ b/bin/vscode-setup
@@ -25,7 +25,7 @@ rm -rf server/temp
 
 BUILD=$(
          cat <<END
-<properties>
+    <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
@@ -47,4 +47,4 @@ BUILD=$(
 END
 )
 
-perl -i -pe "s|<modelVersion>|${BUILD}|g" server/pom.xml
+perl -i -pe "s|\s+<modelVersion>|${BUILD}|g" server/pom.xml

--- a/bin/vscode-setup
+++ b/bin/vscode-setup
@@ -25,7 +25,11 @@ rm -rf server/temp
 
 BUILD=$(
          cat <<END
-<build>
+<properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <build>
         <sourceDirectory>app</sourceDirectory>
         <testSourceDirectory>test</testSourceDirectory>
         <resources>

--- a/civiform.code-workspace
+++ b/civiform.code-workspace
@@ -1,15 +1,20 @@
 {
 	"folders": [
 		{
-			"path": "."
+			"path": "server"
 		},
 		{
-			"path": "server"
+			"path": "."
 		}
 	],
 	"settings": {
 		"files.watcherExclude": {
-			"**/target": true
+			"**/target": true,
+			"**/.bloop": true
+		},
+		"search.exclude": {
+			"*/target": true,
+			"**/.bloop": true
 		},
 		"java.configuration.updateBuildConfiguration": "automatic"
 	}

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -67,7 +67,7 @@ lazy val root = (project in file("."))
       // Autovalue
       "com.google.auto.value" % "auto-value-annotations" % "1.9",
       "com.google.auto.value" % "auto-value" % "1.9",
-      "com.google.auto.value" % "auto-value-parent" % "1.9",
+      "com.google.auto.value" % "auto-value-parent" % "1.9" pomOnly(),
 
       // Errorprone
       "com.google.errorprone" % "error_prone_core" % "2.13.1",

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -67,7 +67,7 @@ lazy val root = (project in file("."))
       // Autovalue
       "com.google.auto.value" % "auto-value-annotations" % "1.9",
       "com.google.auto.value" % "auto-value" % "1.9",
-      "com.google.auto.value" % "auto-value-parent" % "1.9",
+      //"com.google.auto.value" % "auto-value-parent" % "1.9" pomOnly(),
 
       // Errorprone
       "com.google.errorprone" % "error_prone_core" % "2.13.1",

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -67,7 +67,7 @@ lazy val root = (project in file("."))
       // Autovalue
       "com.google.auto.value" % "auto-value-annotations" % "1.9",
       "com.google.auto.value" % "auto-value" % "1.9",
-      //"com.google.auto.value" % "auto-value-parent" % "1.9" pomOnly(),
+      "com.google.auto.value" % "auto-value-parent" % "1.9",
 
       // Errorprone
       "com.google.errorprone" % "error_prone_core" % "2.13.1",


### PR DESCRIPTION
### Description
**bin/vscode-setup**
*   Updated the Maven properties indicating that this is Java 11. Fixes a host of problems reported by VSCode around our use of lambdas and other language features. If unspecified, this defaults to Java 5.

**civiform.code-workspace** 
*   Inverted the order of project definitions. Prior to this, Metals didn't detect a SBT and didn't automatically compile.
*   Added .bloop / target files to list of exemptions for searching. This prevents these files from showing in the quick file open candidate list.

**server/build.sbt**
*   Marked auto-value-parent as [pomOnly](https://stackoverflow.com/q/45608473) since it doesn't have a corresponding JAR. Without this, the call to makePom from vscode-setup adds this as a dependency and VSCode fails to resolve it, preventing any further indexing from occurring.

With these changes, the remaining problems reported by VSCode are largely around AutoValue and auto-generated Scala routes. We'll hopefully address these separately.

### Tested
*   Created a fresh clone of the repository and cleared all home directory Maven / Ivy caches. 
*   Ran `bin/vscode-setup`
*   Opened `civiform.code-workspace` from VSCode and waited for build / index to complete
*   Observed auto-complete and jump to definition working as intended  
*   Ran `bin/run-dev` and confirmed I could make requests
*   Confirmed `bin/build-and-push` successfully built an image