### PR TITLE
Storage Account Backup Contributor Role -> Storage Account Backup Contributor

### DIFF
--- a/cloud/azure/modules/app/role-assignments.tf
+++ b/cloud/azure/modules/app/role-assignments.tf
@@ -54,6 +54,6 @@ resource "azurerm_role_assignment" "storage_account_contributor_canary" {
 
 resource "azurerm_role_assignment" "storage_backup_contributor" {
   scope                = azurerm_storage_account.files_storage_account.id
-  role_definition_name = "Storage Account Backup Contributor Role"
+  role_definition_name = "Storage Account Backup Contributor"
   principal_id         = azurerm_data_protection_backup_vault.backup_vault.identity[0].principal_id
 }


### PR DESCRIPTION
Looks like azure changed the name of this role so we also need to change it in our terraform. [AzRole Website with Details of role name change](https://www.azadvertizer.net/azrolesadvertizer/e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1.html#:~:text=Lets%20you%20perform%20backup%20and,Backup%20on%20the%20storage%20account.&text=Old%20DisplayName%3A%20'Storage%20Account%20Backup,Backup%20on%20the%20storage%20account.)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
