### PR TITLE
Question bank additions now use latest revision of the question

### DIFF
--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -162,7 +162,7 @@ public class VersionRepository {
    * Given any revision of a question, return the most recent conceptual version of it. Will return
    * the current DRAFT version if present then the current ACTIVE version.
    */
-  private Optional<Question> getLatestVersionOfQuestion(long questionId) {
+  public Optional<Question> getLatestVersionOfQuestion(long questionId) {
     String questionName =
         database.find(Question.class).setId(questionId).select("name").findSingleAttribute();
     Optional<Question> draftQuestion =

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -31,7 +31,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void create() throws UnsupportedQuestionTypeException {
+  public void create_addOldRevisionAddsLatestRevision() throws UnsupportedQuestionTypeException {
     // Setup.
     QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
     Long activeId = nameQuestion.getId();
@@ -47,7 +47,9 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
     // Execute.
     Request request =
-        fakeRequest(routes.AdminProgramBlockQuestionsController.create(program.id, 1))
+        fakeRequest(
+            controllers.admin.routes.AdminProgramBlockQuestionsController.create(
+                program.id, 1))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .bodyForm(ImmutableMap.of("question-", activeId.toString()))
             .build();

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -1,0 +1,72 @@
+package controllers.admin;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
+import models.LifecycleStage;
+import models.Program;
+import org.junit.Before;
+import static play.test.Helpers.stubMessagesApi;
+import static play.test.Helpers.contentAsString;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.api.test.CSRFTokenHelper.addCSRFToken;
+import static play.mvc.Http.Status.SEE_OTHER;
+import static play.test.Helpers.fakeRequest;
+
+import org.junit.Test;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import repository.ResetPostgres;
+//import repository.VersionRepository;
+import services.LocalizedStrings;
+//import services.question.QuestionService;
+import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+import support.ProgramBuilder;
+
+public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
+
+  private AdminProgramBlockQuestionsController controller;
+  //private QuestionService questionService;
+  //private VersionRepository versionRepository;
+
+  @Before
+  public void setUp() {
+    controller = instanceOf(AdminProgramBlockQuestionsController.class);
+    //questionService = instanceOf(QuestionService.class);
+    //versionRepository = instanceOf(VersionRepository.class);
+  }
+
+  @Test
+  public void create() throws UnsupportedQuestionTypeException {
+    // Setup.
+    QuestionDefinition nameQuestion = testQuestionBank.applicantName().getQuestionDefinition();
+    Long activeId = nameQuestion.getId();
+    Long draftId = activeId + 100000;
+    QuestionDefinition toUpdate =
+        new QuestionDefinitionBuilder(nameQuestion)
+            .setId(draftId)
+            .setQuestionText(LocalizedStrings.withDefaultValue("draft version"))
+            .build();
+    testQuestionBank.maybeSave(toUpdate, LifecycleStage.DRAFT);
+    ProgramBuilder programBuilder = ProgramBuilder.newDraftProgram();
+    Program program = programBuilder.withBlock("block1").build();
+
+    // Execute.
+    Request request =
+            fakeRequest(routes.AdminProgramBlockQuestionsController.create(program.id,1))
+            .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
+            .bodyForm(ImmutableMap.of("question-", activeId.toString()))
+            .build();
+    Result result = controller.create(request, program.id,1);
+
+    // Verify.
+    assertThat(result.status()).withFailMessage(contentAsString(result)).isEqualTo(SEE_OTHER);
+    program.refresh();
+    assertThat(program.getProgramDefinition().hasQuestion(toUpdate)).isTrue();
+    assertThat(program.getProgramDefinition().hasQuestion(nameQuestion)).isFalse();
+
+  }
+}

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -1,26 +1,21 @@
 package controllers.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.mvc.Http.Status.SEE_OTHER;
+import static play.test.Helpers.contentAsString;
+import static play.test.Helpers.fakeRequest;
+import static play.test.Helpers.stubMessagesApi;
+
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import models.LifecycleStage;
 import models.Program;
 import org.junit.Before;
-import static play.test.Helpers.stubMessagesApi;
-import static play.test.Helpers.contentAsString;
-
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static play.api.test.CSRFTokenHelper.addCSRFToken;
-import static play.mvc.Http.Status.SEE_OTHER;
-import static play.test.Helpers.fakeRequest;
-
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.ResetPostgres;
-//import repository.VersionRepository;
 import services.LocalizedStrings;
-//import services.question.QuestionService;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
@@ -29,14 +24,10 @@ import support.ProgramBuilder;
 public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
   private AdminProgramBlockQuestionsController controller;
-  //private QuestionService questionService;
-  //private VersionRepository versionRepository;
 
   @Before
   public void setUp() {
     controller = instanceOf(AdminProgramBlockQuestionsController.class);
-    //questionService = instanceOf(QuestionService.class);
-    //versionRepository = instanceOf(VersionRepository.class);
   }
 
   @Test
@@ -56,17 +47,16 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
     // Execute.
     Request request =
-            fakeRequest(routes.AdminProgramBlockQuestionsController.create(program.id,1))
+        fakeRequest(routes.AdminProgramBlockQuestionsController.create(program.id, 1))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .bodyForm(ImmutableMap.of("question-", activeId.toString()))
             .build();
-    Result result = controller.create(request, program.id,1);
+    Result result = controller.create(request, program.id, 1);
 
     // Verify.
     assertThat(result.status()).withFailMessage(contentAsString(result)).isEqualTo(SEE_OTHER);
     program.refresh();
     assertThat(program.getProgramDefinition().hasQuestion(toUpdate)).isTrue();
     assertThat(program.getProgramDefinition().hasQuestion(nameQuestion)).isFalse();
-
   }
 }

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -48,8 +48,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
     // Execute.
     Request request =
         fakeRequest(
-            controllers.admin.routes.AdminProgramBlockQuestionsController.create(
-                program.id, 1))
+                controllers.admin.routes.AdminProgramBlockQuestionsController.create(program.id, 1))
             .langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi())
             .bodyForm(ImmutableMap.of("question-", activeId.toString()))
             .build();


### PR DESCRIPTION
### Description
The Question Bank contains revision IDs, currently when one is added to a program that specific ID is added even if is old and not an Active or Draft revision. This happens if the UI has been loaded, but Question changes have occurred external to it.

We now lookup the latest revision of the question and add that instead.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2375