### PR TITLE
Remove duplicated metadata in header tag

### DIFF
--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -165,7 +165,6 @@ public class HtmlBundle {
     ContainerTag headerTag =
         header()
             .with(each(toastMessages, toastMessage -> toastMessage.getContainerTag()))
-            .with(metadata)
             .with(headerContent);
 
     if (headerStyles.size() > 0) {


### PR DESCRIPTION
### Description
Removed a duplicate metadata element in the header tag that was already in the head tag.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2258 
