### PR TITLE
Persistence layer for API keys

### DIFF
--- a/server/app/auth/ApiKeyGrants.java
+++ b/server/app/auth/ApiKeyGrants.java
@@ -1,0 +1,67 @@
+package auth;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Stores permissions for {@link models.ApiKey}s.
+ *
+ * <p>Permissions are represented as a resource identifier paired with an ability. E.g.
+ * "utility-discount" program with "read" ability. Multiple permissions may be stored for the same
+ * resource. E.g. having both the "read" and "write" permission for a given resource.
+ */
+public class ApiKeyGrants {
+
+  /** Enumerates the abilities an ApiKey may have with respect to a resource */
+  public enum Permission {
+    WRITE,
+    READ;
+  }
+
+  /** Create a new instance with no grants. */
+  public ApiKeyGrants() {
+    this.programGrants = HashMultimap.create();
+  }
+
+  /**
+   * Used by EBean to deserialize an instance of ApiKeyGrants stored in the database.
+   */
+  @JsonCreator
+  public ApiKeyGrants(@JsonProperty("programGrants") Multimap<String, Permission> programGrants) {
+    this.programGrants = checkNotNull(programGrants);
+  }
+
+  @JsonProperty("programGrants")
+  private Multimap<String, Permission> programGrants;
+
+  /**
+   * Grant the ability to do {@code permission} for the program identified by {@code programSlug}.
+   */
+  public void grantProgramPermission(String programSlug, Permission permission) {
+    programGrants.put(programSlug, permission);
+  }
+
+  /**
+   * Revoke the ability to do {@code permission} for the program identified by {@code programSlug}.
+   */
+  public void revokeProgramPermission(String programSlug, Permission permission) {
+    programGrants.remove(programSlug, permission);
+  }
+
+  /**
+   * Check for the ability to do {@code permission} for the program identified by {@code
+   * programSLug}.
+   */
+  public boolean hasProgramPermission(String programSlug, Permission permission) {
+    return programGrants.get(programSlug).contains(permission);
+  }
+
+  /** Revoke all permissions for all programs. */
+  public void revokeAllProgramPermissions() {
+    this.programGrants = HashMultimap.create();
+  }
+}

--- a/server/app/auth/ApiKeyGrants.java
+++ b/server/app/auth/ApiKeyGrants.java
@@ -22,6 +22,9 @@ public class ApiKeyGrants {
     READ;
   }
 
+  @JsonProperty("programGrants")
+  private Multimap<String, Permission> programGrants;
+
   /** Create a new instance with no grants. */
   public ApiKeyGrants() {
     this.programGrants = HashMultimap.create();
@@ -32,9 +35,6 @@ public class ApiKeyGrants {
   public ApiKeyGrants(@JsonProperty("programGrants") Multimap<String, Permission> programGrants) {
     this.programGrants = checkNotNull(programGrants);
   }
-
-  @JsonProperty("programGrants")
-  private Multimap<String, Permission> programGrants;
 
   /**
    * Grant the ability to do {@code permission} for the program identified by {@code programSlug}.

--- a/server/app/auth/ApiKeyGrants.java
+++ b/server/app/auth/ApiKeyGrants.java
@@ -27,9 +27,7 @@ public class ApiKeyGrants {
     this.programGrants = HashMultimap.create();
   }
 
-  /**
-   * Used by EBean to deserialize an instance of ApiKeyGrants stored in the database.
-   */
+  /** Used by EBean to deserialize an instance of ApiKeyGrants stored in the database. */
   @JsonCreator
   public ApiKeyGrants(@JsonProperty("programGrants") Multimap<String, Permission> programGrants) {
     this.programGrants = checkNotNull(programGrants);

--- a/server/app/auth/ApiKeyGrants.java
+++ b/server/app/auth/ApiKeyGrants.java
@@ -16,7 +16,7 @@ import com.google.common.collect.Multimap;
  */
 public class ApiKeyGrants {
 
-  /** Enumerates the abilities an ApiKey may have with respect to a resource */
+  /** Enumerates the abilities an ApiKey may have with respect to a resource. */
   public enum Permission {
     WRITE,
     READ;

--- a/server/app/models/Account.java
+++ b/server/app/models/Account.java
@@ -21,9 +21,7 @@ import services.program.ProgramDefinition;
  * <p>When a user logs in for the first time either using SSO or as a guest, CiviForm creates an
  * {@code Account} record for them.
  *
- * <p>emailAddress serves as the unchanging unique identifier for accounts though it is not
- * guaranteed to not change in authentication protocols like OIDC. When #1793 is resolved though
- * authorityId will serve that purpose.
+ * <p>authorityId serves as the unchanging unique identifier for accounts.
  *
  * <p>Note that residents have a single {@code Account} and a single {@code Applicant} record,
  * despite the one to many relationship. This is technical debt that stems from earlier reasoning

--- a/server/app/models/ApiKey.java
+++ b/server/app/models/ApiKey.java
@@ -5,6 +5,7 @@ import io.ebean.annotation.DbJsonB;
 import io.ebean.annotation.WhenCreated;
 import io.ebean.annotation.WhenModified;
 import java.time.Instant;
+import java.util.Optional;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -13,40 +14,14 @@ import javax.persistence.Table;
 @Table(name = "api_keys")
 public class ApiKey extends BaseModel {
 
-  /** Timestamp of when the the ApiKey was created. */
   @WhenCreated private Instant createTime;
-
-  /** Timestamp of when the the ApiKey was last modified. */
   @WhenModified private Instant updateTime;
-
-  /** Timestamp of when the ApiKey is no longer valid. */
   private Instant expiration;
-
-  /** The {@code authorityId} of the account that created the ApiKey. */
   private String createdBy;
-
-  /** Human readable name of the ApiKey. */
   private String name;
-
-  /**
-   * Unique identifier for the ApiKey. Paired with the password, comprises the credentials for using
-   * the ApiKey. For more information see https://en.wikipedia.org/wiki/Basic_access_authentication
-   */
   private String keyId;
-
-  /**
-   * The salted key secret (a.k.a. password) of the ApiKey. Created by signing the password with the
-   * API secret using the SHA-HMAC-256 algorithm.
-   */
   private String saltedKeySecret;
-
-  /**
-   * An allowlist of IPv4 addresses specified using CIDR notation.
-   * https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
-   */
   private String subnet;
-
-  /** The client IPv4 address of the last request to successfully auth with the ApiKey. */
   private String lastCallIpAddress;
 
   /** Permissions granted to this ApiKey by the admin. */
@@ -61,73 +36,106 @@ public class ApiKey extends BaseModel {
     return this;
   }
 
+  /** Timestamp of when the the ApiKey was created. */
   public Instant getCreateTime() {
     return createTime;
   }
 
+  /** Timestamp of when the the ApiKey was last modified. */
   public Instant getUpdateTime() {
     return updateTime;
   }
 
+  /** Timestamp of when the ApiKey is no longer valid. */
   public Instant getExpiration() {
     return expiration;
   }
 
+  /**
+   * Timestamp of when the ApiKey is no longer valid. Expiration should be immutable after creation.
+   */
   public ApiKey setExpiration(Instant expiration) {
     this.expiration = expiration;
     return this;
   }
 
+  /** The {@code authorityId} of the account that created the ApiKey. */
   public String getCreatedBy() {
     return createdBy;
   }
 
+  /** The {@code authorityId} of the account that created the ApiKey. */
   public ApiKey setCreatedBy(String createdBy) {
     this.createdBy = createdBy;
     return this;
   }
 
+  /** Human readable name of the ApiKey. */
   public String getName() {
     return name;
   }
 
+  /** Human readable name of the ApiKey. OK to modify after creation. */
   public ApiKey setName(String name) {
     this.name = name;
     return this;
   }
 
+  /**
+   * Unique identifier for the ApiKey. Paired with the password, comprises the credentials for using
+   * the ApiKey. For more information see https://en.wikipedia.org/wiki/Basic_access_authentication
+   */
   public String getKeyId() {
     return keyId;
   }
 
+  /** Unique identifier for the ApiKey. */
   public ApiKey setKeyId(String keyId) {
     this.keyId = keyId;
     return this;
   }
 
+  /**
+   * The salted key secret (a.k.a. password) of the ApiKey. Created by signing the password with the
+   * API secret using the SHA-HMAC-256 algorithm.
+   */
   public String getSaltedKeySecret() {
     return saltedKeySecret;
   }
 
+  /** The salted key secret (a.k.a. password) of the ApiKey. */
   public ApiKey setSaltedKeySecret(String saltedKeySecret) {
     this.saltedKeySecret = saltedKeySecret;
     return this;
   }
 
+  /**
+   * An allowlist of IPv4 addresses that are permitted to authenticate with this ApiKey. Specified
+   * using CIDR notation: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+   */
   public String getSubnet() {
     return subnet;
   }
 
+  /**
+   * An allowlist of IPv4 addresses that are permitted to authenticate with this ApiKey. Specified
+   * using CIDR notation: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+   */
   public ApiKey setSubnet(String subnet) {
     this.subnet = subnet;
     return this;
   }
 
+  /**
+   * The client IPv4 address of the last request to successfully auth with the ApiKey. Empty if the
+   * ApiKey has never been used.
+   */
   public String getLastCallIpAddress() {
-    return lastCallIpAddress;
+    return Optional.ofNullable(lastCallIpAddress);
   }
 
-  public String setLastCallIpAddress(String lastCallIpAddress) {
+  /** The client IPv4 address of the last request to successfully auth with the ApiKey. */
+  public Optional<String> setLastCallIpAddress(String lastCallIpAddress) {
     this.lastCallIpAddress = lastCallIpAddress;
     return this;
   }

--- a/server/app/models/ApiKey.java
+++ b/server/app/models/ApiKey.java
@@ -7,11 +7,8 @@ import io.ebean.annotation.WhenModified;
 import java.time.Instant;
 import javax.persistence.Entity;
 import javax.persistence.Table;
-import play.data.validation.Constraints;
 
-/**
- * An EBean mapped class that represents an API key in CiviForm.
- */
+/** An EBean mapped class that represents an API key in CiviForm. */
 @Entity
 @Table(name = "api_keys")
 public class ApiKey extends BaseModel {

--- a/server/app/models/ApiKey.java
+++ b/server/app/models/ApiKey.java
@@ -13,15 +13,44 @@ import javax.persistence.Table;
 @Table(name = "api_keys")
 public class ApiKey extends BaseModel {
 
+  /** Timestamp of when the the ApiKey was created. */
   @WhenCreated private Instant createTime;
+
+  /** Timestamp of when the the ApiKey was last modified. */
   @WhenModified private Instant updateTime;
 
+  /** Timestamp of when the ApiKey is no longer valid. */
   private Instant expiration;
+
+  /** The {@code authorityId} of the account that created the ApiKey. */
   private String createdBy;
+
+  /** Human readable name of the ApiKey. */
   private String name;
+
+  /**
+   * Unique identifier for the ApiKey. Paired with the password, comprises the credentials for using
+   * the ApiKey. For more information see https://en.wikipedia.org/wiki/Basic_access_authentication
+   */
   private String keyId;
+
+  /**
+   * The salted key secret (a.k.a. password) of the ApiKey. Created by signing the password with the
+   * API secret using the SHA-HMAC-256 algorithm.
+   */
   private String saltedKeySecret;
+
+  /**
+   * An allowlist of IPv4 addresses specified using CIDR notation.
+   * https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+   */
   private String subnet;
+
+  /** The client IPv4 address of the last request to successfully auth with the ApiKey. */
+  private String lastCallIpAddress;
+
+  /** Permissions granted to this ApiKey by the admin. */
+  @DbJsonB private ApiKeyGrants grants;
 
   public ApiKeyGrants getGrants() {
     return grants;
@@ -31,8 +60,6 @@ public class ApiKey extends BaseModel {
     this.grants = grants;
     return this;
   }
-
-  @DbJsonB private ApiKeyGrants grants;
 
   public Instant getCreateTime() {
     return createTime;
@@ -93,6 +120,15 @@ public class ApiKey extends BaseModel {
 
   public ApiKey setSubnet(String subnet) {
     this.subnet = subnet;
+    return this;
+  }
+
+  public String getLastCallIpAddress() {
+    return lastCallIpAddress;
+  }
+
+  public String setLastCallIpAddress(String lastCallIpAddress) {
+    this.lastCallIpAddress = lastCallIpAddress;
     return this;
   }
 }

--- a/server/app/models/ApiKey.java
+++ b/server/app/models/ApiKey.java
@@ -1,0 +1,101 @@
+package models;
+
+import auth.ApiKeyGrants;
+import io.ebean.annotation.DbJsonB;
+import io.ebean.annotation.WhenCreated;
+import io.ebean.annotation.WhenModified;
+import java.time.Instant;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import play.data.validation.Constraints;
+
+/**
+ * An EBean mapped class that represents an API key in CiviForm.
+ */
+@Entity
+@Table(name = "api_keys")
+public class ApiKey extends BaseModel {
+
+  @WhenCreated private Instant createTime;
+  @WhenModified private Instant updateTime;
+
+  private Instant expiration;
+  private String createdBy;
+  private String name;
+  private String keyId;
+  private String saltedKeySecret;
+  private String subnet;
+
+  public ApiKeyGrants getGrants() {
+    return grants;
+  }
+
+  public ApiKey setGrants(ApiKeyGrants grants) {
+    this.grants = grants;
+    return this;
+  }
+
+  @DbJsonB private ApiKeyGrants grants;
+
+  public Instant getCreateTime() {
+    return createTime;
+  }
+
+  public Instant getUpdateTime() {
+    return updateTime;
+  }
+
+  public Instant getExpiration() {
+    return expiration;
+  }
+
+  public ApiKey setExpiration(Instant expiration) {
+    this.expiration = expiration;
+    return this;
+  }
+
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
+  public ApiKey setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ApiKey setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getKeyId() {
+    return keyId;
+  }
+
+  public ApiKey setKeyId(String keyId) {
+    this.keyId = keyId;
+    return this;
+  }
+
+  public String getSaltedKeySecret() {
+    return saltedKeySecret;
+  }
+
+  public ApiKey setSaltedKeySecret(String saltedKeySecret) {
+    this.saltedKeySecret = saltedKeySecret;
+    return this;
+  }
+
+  public String getSubnet() {
+    return subnet;
+  }
+
+  public ApiKey setSubnet(String subnet) {
+    this.subnet = subnet;
+    return this;
+  }
+}

--- a/server/app/models/ApiKey.java
+++ b/server/app/models/ApiKey.java
@@ -130,12 +130,12 @@ public class ApiKey extends BaseModel {
    * The client IPv4 address of the last request to successfully auth with the ApiKey. Empty if the
    * ApiKey has never been used.
    */
-  public String getLastCallIpAddress() {
+  public Optional<String> getLastCallIpAddress() {
     return Optional.ofNullable(lastCallIpAddress);
   }
 
   /** The client IPv4 address of the last request to successfully auth with the ApiKey. */
-  public Optional<String> setLastCallIpAddress(String lastCallIpAddress) {
+  public ApiKey setLastCallIpAddress(String lastCallIpAddress) {
     this.lastCallIpAddress = lastCallIpAddress;
     return this;
   }

--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -10,6 +10,7 @@ public class Models {
   private static final ImmutableList<Class<? extends BaseModel>> MODELS =
       ImmutableList.of(
           Account.class,
+          ApiKey.class,
           Applicant.class,
           Application.class,
           Program.class,

--- a/server/app/repository/ApiKeyRepository.java
+++ b/server/app/repository/ApiKeyRepository.java
@@ -10,7 +10,11 @@ import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.ApiKey;
 
-/** Provides an asynchronous API for persistence and query of {@link ApiKey} instances. */
+/**
+ * Provides an asynchronous API for persistence and query of {@link ApiKey} instances. Uses {@code
+ * DatabaseExecutionContext} for scheduling code to be executed using the database interaction
+ * thread pool.
+ */
 public class ApiKeyRepository {
   private final Database database;
   private final DatabaseExecutionContext executionContext;
@@ -21,7 +25,7 @@ public class ApiKeyRepository {
     this.executionContext = checkNotNull(executionContext);
   }
 
-  /** Insert a new ApiKey record using a thread from {@link DatabaseExecutionContext}. */
+  /** Insert a new {@link ApiKey} record asynchronously. */
   public CompletionStage<ApiKey> insert(ApiKey apiKey) {
     return supplyAsync(
         () -> {
@@ -31,20 +35,14 @@ public class ApiKeyRepository {
         executionContext);
   }
 
-  /**
-   * Find an ApiKey record by database primary ID using a thread from {@link
-   * DatabaseExecutionContext}.
-   */
+  /** Find an ApiKey record by database primary ID asynchronously. */
   public CompletionStage<Optional<ApiKey>> lookupApiKey(long id) {
     return supplyAsync(
         () -> Optional.ofNullable(database.find(ApiKey.class).setId(id).findOne()),
         executionContext);
   }
 
-  /**
-   * Find an ApiKey record by the key's string ID using a thread from {@link
-   * DatabaseExecutionContext}.
-   */
+  /** Find an ApiKey record by the key's string ID asynchronously. */
   public CompletionStage<Optional<ApiKey>> lookupApiKey(String keyId) {
     return supplyAsync(
         () ->

--- a/server/app/repository/ApiKeyRepository.java
+++ b/server/app/repository/ApiKeyRepository.java
@@ -1,0 +1,48 @@
+package repository;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+import io.ebean.DB;
+import io.ebean.Database;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+import models.ApiKey;
+
+/** Provides an asynchronous API for persistence and query of {@link ApiKey} instances. */
+public class ApiKeyRepository {
+  private final Database database;
+  private final DatabaseExecutionContext executionContext;
+
+  @Inject
+  public ApiKeyRepository(DatabaseExecutionContext executionContext) {
+    this.database = DB.getDefault();
+    this.executionContext = checkNotNull(executionContext);
+  }
+
+  /** Insert a new ApiKey record using a thread from {@link DatabaseExecutionContext}. */
+  public CompletionStage<ApiKey> insert(ApiKey apiKey) {
+    return supplyAsync(
+        () -> {
+          database.insert(apiKey);
+          return apiKey;
+        },
+        executionContext);
+  }
+
+  /** Find an ApiKey record by database primary ID using a thread from {@link DatabaseExecutionContext}. */
+  public CompletionStage<Optional<ApiKey>> lookupApiKey(long id) {
+    return supplyAsync(
+        () -> Optional.ofNullable(database.find(ApiKey.class).setId(id).findOne()),
+        executionContext);
+  }
+
+  /** Find an ApiKey record by the key's string ID using a thread from {@link DatabaseExecutionContext}. */
+  public CompletionStage<Optional<ApiKey>> lookupApiKey(String keyId) {
+    return supplyAsync(
+        () ->
+            Optional.ofNullable(database.find(ApiKey.class).where().eq("key_id", keyId).findOne()),
+        executionContext);
+  }
+}

--- a/server/app/repository/ApiKeyRepository.java
+++ b/server/app/repository/ApiKeyRepository.java
@@ -31,14 +31,20 @@ public class ApiKeyRepository {
         executionContext);
   }
 
-  /** Find an ApiKey record by database primary ID using a thread from {@link DatabaseExecutionContext}. */
+  /**
+   * Find an ApiKey record by database primary ID using a thread from {@link
+   * DatabaseExecutionContext}.
+   */
   public CompletionStage<Optional<ApiKey>> lookupApiKey(long id) {
     return supplyAsync(
         () -> Optional.ofNullable(database.find(ApiKey.class).setId(id).findOne()),
         executionContext);
   }
 
-  /** Find an ApiKey record by the key's string ID using a thread from {@link DatabaseExecutionContext}. */
+  /**
+   * Find an ApiKey record by the key's string ID using a thread from {@link
+   * DatabaseExecutionContext}.
+   */
   public CompletionStage<Optional<ApiKey>> lookupApiKey(String keyId) {
     return supplyAsync(
         () ->

--- a/server/conf/evolutions/default/38.sql
+++ b/server/conf/evolutions/default/38.sql
@@ -4,6 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS api_keys (
   id BIGSERIAL PRIMARY KEY NOT NULL,
+  name VARCHAR NOT NULL,
   create_time TIMESTAMP NOT NULL,
   update_time TIMESTAMP NOT NULL,
   created_by VARCHAR NOT NULL,
@@ -13,7 +14,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
   salted_key_secret VARCHAR UNIQUE NOT NULL,
   subnet VARCHAR NOT NULL,
   expiration TIMESTAMP NOT NULL,
-  call_count BIGINT NOT NULL,
+  call_count BIGINT NOT NULL DEFAULT 0,
   last_call_ip_address VARCHAR,
   grants JSONB NOT NULL
 );

--- a/server/conf/evolutions/default/38.sql
+++ b/server/conf/evolutions/default/38.sql
@@ -1,0 +1,26 @@
+ --- Create the api_keys table.
+
+# --- !Ups
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id BIGSERIAL PRIMARY KEY NOT NULL,
+  create_time TIMESTAMP NOT NULL,
+  update_time TIMESTAMP NOT NULL,
+  created_by VARCHAR NOT NULL,
+  retired_time TIMESTAMP,
+  retired_by VARCHAR,
+  key_id VARCHAR UNIQUE NOT NULL,
+  salted_key_secret VARCHAR UNIQUE NOT NULL,
+  subnet VARCHAR NOT NULL,
+  expiration TIMESTAMP NOT NULL,
+  call_count BIGINT NOT NULL,
+  last_call_ip_address VARCHAR,
+  grants JSONB NOT NULL
+);
+
+CREATE UNIQUE INDEX api_key_ids ON api_keys (key_id);
+
+# --- !Downs
+
+DROP TABLE IF EXISTS api_keys;
+DROP INDEX IF EXISTS api_key_ids;

--- a/server/test/auth/ApiKeyGrantsTest.java
+++ b/server/test/auth/ApiKeyGrantsTest.java
@@ -9,58 +9,82 @@ public class ApiKeyGrantsTest {
 
   private static final String PROGRAM_1_SLUG = "program-1";
   private static final String PROGRAM_2_SLUG = "program-2";
-  private ApiKeyGrants subject;
+  private ApiKeyGrants apiKeyGrants;
 
   @Before
   public void setUp() {
-    subject = new ApiKeyGrants();
+    apiKeyGrants = new ApiKeyGrants();
   }
 
   @Test
   public void hasProgramPermission_readAllowsRead() {
-    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+    apiKeyGrants.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
 
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
         .isFalse();
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ)).isTrue();
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+        .isTrue();
   }
 
   @Test
   public void hasProgramPermission_writeAllowsWrite() {
-    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
+    apiKeyGrants.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
 
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
         .isTrue();
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+        .isFalse();
+  }
+
+  @Test
+  public void hasProgramPermission_doesntConfuseSlugs() {
+    apiKeyGrants.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
+    apiKeyGrants.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ);
+
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isTrue();
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+        .isFalse();
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isFalse();
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ))
+        .isTrue();
+  }
+
+  @Test
+  public void hasProgramPermission_allPermissionsAreFalse() {
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isFalse();
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
         .isFalse();
   }
 
   @Test
   public void revokeProgramPermission_removesThePermission() {
-    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
-    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
+    apiKeyGrants.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+    apiKeyGrants.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
 
-    subject.revokeProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+    apiKeyGrants.revokeProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
 
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
         .isTrue();
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
         .isFalse();
   }
 
   @Test
   public void revokeAllProgramPermissions_revokesAllPermissions() {
-    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
-    subject.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ);
-    subject.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE);
+    apiKeyGrants.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+    apiKeyGrants.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ);
+    apiKeyGrants.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE);
 
-    subject.revokeAllProgramPermissions();
+    apiKeyGrants.revokeAllProgramPermissions();
 
-    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
         .isFalse();
-    assertThat(subject.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ))
         .isFalse();
-    assertThat(subject.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE))
+    assertThat(apiKeyGrants.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE))
         .isFalse();
   }
 }

--- a/server/test/auth/ApiKeyGrantsTest.java
+++ b/server/test/auth/ApiKeyGrantsTest.java
@@ -1,0 +1,66 @@
+package auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ApiKeyGrantsTest {
+
+  private static final String PROGRAM_1_SLUG = "program-1";
+  private static final String PROGRAM_2_SLUG = "program-2";
+  private ApiKeyGrants subject;
+
+  @Before
+  public void setUp() {
+    subject = new ApiKeyGrants();
+  }
+
+  @Test
+  public void hasProgramPermission_readAllowsRead() {
+    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isFalse();
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ)).isTrue();
+  }
+
+  @Test
+  public void hasProgramPermission_writeAllowsWrite() {
+    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
+
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isTrue();
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+        .isFalse();
+  }
+
+  @Test
+  public void revokeProgramPermission_removesThePermission() {
+    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE);
+
+    subject.revokeProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isTrue();
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+        .isFalse();
+  }
+
+  @Test
+  public void revokeAllProgramPermissions_revokesAllPermissions() {
+    subject.grantProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ);
+    subject.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ);
+    subject.grantProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE);
+
+    subject.revokeAllProgramPermissions();
+
+    assertThat(subject.hasProgramPermission(PROGRAM_1_SLUG, ApiKeyGrants.Permission.READ))
+        .isFalse();
+    assertThat(subject.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.READ))
+        .isFalse();
+    assertThat(subject.hasProgramPermission(PROGRAM_2_SLUG, ApiKeyGrants.Permission.WRITE))
+        .isFalse();
+  }
+}

--- a/server/test/repository/ApiKeyRepositoryTest.java
+++ b/server/test/repository/ApiKeyRepositoryTest.java
@@ -1,0 +1,66 @@
+package repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import auth.ApiKeyGrants;
+import io.ebean.DataIntegrityException;
+import java.time.Instant;
+import java.util.concurrent.CompletionException;
+import models.ApiKey;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ApiKeyRepositoryTest extends ResetPostgres {
+
+  private ApiKeyRepository repo;
+
+  @Before
+  public void setUp() {
+    repo = instanceOf(ApiKeyRepository.class);
+  }
+
+  @Test
+  public void insert_persistsANewKey() {
+    ApiKey foundKey;
+    ApiKey apiKey = new ApiKey();
+    apiKey.setName("key name");
+    apiKey.setKeyId("key-id");
+    apiKey.setCreatedBy("test@example.com");
+    apiKey.setSaltedKeySecret("secret");
+    apiKey.setSubnet("0.0.0.0/32");
+    apiKey.setExpiration(Instant.ofEpochSecond(100));
+    ApiKeyGrants grants = new ApiKeyGrants();
+    grants.grantProgramPermission("program-a", ApiKeyGrants.Permission.READ);
+    apiKey.setGrants(grants);
+
+    ApiKeyRepository repo = instanceOf(ApiKeyRepository.class);
+    repo.insert(apiKey).toCompletableFuture().join();
+
+    long id = apiKey.id;
+    foundKey = repo.lookupApiKey(id).toCompletableFuture().join().get();
+    assertThat(foundKey.id).isEqualTo(id);
+
+    foundKey = repo.lookupApiKey("key-id").toCompletableFuture().join().get();
+    assertThat(foundKey.id).isEqualTo(id);
+    assertThat(foundKey.getName()).isEqualTo("key name");
+    assertThat(foundKey.getKeyId()).isEqualTo("key-id");
+    assertThat(foundKey.getCreatedBy()).isEqualTo("test@example.com");
+    assertThat(foundKey.getSaltedKeySecret()).isEqualTo("secret");
+    assertThat(foundKey.getSubnet()).isEqualTo("0.0.0.0/32");
+    assertThat(foundKey.getExpiration()).isEqualTo(Instant.ofEpochSecond(100));
+    assertThat(foundKey.getGrants().hasProgramPermission("program-a", ApiKeyGrants.Permission.READ))
+        .isTrue();
+  }
+
+  @Test
+  public void insert_missingRequiredAttributes_raisesAnException() {
+    ApiKey apiKey = new ApiKey();
+
+    CompletionException exception = assertThrows(CompletionException.class,
+        () -> repo.insert(apiKey).toCompletableFuture().join());
+
+    assertThat(exception.getCause()).isInstanceOf(DataIntegrityException.class);
+    assertThat(exception.getCause().getMessage()).contains("violates not-null constraint");
+  }
+}

--- a/server/test/repository/ApiKeyRepositoryTest.java
+++ b/server/test/repository/ApiKeyRepositoryTest.java
@@ -57,8 +57,9 @@ public class ApiKeyRepositoryTest extends ResetPostgres {
   public void insert_missingRequiredAttributes_raisesAnException() {
     ApiKey apiKey = new ApiKey();
 
-    CompletionException exception = assertThrows(CompletionException.class,
-        () -> repo.insert(apiKey).toCompletableFuture().join());
+    CompletionException exception =
+        assertThrows(
+            CompletionException.class, () -> repo.insert(apiKey).toCompletableFuture().join());
 
     assertThat(exception.getCause()).isInstanceOf(DataIntegrityException.class);
     assertThat(exception.getCause().getMessage()).contains("violates not-null constraint");

--- a/server/test/repository/ApiKeyRepositoryTest.java
+++ b/server/test/repository/ApiKeyRepositoryTest.java
@@ -23,16 +23,18 @@ public class ApiKeyRepositoryTest extends ResetPostgres {
   @Test
   public void insert_persistsANewKey() {
     ApiKey foundKey;
-    ApiKey apiKey = new ApiKey();
-    apiKey.setName("key name");
-    apiKey.setKeyId("key-id");
-    apiKey.setCreatedBy("test@example.com");
-    apiKey.setSaltedKeySecret("secret");
-    apiKey.setSubnet("0.0.0.0/32");
-    apiKey.setExpiration(Instant.ofEpochSecond(100));
     ApiKeyGrants grants = new ApiKeyGrants();
     grants.grantProgramPermission("program-a", ApiKeyGrants.Permission.READ);
-    apiKey.setGrants(grants);
+    ApiKey apiKey = new ApiKey();
+
+    apiKey
+        .setName("key name")
+        .setKeyId("key-id")
+        .setCreatedBy("test@example.com")
+        .setSaltedKeySecret("secret")
+        .setSubnet("0.0.0.0/32")
+        .setExpiration(Instant.ofEpochSecond(100))
+        .setGrants(grants);
 
     ApiKeyRepository repo = instanceOf(ApiKeyRepository.class);
     repo.insert(apiKey).toCompletableFuture().join();


### PR DESCRIPTION
### Description
- [x] create a new DB table for api keys
- [x] add an ebean model for interacting with the table
- [x] add a repository class for async DB queries with api keys
- [x] implement ApiKeyGrants class, serialize to jsonb and deserialize on load

### Checklist
- [x] Created tests which fail without the change (if possible)

