### PR TITLE
Move checking question-requiredness into `getValidationErrors`. Only display validation errors on an unsuccessful attempt

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -159,7 +159,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             inReview,
                             roApplicantProgramService,
                             block.get(),
-                            applicantName)));
+                            applicantName,
+                            /* displayErrors= */ false)));
               } else {
                 return notFound();
               }
@@ -209,7 +210,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             inReview,
                             roApplicantProgramService,
                             block.get(),
-                            applicantName)));
+                            applicantName,
+                            /* displayErrors= */ false)));
               } else {
                 return notFound();
               }
@@ -371,7 +373,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           inReview,
                           roApplicantProgramService,
                           thisBlockUpdated,
-                          applicantName))));
+                          applicantName,
+                          /* displayErrors= */ true))));
     }
 
     if (inReview) {
@@ -415,7 +418,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       boolean inReview,
       ReadOnlyApplicantProgramService roApplicantProgramService,
       Block block,
-      String applicantName) {
+      String applicantName,
+      boolean displayErrors) {
     return ApplicantProgramBlockEditView.Params.builder()
         .setRequest(request)
         .setMessages(messagesApi.preferred(request))
@@ -430,6 +434,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
         .setPreferredLanguageSupported(roApplicantProgramService.preferredLanguageSupported())
         .setStorageClient(storageClient)
         .setBaseUrl(baseUrl)
+        .setDisplayErrors(displayErrors)
         .build();
   }
 

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -42,6 +42,7 @@ import views.FileUploadViewStrategy;
 import views.applicant.ApplicantProgramBlockEditView;
 import views.applicant.ApplicantProgramBlockEditViewFactory;
 import views.questiontypes.ApplicantQuestionRendererFactory;
+import views.questiontypes.ApplicantQuestionRendererParams;
 
 /**
  * Controller for handling an applicant filling out a single program. CAUTION: you must explicitly
@@ -160,7 +161,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             roApplicantProgramService,
                             block.get(),
                             applicantName,
-                            /* displayErrors= */ false)));
+                            ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)));
               } else {
                 return notFound();
               }
@@ -211,7 +212,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             roApplicantProgramService,
                             block.get(),
                             applicantName,
-                            /* displayErrors= */ false)));
+                            ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)));
               } else {
                 return notFound();
               }
@@ -374,7 +375,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                           roApplicantProgramService,
                           thisBlockUpdated,
                           applicantName,
-                          /* displayErrors= */ true))));
+                          ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS))));
     }
 
     if (inReview) {
@@ -419,7 +420,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       ReadOnlyApplicantProgramService roApplicantProgramService,
       Block block,
       String applicantName,
-      boolean displayErrors) {
+      ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode) {
     return ApplicantProgramBlockEditView.Params.builder()
         .setRequest(request)
         .setMessages(messagesApi.preferred(request))
@@ -434,7 +435,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
         .setPreferredLanguageSupported(roApplicantProgramService.preferredLanguageSupported())
         .setStorageClient(storageClient)
         .setBaseUrl(baseUrl)
-        .setDisplayErrors(displayErrors)
+        .setErrorDisplayMode(errorDisplayMode)
         .build();
   }
 

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -419,7 +419,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
       boolean inReview,
       ReadOnlyApplicantProgramService roApplicantProgramService,
       Block block,
-      Optional<String> applicantName
+      Optional<String> applicantName,
       ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode) {
     return ApplicantProgramBlockEditView.Params.builder()
         .setRequest(request)

--- a/server/app/services/applicant/question/Question.java
+++ b/server/app/services/applicant/question/Question.java
@@ -27,7 +27,7 @@ public interface Question {
 
   /**
    * Returns true any part of the question has been answered by the applicant. Blank answers should
-   * not count. If a question is not answered, it should not have errors associated with it.
+   * not count.
    */
   boolean isAnswered();
 

--- a/server/app/services/applicant/question/QuestionImpl.java
+++ b/server/app/services/applicant/question/QuestionImpl.java
@@ -36,7 +36,7 @@ abstract class QuestionImpl implements Question {
 
   @Override
   public final ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> getValidationErrors() {
-    if (!isAnswered()) {
+    if (!isAnswered() && applicantQuestion.isOptional()) {
       return ImmutableMap.of();
     }
     // Why not just return the result of getValidationErrorsInternal()?

--- a/server/app/views/AwsFileUploadViewStrategy.java
+++ b/server/app/views/AwsFileUploadViewStrategy.java
@@ -87,6 +87,7 @@ public class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
         ApplicantQuestionRendererParams.builder()
             .setMessages(params.messages())
             .setSignedFileUploadRequest(signedRequest)
+            .setDisplayErrors(params.displayErrors())
             .build();
 
     Tag uploadForm =

--- a/server/app/views/AwsFileUploadViewStrategy.java
+++ b/server/app/views/AwsFileUploadViewStrategy.java
@@ -87,7 +87,7 @@ public class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
         ApplicantQuestionRendererParams.builder()
             .setMessages(params.messages())
             .setSignedFileUploadRequest(signedRequest)
-            .setDisplayErrors(params.displayErrors())
+            .setErrorDisplayMode(params.errorDisplayMode())
             .build();
 
     Tag uploadForm =

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -86,7 +86,7 @@ public class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
         ApplicantQuestionRendererParams.builder()
             .setMessages(params.messages())
             .setSignedFileUploadRequest(blobStorageUploadRequest)
-            .setDisplayErrors(params.displayErrors())
+            .setErrorDisplayMode(params.errorDisplayMode())
             .build();
 
     ContainerTag formTag =

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -86,6 +86,7 @@ public class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
         ApplicantQuestionRendererParams.builder()
             .setMessages(params.messages())
             .setSignedFileUploadRequest(blobStorageUploadRequest)
+            .setDisplayErrors(params.displayErrors())
             .build();
 
     ContainerTag formTag =

--- a/server/app/views/FileUploadViewStrategy.java
+++ b/server/app/views/FileUploadViewStrategy.java
@@ -115,7 +115,7 @@ public abstract class FileUploadViewStrategy {
     ApplicantQuestionRendererParams rendererParams =
         ApplicantQuestionRendererParams.builder()
             .setMessages(params.messages())
-            .setDisplayErrors(params.displayErrors())
+            .setErrorDisplayMode(params.errorDisplayMode())
             .build();
 
     Tag continueForm =

--- a/server/app/views/FileUploadViewStrategy.java
+++ b/server/app/views/FileUploadViewStrategy.java
@@ -113,7 +113,10 @@ public abstract class FileUploadViewStrategy {
                 params.applicantId(), params.programId(), params.block().getId(), params.inReview())
             .url();
     ApplicantQuestionRendererParams rendererParams =
-        ApplicantQuestionRendererParams.builder().setMessages(params.messages()).build();
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(params.messages())
+            .setDisplayErrors(params.displayErrors())
+            .build();
 
     Tag continueForm =
         form()

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -257,7 +257,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
       public abstract Builder setStorageClient(StorageClient storageClient);
 
       public abstract Builder setBaseUrl(String baseUrl);
-      
+
       public abstract Builder setErrorDisplayMode(
           ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode);
 

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -127,7 +127,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
     ApplicantQuestionRendererParams rendererParams =
         ApplicantQuestionRendererParams.builder()
             .setMessages(params.messages())
-            .setDisplayErrors(params.displayErrors())
+            .setErrorDisplayMode(params.errorDisplayMode())
             .build();
 
     return form()
@@ -228,7 +228,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
     public abstract String applicantName();
 
-    public abstract boolean displayErrors();
+    public abstract ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode();
 
     @AutoValue.Builder
     public abstract static class Builder {
@@ -258,7 +258,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
       public abstract Builder setApplicantName(String applicantName);
 
-      public abstract Builder setDisplayErrors(boolean displayErrors);
+      public abstract Builder setErrorDisplayMode(
+          ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode);
 
       public abstract Params build();
     }

--- a/server/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -125,7 +125,10 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
                 params.applicantId(), params.programId(), params.block().getId(), params.inReview())
             .url();
     ApplicantQuestionRendererParams rendererParams =
-        ApplicantQuestionRendererParams.builder().setMessages(params.messages()).build();
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(params.messages())
+            .setDisplayErrors(params.displayErrors())
+            .build();
 
     return form()
         .withId(BLOCK_FORM_ID)
@@ -225,6 +228,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
     public abstract String applicantName();
 
+    public abstract boolean displayErrors();
+
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder setRequest(Http.Request request);
@@ -252,6 +257,8 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
       public abstract Builder setBaseUrl(String baseUrl);
 
       public abstract Builder setApplicantName(String applicantName);
+
+      public abstract Builder setDisplayErrors(boolean displayErrors);
 
       public abstract Params build();
     }

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -28,12 +28,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
-
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        addressQuestion.getValidationErrors();
 
     Tag addressQuestionFormContent =
         div()

--- a/server/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/server/app/views/questiontypes/AddressQuestionRenderer.java
@@ -28,7 +28,9 @@ public class AddressQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     AddressQuestion addressQuestion = question.createAddressQuestion();
 

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -5,7 +5,6 @@ import static j2html.TagCreator.div;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import play.i18n.Messages;
@@ -36,7 +35,9 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
     return question.isOptional() ? "" : ReferenceClasses.REQUIRED_QUESTION;
   }
 
-  protected abstract Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
+  protected abstract Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors);
 
   @Override
   public final Tag render(ApplicantQuestionRendererParams params) {
@@ -58,11 +59,13 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
                     .with(TextFormatter.createLinksAndEscapeText(question.getQuestionHelpText())))
             .withClasses(Styles.MB_4);
 
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors = params.displayErrors() ?
-      question.errorsPresenter().getValidationErrors() : ImmutableMap.of();
+    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
+        params.displayErrors()
+            ? question.errorsPresenter().getValidationErrors()
+            : ImmutableMap.of();
 
-    ImmutableSet<ValidationErrorMessage> questionErrors = validationErrors.getOrDefault(
-      question.getContextualizedPath(), ImmutableSet.of());
+    ImmutableSet<ValidationErrorMessage> questionErrors =
+        validationErrors.getOrDefault(question.getContextualizedPath(), ImmutableSet.of());
     // TODO(#1944): Remove special handling for enumerators once client-side validation is removed
     // and they don't render a separate div.
     if (!questionErrors.isEmpty() && question.getType() != QuestionType.ENUMERATOR) {

--- a/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererImpl.java
@@ -59,10 +59,18 @@ abstract class ApplicantQuestionRendererImpl implements ApplicantQuestionRendere
                     .with(TextFormatter.createLinksAndEscapeText(question.getQuestionHelpText())))
             .withClasses(Styles.MB_4);
 
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        params.displayErrors()
-            ? question.errorsPresenter().getValidationErrors()
-            : ImmutableMap.of();
+    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors;
+    switch (params.errorDisplayMode()) {
+      case HIDE_ERRORS:
+        validationErrors = ImmutableMap.of();
+        break;
+      case DISPLAY_ERRORS:
+        validationErrors = question.errorsPresenter().getValidationErrors();
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unhandled error display mode: %s", params.errorDisplayMode()));
+    }
 
     ImmutableSet<ValidationErrorMessage> questionErrors =
         validationErrors.getOrDefault(question.getContextualizedPath(), ImmutableSet.of());

--- a/server/app/views/questiontypes/ApplicantQuestionRendererParams.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererParams.java
@@ -9,12 +9,30 @@ import services.cloud.StorageUploadRequest;
 @AutoValue
 public abstract class ApplicantQuestionRendererParams {
 
+  /** Indicates whether validation errors should be rendered when displaying the question. */
+  public enum ErrorDisplayMode {
+    /**
+     * Validation errors aren't displayed. Typically used when displaying the question to the
+     * applicant prior to an attempt to submit.
+     */
+    HIDE_ERRORS,
+    /**
+     * Validation errors are displayed. Typically used when displaying a question in response to the
+     * applicant attempting a submit.
+     */
+    DISPLAY_ERRORS
+  }
+
   public static Builder builder() {
     return new AutoValue_ApplicantQuestionRendererParams.Builder().setIsSample(false);
   }
 
   public static ApplicantQuestionRendererParams sample(Messages messages) {
-    return builder().setIsSample(true).setDisplayErrors(false).setMessages(messages).build();
+    return builder()
+        .setIsSample(true)
+        .setErrorDisplayMode(ErrorDisplayMode.HIDE_ERRORS)
+        .setMessages(messages)
+        .build();
   }
 
   public abstract boolean isSample();
@@ -23,7 +41,7 @@ public abstract class ApplicantQuestionRendererParams {
 
   public abstract Optional<StorageUploadRequest> signedFileUploadRequest();
 
-  public abstract boolean displayErrors();
+  public abstract ErrorDisplayMode errorDisplayMode();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -34,7 +52,7 @@ public abstract class ApplicantQuestionRendererParams {
     public abstract Builder setSignedFileUploadRequest(
         StorageUploadRequest signedFileUploadRequest);
 
-    public abstract Builder setDisplayErrors(boolean displayErrors);
+    public abstract Builder setErrorDisplayMode(ErrorDisplayMode errorDisplayMode);
 
     public abstract ApplicantQuestionRendererParams build();
   }

--- a/server/app/views/questiontypes/ApplicantQuestionRendererParams.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererParams.java
@@ -14,7 +14,7 @@ public abstract class ApplicantQuestionRendererParams {
   }
 
   public static ApplicantQuestionRendererParams sample(Messages messages) {
-    return builder().setIsSample(true).setMessages(messages).build();
+    return builder().setIsSample(true).setDisplayErrors(false).setMessages(messages).build();
   }
 
   public abstract boolean isSample();
@@ -22,6 +22,8 @@ public abstract class ApplicantQuestionRendererParams {
   public abstract Messages messages();
 
   public abstract Optional<StorageUploadRequest> signedFileUploadRequest();
+
+  public abstract boolean displayErrors();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -31,6 +33,8 @@ public abstract class ApplicantQuestionRendererParams {
 
     public abstract Builder setSignedFileUploadRequest(
         StorageUploadRequest signedFileUploadRequest);
+
+    public abstract Builder setDisplayErrors(boolean displayErrors);
 
     public abstract ApplicantQuestionRendererParams build();
   }

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -6,12 +6,10 @@ import static j2html.TagCreator.label;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
-import java.util.Comparator;
-
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Comparator;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
@@ -35,7 +33,9 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
     Tag checkboxQuestionFormContent =

--- a/server/app/views/questiontypes/CheckboxQuestionRenderer.java
+++ b/server/app/views/questiontypes/CheckboxQuestionRenderer.java
@@ -4,10 +4,16 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Comparator;
+
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
-import java.util.Comparator;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.MultiSelectQuestion;
 import services.question.LocalizedQuestionOption;
@@ -29,7 +35,7 @@ public class CheckboxQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     MultiSelectQuestion multiOptionQuestion = question.createMultiSelectQuestion();
 
     Tag checkboxQuestionFormContent =

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -26,7 +26,9 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 
     FieldWithLabel currencyField =

--- a/server/app/views/questiontypes/CurrencyQuestionRenderer.java
+++ b/server/app/views/questiontypes/CurrencyQuestionRenderer.java
@@ -2,9 +2,11 @@ package views.questiontypes;
 
 import static j2html.TagCreator.div;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import services.MessageKey;
+import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.CurrencyQuestion;
@@ -24,7 +26,7 @@ public class CurrencyQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     CurrencyQuestion currencyQuestion = question.createCurrencyQuestion();
 
     FieldWithLabel currencyField =

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -1,8 +1,12 @@
 package views.questiontypes;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.time.LocalDate;
 import java.util.Optional;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.DateQuestion;
 import views.components.FieldWithLabel;
@@ -21,7 +25,7 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =

--- a/server/app/views/questiontypes/DateQuestionRenderer.java
+++ b/server/app/views/questiontypes/DateQuestionRenderer.java
@@ -25,7 +25,9 @@ public class DateQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     DateQuestion dateQuestion = question.createDateQuestion();
 
     FieldWithLabel dateField =

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -3,10 +3,14 @@ package views.questiontypes;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static j2html.TagCreator.div;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.util.Comparator;
 import play.i18n.Messages;
 import services.MessageKey;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.SingleSelectQuestion;
 import services.question.LocalizedQuestionOption;
@@ -25,7 +29,7 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 

--- a/server/app/views/questiontypes/DropdownQuestionRenderer.java
+++ b/server/app/views/questiontypes/DropdownQuestionRenderer.java
@@ -29,7 +29,9 @@ public class DropdownQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     SingleSelectQuestion singleSelectQuestion = question.createSingleSelectQuestion();
 

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -23,11 +23,8 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
-
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        emailQuestion.getValidationErrors();
 
     Tag questionFormContent =
         FieldWithLabel.email()

--- a/server/app/views/questiontypes/EmailQuestionRenderer.java
+++ b/server/app/views/questiontypes/EmailQuestionRenderer.java
@@ -23,7 +23,9 @@ public class EmailQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     EmailQuestion emailQuestion = question.createEmailQuestion();
 
     Tag questionFormContent =

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -3,7 +3,9 @@ package views.questiontypes;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import j2html.TagCreator;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
@@ -13,6 +15,7 @@ import java.util.Optional;
 import play.i18n.Messages;
 import services.MessageKey;
 import services.Path;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.EnumeratorQuestion;
 import services.applicant.question.Scalar;
@@ -50,7 +53,7 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();

--- a/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
+++ b/server/app/views/questiontypes/EnumeratorQuestionRenderer.java
@@ -3,8 +3,8 @@ package views.questiontypes;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.TagCreator;
 import j2html.attributes.Attr;
@@ -53,7 +53,9 @@ public class EnumeratorQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     EnumeratorQuestion enumeratorQuestion = question.createEnumeratorQuestion();
     String localizedEntityType = enumeratorQuestion.getEntityType();

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -3,9 +3,13 @@ package views.questiontypes;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.FileUploadQuestion;
 import views.FileUploadViewStrategy;
@@ -45,7 +49,7 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     return fileUploadFields(params);
   }
 

--- a/server/app/views/questiontypes/FileUploadQuestionRenderer.java
+++ b/server/app/views/questiontypes/FileUploadQuestionRenderer.java
@@ -49,7 +49,9 @@ public class FileUploadQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     return fileUploadFields(params);
   }
 

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -22,7 +22,9 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     IdQuestion idQuestion = question.createIdQuestion();
 
     Tag questionFormContent =

--- a/server/app/views/questiontypes/IdQuestionRenderer.java
+++ b/server/app/views/questiontypes/IdQuestionRenderer.java
@@ -22,11 +22,8 @@ public class IdQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     IdQuestion idQuestion = question.createIdQuestion();
-
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        idQuestion.getValidationErrors();
 
     Tag questionFormContent =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -27,7 +27,9 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
 

--- a/server/app/views/questiontypes/NameQuestionRenderer.java
+++ b/server/app/views/questiontypes/NameQuestionRenderer.java
@@ -27,12 +27,9 @@ public class NameQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     Messages messages = params.messages();
     NameQuestion nameQuestion = question.createNameQuestion();
-
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        nameQuestion.getValidationErrors();
 
     Tag nameQuestionFormContent =
         div()

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -2,10 +2,12 @@ package views.questiontypes;
 
 import static j2html.TagCreator.div;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.Tag;
 import java.util.OptionalLong;
 import services.MessageKey;
+import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.NumberQuestion;
@@ -24,7 +26,7 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =

--- a/server/app/views/questiontypes/NumberQuestionRenderer.java
+++ b/server/app/views/questiontypes/NumberQuestionRenderer.java
@@ -26,7 +26,9 @@ public class NumberQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     NumberQuestion numberQuestion = question.createNumberQuestion();
 
     FieldWithLabel numberField =

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -4,10 +4,14 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.Comparator;
+import services.Path;
+import services.applicant.ValidationErrorMessage;
 import services.applicant.question.ApplicantQuestion;
 import services.applicant.question.SingleSelectQuestion;
 import services.question.LocalizedQuestionOption;
@@ -29,7 +33,7 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
     Tag radioQuestionFormContent =

--- a/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
+++ b/server/app/views/questiontypes/RadioButtonQuestionRenderer.java
@@ -33,7 +33,9 @@ public class RadioButtonQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     SingleSelectQuestion singleOptionQuestion = question.createSingleSelectQuestion();
 
     Tag radioQuestionFormContent =

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -22,11 +22,8 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params) {
+  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     TextQuestion textQuestion = question.createTextQuestion();
-
-    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
-        textQuestion.getValidationErrors();
 
     Tag questionFormContent =
         FieldWithLabel.input()

--- a/server/app/views/questiontypes/TextQuestionRenderer.java
+++ b/server/app/views/questiontypes/TextQuestionRenderer.java
@@ -22,7 +22,9 @@ public class TextQuestionRenderer extends ApplicantQuestionRendererImpl {
   }
 
   @Override
-  protected Tag renderTag(ApplicantQuestionRendererParams params, ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
+  protected Tag renderTag(
+      ApplicantQuestionRendererParams params,
+      ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors) {
     TextQuestion textQuestion = question.createTextQuestion();
 
     Tag questionFormContent =

--- a/server/test/services/applicant/ApplicantServiceImplTest.java
+++ b/server/test/services/applicant/ApplicantServiceImplTest.java
@@ -69,6 +69,13 @@ public class ApplicantServiceImplTest extends ResetPostgres {
   @Test
   public void stageAndUpdateIfValid_emptySetOfUpdates_leavesQuestionsUnansweredAndUpdatesMetadata()
       throws Exception {
+    // We make the question optional since it's not valid to stage empty updates
+    // for a required question.
+    programDefinition =
+        ProgramBuilder.newDraftProgram("test program", "desc")
+            .withBlock()
+            .withOptionalQuestion(questionDefinition)
+            .buildDefinition();
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
     subject
         .stageAndUpdateIfValid(applicant.id, programDefinition.id(), "1", ImmutableMap.of())
@@ -88,6 +95,13 @@ public class ApplicantServiceImplTest extends ResetPostgres {
 
   @Test
   public void stageAndUpdateIfValid_withUpdatesWithEmptyStrings_deletesJsonData() {
+    // We make the question optional since it's not valid to update a required
+    // question with an empty string (done below).
+    programDefinition =
+        ProgramBuilder.newDraftProgram("test program", "desc")
+            .withBlock()
+            .withOptionalQuestion(questionDefinition)
+            .buildDefinition();
     Applicant applicant = subject.createApplicant(1L).toCompletableFuture().join();
     Path questionPath = Path.create("applicant.name");
 

--- a/server/test/services/applicant/BlockTest.java
+++ b/server/test/services/applicant/BlockTest.java
@@ -179,8 +179,12 @@ public class BlockTest {
 
   @Test
   public void hasErrors_returnsFalseIfQuestionsHaveNoErrors() {
+    ApplicantData applicantData = new ApplicantData();
     BlockDefinition definition = setUpBlockWithQuestions();
-    Block block = new Block("1", definition, new ApplicantData(), Optional.empty());
+    // Both questions are required. Fill out an answer.
+    answerColorQuestion(applicantData, UNUSED_PROGRAM_ID);
+    answerNameQuestion(applicantData, UNUSED_PROGRAM_ID);
+    Block block = new Block("1", definition, applicantData, Optional.empty());
 
     assertThat(block.hasErrors()).isFalse();
   }

--- a/server/test/services/applicant/question/AddressQuestionTest.java
+++ b/server/test/services/applicant/question/AddressQuestionTest.java
@@ -18,6 +18,7 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.program.ProgramQuestionDefinition;
 import services.question.types.AddressQuestionDefinition;
 import support.QuestionAnswerer;
 
@@ -54,9 +55,13 @@ public class AddressQuestionTest {
   }
 
   @Test
-  public void withEmptyApplicantData() {
+  public void withEmptyApplicantData_optionalQuestion() {
     ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(addressQuestionDefinition, applicantData, Optional.empty());
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(addressQuestionDefinition, Optional.empty())
+                .setOptional(true),
+            applicantData,
+            Optional.empty());
 
     AddressQuestion addressQuestion = new AddressQuestion(applicantQuestion);
 

--- a/server/test/services/applicant/question/ApplicantQuestionTest.java
+++ b/server/test/services/applicant/question/ApplicantQuestionTest.java
@@ -68,7 +68,10 @@ public class ApplicantQuestionTest {
     QuestionDefinition definition =
         testQuestionBank.getSampleQuestionsForAllTypes().get(questionType).getQuestionDefinition();
     ApplicantQuestion question =
-        new ApplicantQuestion(definition, new ApplicantData(), Optional.empty());
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(definition, Optional.empty()).setOptional(true),
+            new ApplicantData(),
+            Optional.empty());
 
     assertThat(question.errorsPresenter().getValidationErrors().isEmpty()).isTrue();
   }

--- a/server/test/services/applicant/question/MultiSelectQuestionTest.java
+++ b/server/test/services/applicant/question/MultiSelectQuestionTest.java
@@ -15,6 +15,7 @@ import services.MessageKey;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ValidationErrorMessage;
+import services.program.ProgramQuestionDefinition;
 import services.question.QuestionOption;
 import services.question.types.CheckboxQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
@@ -48,13 +49,35 @@ public class MultiSelectQuestionTest {
   }
 
   @Test
-  public void withEmptyApplicantData() {
+  public void withEmptyApplicantData_optionalQuestion() {
     ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(CHECKBOX_QUESTION, applicantData, Optional.empty());
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(CHECKBOX_QUESTION, Optional.empty()).setOptional(true),
+            applicantData,
+            Optional.empty());
 
     MultiSelectQuestion multiSelectQuestion = new MultiSelectQuestion(applicantQuestion);
 
     assertThat(multiSelectQuestion.getValidationErrors().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void withEmptyApplicantData_requiredQuestion_failsValidation() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(CHECKBOX_QUESTION, Optional.empty()),
+            applicantData,
+            Optional.empty());
+
+    MultiSelectQuestion multiSelectQuestion = new MultiSelectQuestion(applicantQuestion);
+
+    ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> validationErrors =
+        multiSelectQuestion.getValidationErrors();
+    assertThat(validationErrors.size()).isEqualTo(1);
+    assertThat(
+            validationErrors.getOrDefault(
+                applicantQuestion.getContextualizedPath(), ImmutableSet.of()))
+        .containsOnly(ValidationErrorMessage.create(MessageKey.MULTI_SELECT_VALIDATION_TOO_FEW, 2));
   }
 
   @Test

--- a/server/test/services/applicant/question/NameQuestionTest.java
+++ b/server/test/services/applicant/question/NameQuestionTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
+import services.program.ProgramQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import support.QuestionAnswerer;
 
@@ -38,9 +39,13 @@ public class NameQuestionTest {
   }
 
   @Test
-  public void withEmptyApplicantData() {
+  public void withEmptyApplicantData_optionalQuestion() {
     ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(nameQuestionDefinition, applicantData, Optional.empty());
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(nameQuestionDefinition, Optional.empty())
+                .setOptional(true),
+            applicantData,
+            Optional.empty());
 
     NameQuestion nameQuestion = new NameQuestion(applicantQuestion);
 

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -214,9 +214,13 @@ public class ProgramBuilder {
     }
 
     public BlockBuilder withOptionalQuestion(Question question) {
+      return withOptionalQuestion(question.getQuestionDefinition());
+    }
+
+    public BlockBuilder withOptionalQuestion(QuestionDefinition question) {
       blockDefBuilder.addQuestion(
           ProgramQuestionDefinition.create(
-                  question.getQuestionDefinition(), Optional.of(programBuilder.programDefinitionId))
+                  question, Optional.of(programBuilder.programDefinitionId))
               .setOptional(true));
       return this;
     }
@@ -239,16 +243,10 @@ public class ProgramBuilder {
     }
 
     public BlockBuilder withRequiredQuestions(ImmutableList<Question> questions) {
-      ImmutableList<ProgramQuestionDefinition> pqds =
+      return withRequiredQuestionDefinitions(
           questions.stream()
               .map(Question::getQuestionDefinition)
-              .map(
-                  questionDefinition ->
-                      ProgramQuestionDefinition.create(
-                          questionDefinition, Optional.of(programBuilder.programDefinitionId)))
-              .collect(ImmutableList.toImmutableList());
-      blockDefBuilder.setProgramQuestionDefinitions(pqds);
-      return this;
+              .collect(ImmutableList.toImmutableList()));
     }
 
     public BlockBuilder withRequiredQuestionDefinitions(

--- a/server/test/views/questiontypes/ApplicantQuestionRendererParamsTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererParamsTest.java
@@ -24,7 +24,10 @@ public class ApplicantQuestionRendererParamsTest {
 
     Messages messages = stubMessagesApi().preferred(ImmutableSet.of(Lang.defaultLang()));
     ApplicantQuestionRendererParams params =
-        ApplicantQuestionRendererParams.builder().setMessages(messages).build();
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setDisplayErrors(false)
+            .build();
 
     assertThat(params.isSample()).isFalse();
   }

--- a/server/test/views/questiontypes/ApplicantQuestionRendererParamsTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererParamsTest.java
@@ -26,7 +26,7 @@ public class ApplicantQuestionRendererParamsTest {
     ApplicantQuestionRendererParams params =
         ApplicantQuestionRendererParams.builder()
             .setMessages(messages)
-            .setDisplayErrors(false)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.HIDE_ERRORS)
             .build();
 
     assertThat(params.isSample()).isFalse();

--- a/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -49,7 +49,10 @@ public class CheckboxQuestionRendererTest extends ResetPostgres {
   public void setup() {
     question = new ApplicantQuestion(CHECKBOX_QUESTION, applicantData, Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.sample(messages);
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setDisplayErrors(true)
+        .build();
     renderer = new CheckboxQuestionRenderer(question);
   }
 

--- a/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -52,7 +52,7 @@ public class CheckboxQuestionRendererTest extends ResetPostgres {
     params =
         ApplicantQuestionRendererParams.builder()
             .setMessages(messages)
-            .setDisplayErrors(true)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
             .build();
     renderer = new CheckboxQuestionRenderer(question);
   }

--- a/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
+++ b/server/test/views/questiontypes/CheckboxQuestionRendererTest.java
@@ -49,10 +49,11 @@ public class CheckboxQuestionRendererTest extends ResetPostgres {
   public void setup() {
     question = new ApplicantQuestion(CHECKBOX_QUESTION, applicantData, Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setDisplayErrors(true)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setDisplayErrors(true)
+            .build();
     renderer = new CheckboxQuestionRenderer(question);
   }
 

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -16,6 +16,7 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.program.ProgramQuestionDefinition;
 import services.question.types.IdQuestionDefinition;
 import services.question.types.IdQuestionDefinition.IdValidationPredicates;
 import support.QuestionAnswerer;
@@ -40,7 +41,12 @@ public class IdQuestionRendererTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    question = new ApplicantQuestion(ID_QUESTION_DEFINITION, applicantData, Optional.empty());
+    question =
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(ID_QUESTION_DEFINITION, Optional.empty())
+                .setOptional(true),
+            applicantData,
+            Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
     params = ApplicantQuestionRendererParams.sample(messages);
     renderer = new IdQuestionRenderer(question);

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -48,7 +48,10 @@ public class IdQuestionRendererTest extends ResetPostgres {
             applicantData,
             Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.sample(messages);
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setDisplayErrors(true)
+        .build();
     renderer = new IdQuestionRenderer(question);
   }
 

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -51,7 +51,7 @@ public class IdQuestionRendererTest extends ResetPostgres {
     params =
         ApplicantQuestionRendererParams.builder()
             .setMessages(messages)
-            .setDisplayErrors(true)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
             .build();
     renderer = new IdQuestionRenderer(question);
   }

--- a/server/test/views/questiontypes/IdQuestionRendererTest.java
+++ b/server/test/views/questiontypes/IdQuestionRendererTest.java
@@ -48,10 +48,11 @@ public class IdQuestionRendererTest extends ResetPostgres {
             applicantData,
             Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setDisplayErrors(true)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setDisplayErrors(true)
+            .build();
     renderer = new IdQuestionRenderer(question);
   }
 

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -51,7 +51,7 @@ public class TextQuestionRendererTest extends ResetPostgres {
     params =
         ApplicantQuestionRendererParams.builder()
             .setMessages(messages)
-            .setDisplayErrors(true)
+            .setErrorDisplayMode(ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS)
             .build();
     renderer = new TextQuestionRenderer(question);
   }

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -48,7 +48,10 @@ public class TextQuestionRendererTest extends ResetPostgres {
             applicantData,
             Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.sample(messages);
+    params = ApplicantQuestionRendererParams.builder()
+        .setMessages(messages)
+        .setDisplayErrors(true)
+        .build();
     renderer = new TextQuestionRenderer(question);
   }
 

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -16,6 +16,7 @@ import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
+import services.program.ProgramQuestionDefinition;
 import services.question.types.TextQuestionDefinition;
 import services.question.types.TextQuestionDefinition.TextValidationPredicates;
 import support.QuestionAnswerer;
@@ -40,7 +41,12 @@ public class TextQuestionRendererTest extends ResetPostgres {
 
   @Before
   public void setUp() {
-    question = new ApplicantQuestion(TEXT_QUESTION_DEFINITION, applicantData, Optional.empty());
+    question =
+        new ApplicantQuestion(
+            ProgramQuestionDefinition.create(TEXT_QUESTION_DEFINITION, Optional.empty())
+                .setOptional(true),
+            applicantData,
+            Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
     params = ApplicantQuestionRendererParams.sample(messages);
     renderer = new TextQuestionRenderer(question);

--- a/server/test/views/questiontypes/TextQuestionRendererTest.java
+++ b/server/test/views/questiontypes/TextQuestionRendererTest.java
@@ -48,10 +48,11 @@ public class TextQuestionRendererTest extends ResetPostgres {
             applicantData,
             Optional.empty());
     messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
-    params = ApplicantQuestionRendererParams.builder()
-        .setMessages(messages)
-        .setDisplayErrors(true)
-        .build();
+    params =
+        ApplicantQuestionRendererParams.builder()
+            .setMessages(messages)
+            .setDisplayErrors(true)
+            .build();
     renderer = new TextQuestionRenderer(question);
   }
 


### PR DESCRIPTION
### Description
Previously, each question's validation only depended on whether the question was answered or not. This meant that calling getValidationErrors on a required, unanswered question would return success. Moving into QuestionImpl consolidates validation requirements.

With this change, rendering an edit block for the first time would have shown many validation errors for required fields. The question should always fail validation when required inputs aren't present, but likely shouldn't display until the applicant has attempted to submit. For this, I plumbed a parameter through indicating whether question validation errors. Rather than making each question renderer responsible for checking this, `ApplicantQuestionRendererImpl.render` passes validation errors to `renderTag` only if the parameter is set.

This is part of a larger sequence to remove client-side validation in #1944.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1944 
