### PR TITLE
Using Terraform Resource to generate ssh key

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -103,8 +103,6 @@ jobs:
     steps:
       - name: check out pr branch
         uses: actions/checkout@v3
-      - name: generate bastion key
-        run:  ssh-keygen -q -t rsa -b 4096 -N '' -f "${HOME}/.ssh/bastion"
       - name: setup terraform
         uses: hashicorp/setup-terraform@v1
       # as we add more templates, we will add checks to validate them. for now, we only have one

--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -205,11 +205,3 @@ storage account within that resource group. For example in the below azure
 portal the resource group name is 'tfstate' and the storage_account_name is 
 'tfstate7307'.
 ![Image of Azure portal showing where to find the storage_account_name](img/how_to_find_backend_vars.png?raw=true)
-
-## Can't find the .pub key for terraform
-
-We are required to pass in an initial pub key pair at `$HOME/.ssh/bastion` to set up the bastion vm. If terraform complains about this, you can generate a key via the following command. 
-
-```
-ssh-keygen -t rsa -b 4096 -f $HOME/.ssh/bastion
-```

--- a/cloud/azure/bin/lib/azure.sh
+++ b/cloud/azure/bin/lib/azure.sh
@@ -175,6 +175,7 @@ function azure::get_current_user_id() {
 #   3. scope name
 #######################################
 function azure::ensure_role_assignment() {
+  echo "creating role assignment for ${2}"
   local USER_TYPE="$(az account show --query user.type -o tsv)"
   local object_id=""
   

--- a/cloud/azure/modules/bastion/main.tf
+++ b/cloud/azure/modules/bastion/main.tf
@@ -63,6 +63,10 @@ resource "azurerm_network_interface_security_group_association" "nic_sg" {
   network_interface_id      = azurerm_network_interface.bastion_nic.id
   network_security_group_id = azurerm_network_security_group.public_nsg.id
 }
+resource "tls_private_key" "throwaway_public_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
 
 # Create bastion host VM.
 resource "azurerm_linux_virtual_machine" "bastion_vm" {
@@ -76,7 +80,7 @@ resource "azurerm_linux_virtual_machine" "bastion_vm" {
   # this is required, but we deny all ingres to the machine
   admin_ssh_key {
     username   = "adminuser"
-    public_key = file("~/.ssh/bastion.pub")
+    public_key = tls_private_key.throwaway_public_key.public_key_openssh
   }
 
   os_disk {

--- a/cloud/azure/templates/azure_saml_ses/bin/setup.py
+++ b/cloud/azure/templates/azure_saml_ses/bin/setup.py
@@ -22,8 +22,6 @@ class Setup:
         return True
 
     def pre_terraform_setup(self):
-        print(" - Generating ssh keyfile")
-        self._create_ssh_keyfile()
         print(" - Setting up shared state")
         self._setup_shared_state()
         print(" - Setting up the keyvault")
@@ -95,11 +93,6 @@ class Setup:
                        check=True)
         self.resource_group = resource_group
         self.resource_group_location = resource_group_location
-
-    def _create_ssh_keyfile(self):
-        subprocess.run(["/bin/bash",
-            "-c", "ssh-keygen -q -t rsa -b 4096 -N '' -f $HOME/.ssh/bastion <<< y"
-        ], check=True)
 
     def _make_backend_override(self):
         current_directory = self.config.get_template_dir()

--- a/cloud/shared/bin/lib/terraform.sh
+++ b/cloud/shared/bin/lib/terraform.sh
@@ -21,7 +21,7 @@ function terraform::perform_apply() {
       -upgrade \
       -backend-config="${BACKEND_VARS_FILENAME}"
   fi
-
+  
   terraform \
     -chdir="${TERRAFORM_TEMPLATE_DIR}" \
     apply \


### PR DESCRIPTION
### Description
Terraform deploys are failing due to not being able to find a file, there's a terraform resource that lets us create the initial key so we can use that here. note this is purely to make the azure terraform code happy as we prevent all ingres to the machine and then to access the bastion you have to manually add your own key to it via the scripts

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2383 
