### PR TITLE
Persist selected export state upon question creation.

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -193,7 +193,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')
     await waitForPageJsLoad(adminQuestions.page)
-    // expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION))).toBeTruthy()
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION), {strict: true})).toBeTruthy()
 
     const questionName = 'textQuestionWithObfuscatedExport'
     await adminQuestions.addTextQuestion({
@@ -202,18 +202,14 @@ describe('normal question lifecycle', () => {
     })
 
     // Confirm that the previously selected export option was propagated.
-    await page.click(
-      adminQuestions.selectWithinQuestionTableRow(questionName, ':text("Edit")')
-    )
-    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_OBFUSCATED_OPTION))).toBeTruthy()
+    await adminQuestions.gotoQuestionEditPage(questionName)
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_OBFUSCATED_OPTION), {strict: true})).toBeTruthy()
 
     // Edit the result and confirm that the new value is propagated.
     await adminQuestions.selectExportOption(AdminQuestions.EXPORT_VALUE_OPTION)
     await adminQuestions.clickSubmitButtonAndNavigate('Update')
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
-    await page.click(
-      adminQuestions.selectWithinQuestionTableRow(questionName, ':text("Edit")')
-    )
-    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION))).toBeTruthy()
+    await adminQuestions.gotoQuestionEditPage(questionName)
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION), {strict: true})).toBeTruthy()
   })
 })

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -193,6 +193,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')
     await waitForPageJsLoad(adminQuestions.page)
+    await page.waitForTimeout(1000);
     expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION), {strict: true})).toBeTruthy()
 
     const questionName = 'textQuestionWithObfuscatedExport'
@@ -203,6 +204,7 @@ describe('normal question lifecycle', () => {
 
     // Confirm that the previously selected export option was propagated.
     await adminQuestions.gotoQuestionEditPage(questionName)
+    await page.waitForTimeout(1000);
     expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_OBFUSCATED_OPTION), {strict: true})).toBeTruthy()
 
     // Edit the result and confirm that the new value is propagated.
@@ -210,6 +212,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.clickSubmitButtonAndNavigate('Update')
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
     await adminQuestions.gotoQuestionEditPage(questionName)
+    await page.waitForTimeout(1000);
     expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION), {strict: true})).toBeTruthy()
   })
 })

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -193,7 +193,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')
     await waitForPageJsLoad(adminQuestions.page)
-    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION))).toBeTruthy()
+    // expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION))).toBeTruthy()
 
     const questionName = 'textQuestionWithObfuscatedExport'
     await adminQuestions.addTextQuestion({

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -193,8 +193,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')
     await waitForPageJsLoad(adminQuestions.page)
-    await page.waitForTimeout(1000);
-    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION), {strict: true})).toBeTruthy()
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION))).toBeTruthy()
 
     const questionName = 'textQuestionWithObfuscatedExport'
     await adminQuestions.addTextQuestion({
@@ -204,15 +203,13 @@ describe('normal question lifecycle', () => {
 
     // Confirm that the previously selected export option was propagated.
     await adminQuestions.gotoQuestionEditPage(questionName)
-    await page.waitForTimeout(1000);
-    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_OBFUSCATED_OPTION), {strict: true})).toBeTruthy()
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_OBFUSCATED_OPTION))).toBeTruthy()
 
     // Edit the result and confirm that the new value is propagated.
     await adminQuestions.selectExportOption(AdminQuestions.EXPORT_VALUE_OPTION)
     await adminQuestions.clickSubmitButtonAndNavigate('Update')
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
     await adminQuestions.gotoQuestionEditPage(questionName)
-    await page.waitForTimeout(1000);
-    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION), {strict: true})).toBeTruthy()
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION))).toBeTruthy()
   })
 })

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -4,6 +4,7 @@ import {
   AdminQuestions,
   AdminPrograms,
   endSession,
+  waitForPageJsLoad,
 } from './support'
 
 describe('normal question lifecycle', () => {
@@ -178,5 +179,41 @@ describe('normal question lifecycle', () => {
     await adminQuestions.clickSubmitButtonAndNavigate('Update')
 
     await adminQuestions.expectMultiOptionBlankOptionError(options)
+  })
+
+  it('persists export state', async () => {
+    const { page } = await startSession()
+    page.setDefaultTimeout(4000)
+
+    await loginAsAdmin(page)
+    const adminQuestions = new AdminQuestions(page)
+
+    // Navigate to the new question page and ensure that "No export" is pre-selected.
+    await adminQuestions.gotoAdminQuestionsPage()
+    await adminQuestions.page.click('#create-question-button')
+    await adminQuestions.page.click('#create-text-question')
+    await waitForPageJsLoad(adminQuestions.page)
+    await adminQuestions.expectExportState(AdminQuestions.NO_EXPORT_OPTION)
+
+    const questionName = 'textQuestionWithObfuscatedExport'
+    await adminQuestions.addTextQuestion({
+      questionName,
+      exportOption: AdminQuestions.EXPORT_OBFUSCATED_OPTION,
+    })
+
+    // Confirm that the previously selected export option was propagated.
+    await page.click(
+      adminQuestions.selectWithinQuestionTableRow(questionName, ':text("Edit")')
+    )
+    await adminQuestions.expectExportState(AdminQuestions.EXPORT_OBFUSCATED_OPTION)
+    
+    // Edit the result and confirm that the new value is propagated.
+    await adminQuestions.selectExportOption(AdminQuestions.EXPORT_VALUE_OPTION)
+    await adminQuestions.clickSubmitButtonAndNavigate('Update')
+    await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
+    await page.click(
+      adminQuestions.selectWithinQuestionTableRow(questionName, ':text("Edit")')
+    )
+    await adminQuestions.expectExportState(AdminQuestions.EXPORT_VALUE_OPTION)
   })
 })

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -193,7 +193,7 @@ describe('normal question lifecycle', () => {
     await adminQuestions.page.click('#create-question-button')
     await adminQuestions.page.click('#create-text-question')
     await waitForPageJsLoad(adminQuestions.page)
-    await adminQuestions.expectExportState(AdminQuestions.NO_EXPORT_OPTION)
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.NO_EXPORT_OPTION))).toBeTruthy()
 
     const questionName = 'textQuestionWithObfuscatedExport'
     await adminQuestions.addTextQuestion({
@@ -205,8 +205,8 @@ describe('normal question lifecycle', () => {
     await page.click(
       adminQuestions.selectWithinQuestionTableRow(questionName, ':text("Edit")')
     )
-    await adminQuestions.expectExportState(AdminQuestions.EXPORT_OBFUSCATED_OPTION)
-    
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_OBFUSCATED_OPTION))).toBeTruthy()
+
     // Edit the result and confirm that the new value is propagated.
     await adminQuestions.selectExportOption(AdminQuestions.EXPORT_VALUE_OPTION)
     await adminQuestions.clickSubmitButtonAndNavigate('Update')
@@ -214,6 +214,6 @@ describe('normal question lifecycle', () => {
     await page.click(
       adminQuestions.selectWithinQuestionTableRow(questionName, ':text("Edit")')
     )
-    await adminQuestions.expectExportState(AdminQuestions.EXPORT_VALUE_OPTION)
+    expect(await page.isChecked(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION))).toBeTruthy()
   })
 })

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -109,7 +109,7 @@ export class AdminQuestions {
     if (!exportOption) {
       throw new Error('A non-empty export option must be provided')
     }
-    await this.page.check(`label:has-text("${exportOption}") input`)
+    await this.page.check(this.selectorForExportOption(exportOption))
   }
 
   async updateQuestionText(updateText: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -8,12 +8,17 @@ type QuestionParams = {
   questionText?: string
   helpText?: string
   enumeratorName?: string
+  exportOption?: string
 }
 
 export class AdminQuestions {
   public page!: Page
 
   static readonly DOES_NOT_REPEAT_OPTION = 'does not repeat'
+  
+  public static readonly NO_EXPORT_OPTION = 'No export'
+  public static readonly EXPORT_VALUE_OPTION = 'Export Value'
+  public static readonly EXPORT_OBFUSCATED_OPTION = 'Export Obfuscated'
 
   constructor(page: Page) {
     this.page = page
@@ -46,6 +51,10 @@ export class AdminQuestions {
     // expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
   }
 
+  async expectExportState(exportOption: string) {
+    expect(await this.page.isChecked(`label:has-text("${exportOption}") input`)).toEqual(true)
+  }
+
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {
     const toastContainer = await this.page.innerHTML('#toast-container')
 
@@ -75,13 +84,14 @@ export class AdminQuestions {
     }
   }
 
-  async fillInQuestionBasics(
-    questionName: string,
-    description: string,
-    questionText: string,
-    helpText: string,
-    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION
-  ) {
+  async fillInQuestionBasics({
+    questionName,
+    description,
+    questionText,
+    helpText,
+    enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
+  } : QuestionParams) {
     // This function should only be called on question create/edit page.
     await this.page.fill('label:has-text("Name")', questionName)
     await this.page.fill('label:has-text("Description")', description)
@@ -90,6 +100,16 @@ export class AdminQuestions {
     await this.page.selectOption('#question-enumerator-select', {
       label: enumeratorName,
     })
+    if (exportOption) {
+      await this.selectExportOption(exportOption)
+    }
+  }
+
+  async selectExportOption(exportOption: string) {
+    if (!exportOption) {
+      throw new Error('A non-empty export option must be provided')
+    }
+    await this.page.check(`label:has-text("${exportOption}") input`)
   }
 
   async updateQuestionText(updateText: string) {
@@ -334,6 +354,7 @@ export class AdminQuestions {
     questionText = 'address question text',
     helpText = 'address question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -341,13 +362,14 @@ export class AdminQuestions {
     await this.page.click('#create-address-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -362,6 +384,7 @@ export class AdminQuestions {
     questionText = 'date question text',
     helpText = 'date question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -369,13 +392,14 @@ export class AdminQuestions {
     await this.page.click('#create-date-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -391,6 +415,7 @@ export class AdminQuestions {
     questionText = 'checkbox question text',
     helpText = 'checkbox question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -398,13 +423,14 @@ export class AdminQuestions {
     await this.page.click('#create-checkbox-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     for (var index in options) {
       await this.page.click('#add-new-option')
@@ -430,6 +456,7 @@ export class AdminQuestions {
     questionText = 'dropdown question text',
     helpText = 'dropdown question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -438,13 +465,14 @@ export class AdminQuestions {
     await this.page.waitForURL('**/admin/questions/new?type=dropdown')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     for (let index in options) {
       await this.page.click('#add-new-option')
@@ -469,18 +497,20 @@ export class AdminQuestions {
     questionText = 'currency question text',
     helpText = 'currency question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
     await this.page.click('#create-question-button')
     await this.page.click('#create-currency-question')
     await waitForPageJsLoad(this.page)
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
     await this.clickSubmitButtonAndNavigate('Create')
     await this.expectAdminQuestionsPageWithCreateSuccessToast()
     await this.expectDraftQuestionExist(questionName, questionText)
@@ -494,6 +524,7 @@ export class AdminQuestions {
     questionText = 'dropdown question text',
     helpText = 'dropdown question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.createDropdownQuestion({
       questionName,
@@ -515,6 +546,7 @@ export class AdminQuestions {
     questionText = 'fileupload question text',
     helpText = 'fileupload question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -522,13 +554,14 @@ export class AdminQuestions {
     await this.page.click('#create-fileupload-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -542,6 +575,7 @@ export class AdminQuestions {
     description = 'static description',
     questionText = 'static question text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = '',
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -569,6 +603,7 @@ export class AdminQuestions {
     questionText = 'name question text',
     helpText = 'name question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -576,13 +611,14 @@ export class AdminQuestions {
     await this.page.click('#create-name-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -597,6 +633,7 @@ export class AdminQuestions {
     questionText = 'number question text',
     helpText = 'number question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -604,13 +641,14 @@ export class AdminQuestions {
     await this.page.click('#create-number-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -626,6 +664,7 @@ export class AdminQuestions {
     questionText = 'radio button question text',
     helpText = 'radio button question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.createRadioButtonQuestion({
       questionName,
@@ -648,6 +687,7 @@ export class AdminQuestions {
     questionText = 'radio button question text',
     helpText = 'radio button question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -655,13 +695,14 @@ export class AdminQuestions {
     await this.page.click('#create-radio_button-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     for (var index in options) {
       await this.page.click('#add-new-option')
@@ -681,6 +722,7 @@ export class AdminQuestions {
     questionText = 'text question text',
     helpText = 'text question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -688,13 +730,14 @@ export class AdminQuestions {
     await this.page.click('#create-text-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -709,6 +752,7 @@ export class AdminQuestions {
     questionText = 'id question text',
     helpText = 'id question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -716,13 +760,14 @@ export class AdminQuestions {
     await this.page.click('#create-id-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -737,6 +782,7 @@ export class AdminQuestions {
     questionText = 'email question text',
     helpText = 'email question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -744,13 +790,14 @@ export class AdminQuestions {
     await this.page.click('#create-email-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.clickSubmitButtonAndNavigate('Create')
 
@@ -768,6 +815,7 @@ export class AdminQuestions {
     questionText = 'enumerator question text',
     helpText = 'enumerator question help text',
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
+    exportOption = '',
   }: QuestionParams) {
     await this.gotoAdminQuestionsPage()
 
@@ -775,13 +823,14 @@ export class AdminQuestions {
     await this.page.click('#create-enumerator-question')
     await waitForPageJsLoad(this.page)
 
-    await this.fillInQuestionBasics(
+    await this.fillInQuestionBasics({
       questionName,
       description,
       questionText,
       helpText,
-      enumeratorName
-    )
+      enumeratorName,
+      exportOption,
+    })
 
     await this.page.fill('text=Repeated Entity Type', 'Entity')
 

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -51,8 +51,8 @@ export class AdminQuestions {
     // expect(await this.page.isDisabled(`text=${questionName}`)).toEqual(true)
   }
 
-  async expectExportState(exportOption: string) {
-    expect(await this.page.isChecked(`label:has-text("${exportOption}") input`)).toEqual(true)
+  selectorForExportOption(exportOption: string) {
+    return `label:has-text("${exportOption}") input`
   }
 
   async expectAdminQuestionsPageWithSuccessToast(successText: string) {

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
-import models.QuestionTag;
 import org.pac4j.play.java.Secure;
 import play.data.FormFactory;
 import play.libs.concurrent.HttpExecutionContext;
@@ -288,8 +287,7 @@ public class AdminQuestionController extends CiviFormController {
     }
     try {
       service.setExportState(
-          errorAndUpdatedQuestionDefinition.getResult(),
-          questionForm.getQuestionExportStateTag());
+          errorAndUpdatedQuestionDefinition.getResult(), questionForm.getQuestionExportStateTag());
     } catch (InvalidUpdateException | QuestionNotFoundException e) {
       return badRequest(e.toString());
     }

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -165,6 +165,16 @@ public class AdminQuestionController extends CiviFormController {
               request, questionForm, enumeratorQuestionDefinitions, errorMessage));
     }
 
+    QuestionTag exportStateTag =
+        questionForm.getQuestionExportState().isEmpty()
+            ? QuestionTag.NON_DEMOGRAPHIC
+            : QuestionTag.valueOf(questionForm.getQuestionExportState());
+    try {
+      service.setExportState(result.getResult(), exportStateTag);
+    } catch (InvalidUpdateException | QuestionNotFoundException e) {
+      return badRequest(e.toString());
+    }
+
     String successMessage = String.format("question %s created", questionForm.getQuestionName());
     return withMessage(redirect(routes.AdminQuestionController.index()), successMessage);
   }

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -165,12 +165,8 @@ public class AdminQuestionController extends CiviFormController {
               request, questionForm, enumeratorQuestionDefinitions, errorMessage));
     }
 
-    QuestionTag exportStateTag =
-        questionForm.getQuestionExportState().isEmpty()
-            ? QuestionTag.NON_DEMOGRAPHIC
-            : QuestionTag.valueOf(questionForm.getQuestionExportState());
     try {
-      service.setExportState(result.getResult(), exportStateTag);
+      service.setExportState(result.getResult(), questionForm.getQuestionExportStateTag());
     } catch (InvalidUpdateException | QuestionNotFoundException e) {
       return badRequest(e.toString());
     }
@@ -293,7 +289,7 @@ public class AdminQuestionController extends CiviFormController {
     try {
       service.setExportState(
           errorAndUpdatedQuestionDefinition.getResult(),
-          QuestionTag.valueOf(questionForm.getQuestionExportState()));
+          questionForm.getQuestionExportStateTag());
     } catch (InvalidUpdateException | QuestionNotFoundException e) {
       return badRequest(e.toString());
     }

--- a/server/app/forms/QuestionForm.java
+++ b/server/app/forms/QuestionForm.java
@@ -132,8 +132,8 @@ public abstract class QuestionForm {
   }
 
   /**
-   * The {@link QuestionTag} to use for export state. Callers external to this
-   * class should use this rather than {@link getQuestionExportState}.
+   * The {@link QuestionTag} to use for export state. Callers external to this class should use this
+   * rather than {@link getQuestionExportState}.
    */
   public QuestionTag getQuestionExportStateTag() {
     String rawState = getQuestionExportState();
@@ -141,9 +141,9 @@ public abstract class QuestionForm {
   }
 
   /**
-   * The string representation of export state. This is only public since
-   * the Play framework requires public getters and setters. Callers external
-   * to this class should prefer {@link getQuestionExportStateTag}.
+   * The string representation of export state. This is only public since the Play framework
+   * requires public getters and setters. Callers external to this class should prefer {@link
+   * getQuestionExportStateTag}.
    */
   public String getQuestionExportState() {
     if (ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(getQuestionType())) {

--- a/server/app/forms/QuestionForm.java
+++ b/server/app/forms/QuestionForm.java
@@ -121,7 +121,7 @@ public abstract class QuestionForm {
     this.questionExportState = Optional.of(questionExportState);
   }
 
-  public void setQuestionExportStateFromTags(List<QuestionTag> questionTags) {
+  private void populateQuestionExportStateFromTags(List<QuestionTag> questionTags) {
     if (questionTags.contains(QuestionTag.DEMOGRAPHIC)) {
       questionExportState = Optional.of(QuestionTag.DEMOGRAPHIC.getValue());
     } else if (questionTags.contains(QuestionTag.DEMOGRAPHIC_PII)) {
@@ -131,6 +131,20 @@ public abstract class QuestionForm {
     }
   }
 
+  /**
+   * The {@link QuestionTag} to use for export state. Callers external to this
+   * class should use this rather than {@link getQuestionExportState}.
+   */
+  public QuestionTag getQuestionExportStateTag() {
+    String rawState = getQuestionExportState();
+    return rawState.isEmpty() ? QuestionTag.NON_DEMOGRAPHIC : QuestionTag.valueOf(rawState);
+  }
+
+  /**
+   * The string representation of export state. This is only public since
+   * the Play framework requires public getters and setters. Callers external
+   * to this class should prefer {@link getQuestionExportStateTag}.
+   */
   public String getQuestionExportState() {
     if (ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(getQuestionType())) {
       return QuestionTag.NON_DEMOGRAPHIC.getValue();
@@ -139,7 +153,7 @@ public abstract class QuestionForm {
     if (questionExportState.isEmpty()) {
       Question q = new Question(this.qd);
       q.refresh();
-      setQuestionExportStateFromTags(q.getQuestionTags());
+      populateQuestionExportStateFromTags(q.getQuestionTags());
     }
     return questionExportState.get();
   }

--- a/server/app/services/question/QuestionServiceImpl.java
+++ b/server/app/services/question/QuestionServiceImpl.java
@@ -182,17 +182,19 @@ public final class QuestionServiceImpl implements QuestionService {
   @Override
   public void setExportState(QuestionDefinition questionDefinition, QuestionTag questionExportState)
       throws QuestionNotFoundException, InvalidUpdateException {
-    if (ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(
-        questionDefinition.getQuestionType())) {
-      return;
-    }
-
     Optional<Question> questionMaybe =
         questionRepository.lookupQuestion(questionDefinition.getId()).toCompletableFuture().join();
     if (questionMaybe.isEmpty()) {
       throw new QuestionNotFoundException(questionDefinition.getId());
     }
     Question question = questionMaybe.get();
+    if (ExporterService.NON_EXPORTED_QUESTION_TYPES.contains(
+        questionDefinition.getQuestionType())) {
+      question.removeTag(QuestionTag.DEMOGRAPHIC_PII);
+      question.removeTag(QuestionTag.NON_DEMOGRAPHIC);
+      question.removeTag(QuestionTag.DEMOGRAPHIC);
+    }
+
     switch (questionExportState) {
       case DEMOGRAPHIC:
         question.removeTag(QuestionTag.DEMOGRAPHIC_PII);

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -360,6 +360,8 @@ public final class QuestionEditView extends BaseHtmlView {
 
   private ImmutableList<DomContent> buildDemographicFields(
       QuestionForm questionForm, boolean submittable) {
+
+    QuestionTag exportState = questionForm.getQuestionExportStateTag();
     return ImmutableList.of(
         FieldWithLabel.radio()
             .setId("question-demographic-no-export")
@@ -367,10 +369,7 @@ public final class QuestionEditView extends BaseHtmlView {
             .setFieldName("questionExportState")
             .setLabelText("No export")
             .setValue(QuestionTag.NON_DEMOGRAPHIC.getValue())
-            .setChecked(
-                questionForm
-                    .getQuestionExportState()
-                    .equals(QuestionTag.NON_DEMOGRAPHIC.getValue()))
+            .setChecked(exportState == QuestionTag.NON_DEMOGRAPHIC)
             .getContainer(),
         FieldWithLabel.radio()
             .setId("question-demographic-export-demographic")
@@ -378,8 +377,7 @@ public final class QuestionEditView extends BaseHtmlView {
             .setFieldName("questionExportState")
             .setLabelText("Export Value")
             .setValue(QuestionTag.DEMOGRAPHIC.getValue())
-            .setChecked(
-                questionForm.getQuestionExportState().equals(QuestionTag.DEMOGRAPHIC.getValue()))
+            .setChecked(exportState == QuestionTag.DEMOGRAPHIC)
             .getContainer(),
         FieldWithLabel.radio()
             .setId("question-demographic-export-pii")
@@ -387,10 +385,7 @@ public final class QuestionEditView extends BaseHtmlView {
             .setFieldName("questionExportState")
             .setLabelText("Export Obfuscated")
             .setValue(QuestionTag.DEMOGRAPHIC_PII.getValue())
-            .setChecked(
-                questionForm
-                    .getQuestionExportState()
-                    .equals(QuestionTag.DEMOGRAPHIC_PII.getValue()))
+            .setChecked(exportState == QuestionTag.DEMOGRAPHIC_PII)
             .getContainer());
   }
 


### PR DESCRIPTION
### Description
Previously, we were only persisting the selected export option when updating a question. We now do this as part of creation as well.

While here, I also updated the UI to preselect the "No Export" option since that's what happens in practice.

Finally, added a browser test to catch regressions in this area.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #1889
