### PR TITLE
Refactored ProfileAdapter 3 way merge logic into separate class

### DIFF
--- a/server/app/auth/CiviFormProfileAdapterHelper.java
+++ b/server/app/auth/CiviFormProfileAdapterHelper.java
@@ -10,6 +10,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
+/**
+ * This class serves to abstract out common application logic in ProfileAdapters into shared helper
+ * methods.
+ */
 public class CiviFormProfileAdapterHelper {
 
   private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileAdapterHelper.class);
@@ -17,23 +21,25 @@ public class CiviFormProfileAdapterHelper {
   private final ProfileFactory profileFactory;
   private final Provider<UserRepository> applicantRepositoryProvider;
 
-  public CiviFormProfileAdapterHelper(ProfileFactory profileFactory,
-      Provider<UserRepository> applicantRepositoryProvider) {
+  public CiviFormProfileAdapterHelper(
+      ProfileFactory profileFactory, Provider<UserRepository> applicantRepositoryProvider) {
     this.profileFactory = profileFactory;
     this.applicantRepositoryProvider = applicantRepositoryProvider;
   }
 
   /**
-   * Now we have a three-way merge situation.
+   * This method handles a three way merge between an existing applicant, an existing guest profile,
+   * and an external profile
    *
    * @param existingApplicant a potentially existing applicant in the database
    * @param existingProfile a guest profile in the browser cookie
    * @param externalProfile an OIDC account in the callback from the OIDC server
-   * <p>We will merge 1 and 2, if present, into `existingProfile`, then merge in `externalProfile`.
    * @param mergeFunction a function that merges an external profile into a Civiform profile
    */
-  public <T> Optional<UserProfile> threeWayMerge(Optional<Applicant> existingApplicant,
-      Optional<CiviFormProfile> existingProfile, T externalProfile,
+  public <T> Optional<UserProfile> threeWayMerge(
+      Optional<Applicant> existingApplicant,
+      Optional<CiviFormProfile> existingProfile,
+      T externalProfile,
       BiFunction<CiviFormProfile, T, UserProfile> mergeFunction) {
 
     if (existingApplicant.isPresent()) {
@@ -48,19 +54,27 @@ public class CiviFormProfileAdapterHelper {
     }
 
     // Now merge in the information sent to us by the OIDC server.
-    return Optional.of(mergeFunction.apply(existingProfile.orElseGet(() -> {
-      logger.debug("Found no existing profile in session cookie.");
-      return profileFactory.wrapProfileData(profileFactory.createNewApplicant());
-    }), externalProfile));
+    return Optional.of(
+        mergeFunction.apply(
+            existingProfile.orElseGet(
+                () -> {
+                  logger.debug("Found no existing profile in session cookie.");
+                  return profileFactory.wrapProfileData(profileFactory.createNewApplicant());
+                }),
+            externalProfile));
   }
 
-  private Optional<CiviFormProfile> twoWayMerge(CiviFormProfile existingProfile, Applicant existingApplicant) {
+  private Optional<CiviFormProfile> twoWayMerge(
+      CiviFormProfile existingProfile, Applicant existingApplicant) {
     // For account, use the existing account and ignore the guest account.
     Applicant guestApplicant = existingProfile.getApplicant().join();
     Account existingAccount = existingApplicant.getAccount();
-    Applicant mergedApplicant = applicantRepositoryProvider.get()
-        .mergeApplicants(guestApplicant, existingApplicant, existingAccount)
-        .toCompletableFuture().join();
+    Applicant mergedApplicant =
+        applicantRepositoryProvider
+            .get()
+            .mergeApplicants(guestApplicant, existingApplicant, existingAccount)
+            .toCompletableFuture()
+            .join();
     return Optional.of(profileFactory.wrap(mergedApplicant));
   }
 }

--- a/server/app/auth/CiviFormProfileAdapterHelper.java
+++ b/server/app/auth/CiviFormProfileAdapterHelper.java
@@ -1,0 +1,66 @@
+package auth;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import javax.inject.Provider;
+import models.Account;
+import models.Applicant;
+import org.pac4j.core.profile.UserProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import repository.UserRepository;
+
+public class CiviFormProfileAdapterHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileAdapterHelper.class);
+
+  private final ProfileFactory profileFactory;
+  private final Provider<UserRepository> applicantRepositoryProvider;
+
+  public CiviFormProfileAdapterHelper(ProfileFactory profileFactory,
+      Provider<UserRepository> applicantRepositoryProvider) {
+    this.profileFactory = profileFactory;
+    this.applicantRepositoryProvider = applicantRepositoryProvider;
+  }
+
+  /**
+   * Now we have a three-way merge situation.
+   *
+   * @param existingApplicant a potentially existing applicant in the database
+   * @param existingProfile a guest profile in the browser cookie
+   * @param externalProfile an OIDC account in the callback from the OIDC server
+   * <p>We will merge 1 and 2, if present, into `existingProfile`, then merge in `externalProfile`.
+   * @param mergeFunction a function that merges an external profile into a Civiform profile
+   */
+  public <T> Optional<UserProfile> threeWayMerge(Optional<Applicant> existingApplicant,
+      Optional<CiviFormProfile> existingProfile, T externalProfile,
+      BiFunction<CiviFormProfile, T, UserProfile> mergeFunction) {
+
+    if (existingApplicant.isPresent()) {
+      if (existingProfile.isEmpty()) {
+        // Easy merge case - we have an existing applicant, but no guest profile.
+        // This will be the most common.
+        existingProfile = Optional.of(profileFactory.wrap(existingApplicant.get()));
+      } else {
+        // Merge the two applicants and prefer the newer one.
+        existingProfile = twoWayMerge(existingProfile.get(), existingApplicant.get());
+      }
+    }
+
+    // Now merge in the information sent to us by the OIDC server.
+    return Optional.of(mergeFunction.apply(existingProfile.orElseGet(() -> {
+      logger.debug("Found no existing profile in session cookie.");
+      return profileFactory.wrapProfileData(profileFactory.createNewApplicant());
+    }), externalProfile));
+  }
+
+  private Optional<CiviFormProfile> twoWayMerge(CiviFormProfile existingProfile, Applicant existingApplicant) {
+    // For account, use the existing account and ignore the guest account.
+    Applicant guestApplicant = existingProfile.getApplicant().join();
+    Account existingAccount = existingApplicant.getAccount();
+    Applicant mergedApplicant = applicantRepositoryProvider.get()
+        .mergeApplicants(guestApplicant, existingApplicant, existingAccount)
+        .toCompletableFuture().join();
+    return Optional.of(profileFactory.wrap(mergedApplicant));
+  }
+}

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -14,14 +14,14 @@ import repository.UserRepository;
  * This class serves to abstract out common application logic in ProfileAdapters into shared helper
  * methods.
  */
-public class CiviFormProfileAdapterHelper {
+public class CiviFormProfileMerger {
 
-  private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileAdapterHelper.class);
+  private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileMerger.class);
 
   private final ProfileFactory profileFactory;
   private final Provider<UserRepository> applicantRepositoryProvider;
 
-  public CiviFormProfileAdapterHelper(
+  public CiviFormProfileMerger(
       ProfileFactory profileFactory, Provider<UserRepository> applicantRepositoryProvider) {
     this.profileFactory = profileFactory;
     this.applicantRepositoryProvider = applicantRepositoryProvider;

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -8,7 +8,7 @@ import models.Applicant;
 import org.pac4j.core.profile.UserProfile;
 import repository.UserRepository;
 
-/** This class serves to abstract out common user profile merging logic into a shared helper. */
+/** Helper class for common {@code UserProfile} merging logic. */
 public class CiviFormProfileMerger {
 
   private final ProfileFactory profileFactory;
@@ -21,49 +21,49 @@ public class CiviFormProfileMerger {
   }
 
   /**
-   * This method handles a three way merge between an existing applicant, an existing guest profile,
-   * and an external profile
+   * Performs a three way merge between an existing applicant in the database, a guest profile in
+   * session storage, and an external profile from an external authentication provider
    *
    * @param applicantInDatabase a potentially existing applicant in the database
-   * @param sessionProfile a guest profile from the browser session
+   * @param guestProfile a guest profile from the browser session
    * @param authProviderProfile profile data from an external auth provider, such as OIDC
    * @param mergeFunction a function that merges an external profile into a Civiform profile, or
    *     provides one if it doesn't exist
    */
-  public <T> Optional<UserProfile> threeWayMerge(
+  public <T> Optional<UserProfile> mergeProfiles(
       Optional<Applicant> applicantInDatabase,
-      Optional<CiviFormProfile> sessionProfile,
+      Optional<CiviFormProfile> guestProfile,
       T authProviderProfile,
       BiFunction<Optional<CiviFormProfile>, T, UserProfile> mergeFunction) {
 
     if (applicantInDatabase.isPresent()) {
-      if (sessionProfile.isEmpty()) {
+      if (guestProfile.isEmpty()) {
         // Easy merge case - we have an existing applicant, but no guest profile.
         // This will be the most common.
-        sessionProfile = Optional.of(profileFactory.wrap(applicantInDatabase.get()));
+        guestProfile = Optional.of(profileFactory.wrap(applicantInDatabase.get()));
       } else {
         // Merge the two applicants and prefer the newer one.
-        sessionProfile = twoWayMerge(sessionProfile.get(), applicantInDatabase.get());
+        guestProfile = Optional.of(mergeProfiles(applicantInDatabase.get(), guestProfile.get()));
       }
     }
 
-    // Merge externalProfile into existingProfile
+    // Merge externalProfile into existingProfile.
     // Merge function will create a new CiviFormProfile if it doesn't exist,
-    // or otherwise handle it in some way
-    return Optional.of(mergeFunction.apply(sessionProfile, authProviderProfile));
+    // or otherwise handle it
+    return Optional.of(mergeFunction.apply(guestProfile, authProviderProfile));
   }
 
-  private Optional<CiviFormProfile> twoWayMerge(
-      CiviFormProfile existingProfile, Applicant existingApplicant) {
-    // For account, use the existing account and ignore the guest account.
-    Applicant guestApplicant = existingProfile.getApplicant().join();
-    Account existingAccount = existingApplicant.getAccount();
+  private CiviFormProfile mergeProfiles(
+      Applicant applicantInDatabase, CiviFormProfile sessionGuestProfile) {
+    // Merge guest applicant data into already existing account in database
+    Applicant guestApplicant = sessionGuestProfile.getApplicant().join();
+    Account existingAccount = applicantInDatabase.getAccount();
     Applicant mergedApplicant =
         applicantRepositoryProvider
             .get()
-            .mergeApplicants(guestApplicant, existingApplicant, existingAccount)
+            .mergeApplicants(guestApplicant, applicantInDatabase, existingAccount)
             .toCompletableFuture()
             .join();
-    return Optional.of(profileFactory.wrap(mergedApplicant));
+    return profileFactory.wrap(mergedApplicant);
   }
 }

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -10,9 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
-/**
- * This class serves to abstract out common user profile merging logic into a shared helper.
- */
+/** This class serves to abstract out common user profile merging logic into a shared helper. */
 public class CiviFormProfileMerger {
 
   private static final Logger logger = LoggerFactory.getLogger(CiviFormProfileMerger.class);

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -11,8 +11,7 @@ import org.slf4j.LoggerFactory;
 import repository.UserRepository;
 
 /**
- * This class serves to abstract out common application logic in ProfileAdapters into shared helper
- * methods.
+ * This class serves to abstract out common user profile merging logic into a shared helper.
  */
 public class CiviFormProfileMerger {
 

--- a/server/app/auth/oidc/AdfsProfileAdapter.java
+++ b/server/app/auth/oidc/AdfsProfileAdapter.java
@@ -1,7 +1,6 @@
 package auth.oidc;
 
 import auth.CiviFormProfile;
-import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.Roles;
 import com.google.common.collect.ImmutableSet;
@@ -80,13 +79,11 @@ public class AdfsProfileAdapter extends OidcCiviFormProfileAdapter {
   }
 
   @Override
-  public CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile profile) {
+  public CiviFormProfile createEmptyCiviFormProfile(OidcProfile profile) {
     if (this.isGlobalAdmin(profile)) {
-      return mergeCiviFormProfile(
-          profileFactory.wrapProfileData(profileFactory.createNewAdmin()), profile);
+      return profileFactory.wrapProfileData(profileFactory.createNewAdmin());
     }
-    return mergeCiviFormProfile(
-        profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin()), profile);
+    return profileFactory.wrapProfileData(profileFactory.createNewProgramAdmin());
   }
 
   @Override

--- a/server/app/auth/oidc/IdcsProfileAdapter.java
+++ b/server/app/auth/oidc/IdcsProfileAdapter.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Provider;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.oidc.client.OidcClient;
@@ -61,14 +60,8 @@ public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
   }
 
   @Override
-  public CiviFormProfileData mergeCiviFormProfile(
-      Optional<CiviFormProfile> maybeCiviformProfile, OidcProfile oidcProfile) {
-    var civiformProfile =
-        maybeCiviformProfile.orElseGet(
-            () -> {
-              logger.debug("Found no existing profile in session cookie.");
-              return this.createEmptyCiviFormProfile(oidcProfile);
-            });
+  protected CiviFormProfileData mergeCiviFormProfile(
+      CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
     final String locale = oidcProfile.getAttribute("user_locale", String.class);
     final boolean hasLocale = locale != null && !locale.isEmpty();
     final String displayName = oidcProfile.getAttribute("user_displayname", String.class);
@@ -90,8 +83,7 @@ public class IdcsProfileAdapter extends OidcCiviFormProfileAdapter {
           .toCompletableFuture()
           .join();
     }
-
-    return super.mergeCiviFormProfile(Optional.of(civiformProfile), oidcProfile);
+    return super.mergeCiviFormProfile(civiformProfile, oidcProfile);
   }
 
   @Override

--- a/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -1,7 +1,7 @@
 package auth.oidc;
 
 import auth.CiviFormProfile;
-import auth.CiviFormProfileAdapterHelper;
+import auth.CiviFormProfileMerger;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
@@ -37,7 +37,7 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
   private static final Logger logger = LoggerFactory.getLogger(OidcCiviFormProfileAdapter.class);
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
-  protected final CiviFormProfileAdapterHelper civiFormProfileAdapterHelper;
+  protected final CiviFormProfileMerger civiFormProfileMerger;
 
   public OidcCiviFormProfileAdapter(
       OidcConfiguration configuration,
@@ -47,8 +47,8 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     super(configuration, client);
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
     this.applicantRepositoryProvider = applicantRepositoryProvider;
-    this.civiFormProfileAdapterHelper =
-        new CiviFormProfileAdapterHelper(profileFactory, applicantRepositoryProvider);
+    this.civiFormProfileMerger =
+        new CiviFormProfileMerger(profileFactory, applicantRepositoryProvider);
   }
 
   protected abstract String emailAttributeName();
@@ -127,7 +127,7 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     OidcProfile profile = (OidcProfile) oidcProfile.get();
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
-    return civiFormProfileAdapterHelper.threeWayMerge(
+    return civiFormProfileMerger.threeWayMerge(
         existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
   }
 

--- a/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -47,8 +47,8 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     super(configuration, client);
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
     this.applicantRepositoryProvider = applicantRepositoryProvider;
-    this.civiFormProfileAdapterHelper = new CiviFormProfileAdapterHelper(profileFactory,
-        applicantRepositoryProvider);
+    this.civiFormProfileAdapterHelper =
+        new CiviFormProfileAdapterHelper(profileFactory, applicantRepositoryProvider);
   }
 
   protected abstract String emailAttributeName();
@@ -127,8 +127,8 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
     OidcProfile profile = (OidcProfile) oidcProfile.get();
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
-    return civiFormProfileAdapterHelper.threeWayMerge(existingApplicant, existingProfile, profile,
-        this::mergeCiviFormProfile);
+    return civiFormProfileAdapterHelper.threeWayMerge(
+        existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
   }
 
   @VisibleForTesting

--- a/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -77,7 +77,13 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
 
   /** Merge the two provided profiles into a new CiviFormProfileData. */
   public CiviFormProfileData mergeCiviFormProfile(
-      CiviFormProfile civiformProfile, OidcProfile oidcProfile) {
+      Optional<CiviFormProfile> maybeCiviformProfile, OidcProfile oidcProfile) {
+    var civiformProfile =
+        maybeCiviformProfile.orElseGet(
+            () -> {
+              logger.debug("Found no existing profile in session cookie.");
+              return this.createEmptyCiviFormProfile(oidcProfile);
+            });
     String emailAddress =
         Optional.ofNullable(oidcProfile.getAttribute(emailAttributeName(), String.class))
             .orElseThrow(
@@ -101,7 +107,7 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
   }
 
   /** Create a totally new CiviForm profile from the provided OidcProfile. */
-  public abstract CiviFormProfileData civiformProfileFromOidcProfile(OidcProfile oidcProfile);
+  public abstract CiviFormProfile createEmptyCiviFormProfile(OidcProfile profile);
 
   @Override
   public Optional<UserProfile> create(

--- a/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -1,8 +1,8 @@
 package auth.oidc;
 
 import auth.CiviFormProfile;
-import auth.CiviFormProfileMerger;
 import auth.CiviFormProfileData;
+import auth.CiviFormProfileMerger;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
 import auth.Roles;

--- a/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
+++ b/server/app/auth/oidc/OidcCiviFormProfileAdapter.java
@@ -79,10 +79,11 @@ public abstract class OidcCiviFormProfileAdapter extends OidcProfileCreator {
    * Merge the two provided profiles into a new CiviformProfileData, making sure to create a new
    * civiFormProfile if it doesn't already exist.
    */
+  @VisibleForTesting
   public CiviFormProfileData mergeCiviFormProfile(
-      Optional<CiviFormProfile> maybeCiviformProfile, OidcProfile oidcProfile) {
+      Optional<CiviFormProfile> maybeCiviFormProfile, OidcProfile oidcProfile) {
     var civiformProfile =
-        maybeCiviformProfile.orElseGet(
+        maybeCiviFormProfile.orElseGet(
             () -> {
               logger.debug("Found no existing profile in session cookie.");
               return createEmptyCiviFormProfile(oidcProfile);

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -1,8 +1,8 @@
 package auth.saml;
 
 import auth.CiviFormProfile;
-import auth.CiviFormProfileMerger;
 import auth.CiviFormProfileData;
+import auth.CiviFormProfileMerger;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
 import auth.Roles;

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -110,13 +110,18 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     return Optional.of(String.format("Issuer: %s NameID: %s", issuer, subject));
   }
 
-  public CiviFormProfileData civiformProfileFromSamlProfile(SAML2Profile profile) {
-    return mergeCiviFormProfile(
-        profileFactory.wrapProfileData(profileFactory.createNewApplicant()), profile);
+  public CiviFormProfile createEmptyCiviformProfile() {
+    return profileFactory.wrapProfileData(profileFactory.createNewApplicant());
   }
 
   public CiviFormProfileData mergeCiviFormProfile(
-      CiviFormProfile civiFormProfile, SAML2Profile saml2Profile) {
+      Optional<CiviFormProfile> maybeCiviFormProfile, SAML2Profile saml2Profile) {
+    var civiFormProfile =
+        maybeCiviFormProfile.orElseGet(
+            () -> {
+              logger.debug("Found no existing profile in session cookie.");
+              return createEmptyCiviformProfile();
+            });
     String authorityId =
         getAuthorityId(saml2Profile)
             .orElseThrow(

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -114,6 +114,7 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     return profileFactory.wrapProfileData(profileFactory.createNewApplicant());
   }
 
+  @VisibleForTesting
   public CiviFormProfileData mergeCiviFormProfile(
       Optional<CiviFormProfile> maybeCiviFormProfile, SAML2Profile saml2Profile) {
     var civiFormProfile =

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -1,7 +1,7 @@
 package auth.saml;
 
 import auth.CiviFormProfile;
-import auth.CiviFormProfileAdapterHelper;
+import auth.CiviFormProfileMerger;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
@@ -32,7 +32,7 @@ import repository.UserRepository;
 public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
 
   private static final Logger logger = LoggerFactory.getLogger(SamlCiviFormProfileAdapter.class);
-  protected final CiviFormProfileAdapterHelper civiFormProfileAdapterHelper;
+  protected final CiviFormProfileMerger civiFormProfileMerger;
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
   protected final SAML2Configuration saml2Configuration;
@@ -46,8 +46,8 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     super();
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
     this.applicantRepositoryProvider = Preconditions.checkNotNull(applicantRepositoryProvider);
-    this.civiFormProfileAdapterHelper =
-        new CiviFormProfileAdapterHelper(profileFactory, applicantRepositoryProvider);
+    this.civiFormProfileMerger =
+        new CiviFormProfileMerger(profileFactory, applicantRepositoryProvider);
     this.saml2Client = client;
     this.saml2Configuration = configuration;
   }
@@ -74,7 +74,7 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     SAML2Profile profile = (SAML2Profile) samlProfile.get();
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
-    return this.civiFormProfileAdapterHelper.threeWayMerge(
+    return this.civiFormProfileMerger.threeWayMerge(
         existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
   }
 

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -46,8 +46,8 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     super();
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
     this.applicantRepositoryProvider = Preconditions.checkNotNull(applicantRepositoryProvider);
-    this.civiFormProfileAdapterHelper = new CiviFormProfileAdapterHelper(profileFactory,
-        applicantRepositoryProvider);
+    this.civiFormProfileAdapterHelper =
+        new CiviFormProfileAdapterHelper(profileFactory, applicantRepositoryProvider);
     this.saml2Client = client;
     this.saml2Configuration = configuration;
   }
@@ -74,7 +74,8 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     SAML2Profile profile = (SAML2Profile) samlProfile.get();
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
-    return this.civiFormProfileAdapterHelper.threeWayMerge(existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
+    return this.civiFormProfileAdapterHelper.threeWayMerge(
+        existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
   }
 
   @VisibleForTesting

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -74,7 +74,7 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     SAML2Profile profile = (SAML2Profile) samlProfile.get();
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
     Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
-    return this.civiFormProfileMerger.threeWayMerge(
+    return civiFormProfileMerger.mergeProfiles(
         existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
   }
 

--- a/server/app/auth/saml/SamlCiviFormProfileAdapter.java
+++ b/server/app/auth/saml/SamlCiviFormProfileAdapter.java
@@ -1,6 +1,7 @@
 package auth.saml;
 
 import auth.CiviFormProfile;
+import auth.CiviFormProfileAdapterHelper;
 import auth.CiviFormProfileData;
 import auth.ProfileFactory;
 import auth.ProfileUtils;
@@ -14,7 +15,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.StringJoiner;
 import javax.inject.Provider;
-import models.Account;
 import models.Applicant;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
@@ -32,6 +32,7 @@ import repository.UserRepository;
 public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
 
   private static final Logger logger = LoggerFactory.getLogger(SamlCiviFormProfileAdapter.class);
+  protected final CiviFormProfileAdapterHelper civiFormProfileAdapterHelper;
   protected final ProfileFactory profileFactory;
   protected final Provider<UserRepository> applicantRepositoryProvider;
   protected final SAML2Configuration saml2Configuration;
@@ -45,6 +46,8 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     super();
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
     this.applicantRepositoryProvider = Preconditions.checkNotNull(applicantRepositoryProvider);
+    this.civiFormProfileAdapterHelper = new CiviFormProfileAdapterHelper(profileFactory,
+        applicantRepositoryProvider);
     this.saml2Client = client;
     this.saml2Configuration = configuration;
   }
@@ -69,43 +72,9 @@ public class SamlCiviFormProfileAdapter extends AuthenticatorProfileCreator {
     }
 
     SAML2Profile profile = (SAML2Profile) samlProfile.get();
-
-    // Check if we already have a profile in the database for the user returned to us by SAML2.
     Optional<Applicant> existingApplicant = getExistingApplicant(profile);
-
-    // Now we have a three-way merge situation.  We might have
-    // 1) an applicant in the database (`existingApplicant`),
-    // 2) a guest profile in the browser cookie (`existingProfile`)
-    // 3) a SAML2Profile in the callback from the Identity Provider (`profile`).
-    // We will merge 1 and 2, if present, into `existingProfile`, then merge in `profile`.
-
     Optional<CiviFormProfile> existingProfile = profileUtils.currentUserProfile(context);
-    if (existingApplicant.isPresent()) {
-      if (existingProfile.isEmpty()) {
-        // Easy merge case - we have an existing applicant, but no guest profile.
-        // This will be the most common.
-        existingProfile = Optional.of(profileFactory.wrap(existingApplicant.get()));
-      } else {
-        // Merge the two applicants and prefer the newer one.
-        // For account, use the existing account and ignore the guest account.
-        Applicant guestApplicant = existingProfile.get().getApplicant().join();
-        Account existingAccount = existingApplicant.get().getAccount();
-        Applicant mergedApplicant =
-            applicantRepositoryProvider
-                .get()
-                .mergeApplicants(guestApplicant, existingApplicant.get(), existingAccount)
-                .toCompletableFuture()
-                .join();
-        existingProfile = Optional.of(profileFactory.wrap(mergedApplicant));
-      }
-    }
-
-    // Now merge in the information sent to us by the SAML Identity Provider.
-    if (existingProfile.isEmpty()) {
-      logger.debug("Found no existing profile in session cookie.");
-      return Optional.of(civiformProfileFromSamlProfile(profile));
-    }
-    return Optional.of(mergeCiviFormProfile(existingProfile.get(), profile));
+    return this.civiFormProfileAdapterHelper.threeWayMerge(existingApplicant, existingProfile, profile, this::mergeCiviFormProfile);
   }
 
   @VisibleForTesting

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -59,11 +59,11 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   }
 
   @Test
-  public void threeWayMerge_succeeds_noExistingApplicantAndNoExistingProfile() {
+  public void mergeProfiles_succeeds_noExistingApplicantAndNoExistingProfile() {
     var merged =
-        civiFormProfileMerger.threeWayMerge(
-            Optional.empty(),
-            Optional.empty(),
+        civiFormProfileMerger.mergeProfiles(
+            /* applicantInDatabase= */ Optional.empty(),
+            /* guestProfile= */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               assertThat(civiFormProfile).isEmpty();
@@ -74,11 +74,11 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   }
 
   @Test
-  public void threeWayMerge_succeeds_noExistingProfile() {
+  public void mergeProfiles_succeeds_noExistingProfile() {
     var merged =
-        civiFormProfileMerger.threeWayMerge(
-            Optional.of(applicant),
-            Optional.empty(),
+        civiFormProfileMerger.mergeProfiles(
+            /* applicantInDatabase= */ Optional.of(applicant),
+            /* guestProfile= */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
@@ -90,11 +90,11 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   }
 
   @Test
-  public void threeWayMerge_succeeds_noExistingApplicant() {
+  public void mergeProfiles_succeeds_noExistingApplicant() {
     var merged =
-        civiFormProfileMerger.threeWayMerge(
+        civiFormProfileMerger.mergeProfiles(
             Optional.empty(),
-            Optional.of(profileFactory.wrapProfileData(civiFormProfileData)),
+            /* guestProfile= */ Optional.of(profileFactory.wrapProfileData(civiFormProfileData)),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
@@ -106,7 +106,7 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   }
 
   @Test
-  public void threeWayMerge_succeeds_afterTwoWayMerge() {
+  public void mergeProfiles_succeeds_afterTwoWayMerge() {
     var existingProfile = spy(profileFactory.wrapProfileData(civiFormProfileData));
     doReturn(completedFuture(account)).when(existingProfile).getAccount();
 
@@ -118,7 +118,7 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
         .mergeApplicants(applicant, applicant, account);
 
     var merged =
-        civiFormProfileMerger.threeWayMerge(
+        civiFormProfileMerger.mergeProfiles(
             Optional.of(applicant),
             Optional.of(existingProfile),
             oidcProfile,

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -2,10 +2,10 @@ package auth;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -13,23 +13,27 @@ import models.Account;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.oidc.profile.OidcProfile;
-import repository.ResetPostgres;
 import repository.UserRepository;
 
-public class CiviFormProfileMergerTest extends ResetPostgres {
+@RunWith(MockitoJUnitRunner.class)
+public class CiviFormProfileMergerTest {
 
   private static final String EMAIL_ATTR = "user_emailid";
   private static final String EMAIL1 = "foo@bar.com";
   private static final String EMAIL2 = "bar@foo.com";
   private static final Long ACCOUNT_ID = 12345L;
-  private static final UserProfile USER_PROFILE = new CommonProfile();
 
-  private UserRepository repository;
-  private ProfileFactory profileFactory;
+  @Mock private UserRepository repository;
+  @Mock private ProfileFactory profileFactory;
+  @Mock private CiviFormProfile civiFormProfile;
 
+  private UserProfile userProfile;
   private OidcProfile oidcProfile;
   private CiviFormProfileData civiFormProfileData;
   private Applicant applicant;
@@ -39,9 +43,9 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
 
   @Before
   public void setup() {
-    profileFactory = spy(instanceOf(ProfileFactory.class));
-    repository = spy(instanceOf(UserRepository.class));
     civiFormProfileMerger = new CiviFormProfileMerger(profileFactory, () -> repository);
+
+    userProfile = new CommonProfile();
 
     oidcProfile = new OidcProfile();
     oidcProfile.addAttribute(EMAIL_ATTR, EMAIL1);
@@ -53,9 +57,15 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
     account = new Account();
     account.id = ACCOUNT_ID;
 
-    applicant = spy(new Applicant());
+    applicant = new Applicant();
     applicant.setAccount(account);
     account.setApplicants(Collections.singletonList(applicant));
+
+    when(civiFormProfile.getProfileData()).thenReturn(civiFormProfileData);
+    when(profileFactory.wrap(any(Applicant.class))).thenReturn(civiFormProfile);
+    when(civiFormProfile.getApplicant()).thenReturn(completedFuture(applicant));
+    when(repository.mergeApplicants(applicant, applicant, account))
+        .thenReturn(completedFuture(applicant));
   }
 
   @Test
@@ -68,9 +78,9 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
             (civiFormProfile, profile) -> {
               assertThat(civiFormProfile).isEmpty();
               assertThat(profile).isEqualTo(oidcProfile);
-              return USER_PROFILE;
+              return userProfile;
             });
-    assertThat(merged).hasValue(USER_PROFILE);
+    assertThat(merged).hasValue(userProfile);
   }
 
   @Test
@@ -84,9 +94,9 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
               assertThat(profileData.getId()).isEqualTo(ACCOUNT_ID.toString());
               assertThat(profile).isEqualTo(oidcProfile);
-              return USER_PROFILE;
+              return userProfile;
             });
-    assertThat(merged).hasValue(USER_PROFILE);
+    assertThat(merged).hasValue(userProfile);
   }
 
   @Test
@@ -94,41 +104,31 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
     var merged =
         civiFormProfileMerger.mergeProfiles(
             /* applicantInDatabase = */ Optional.empty(),
-            Optional.of(profileFactory.wrapProfileData(civiFormProfileData)),
+            Optional.of(civiFormProfile),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
               assertThat(profileData.getAttribute(EMAIL_ATTR)).isEqualTo(EMAIL2);
               assertThat(profile).isEqualTo(oidcProfile);
-              return USER_PROFILE;
+              return userProfile;
             });
-    assertThat(merged).hasValue(USER_PROFILE);
+    assertThat(merged).hasValue(userProfile);
   }
 
   @Test
   public void mergeProfiles_succeeds_afterTwoWayMerge() {
-    var existingProfile = spy(profileFactory.wrapProfileData(civiFormProfileData));
-    doReturn(completedFuture(account)).when(existingProfile).getAccount();
-
-    var expectedApplicant = new Applicant();
-    expectedApplicant.setAccount(new Account());
-    expectedApplicant.getAccount().id = ACCOUNT_ID;
-    doReturn(completedFuture(expectedApplicant))
-        .when(repository)
-        .mergeApplicants(applicant, applicant, account);
-
     var merged =
         civiFormProfileMerger.mergeProfiles(
             Optional.of(applicant),
-            Optional.of(existingProfile),
+            Optional.of(civiFormProfile),
             oidcProfile,
             (civiFormProfile, profile) -> {
-              var id = civiFormProfile.orElseThrow().getId();
-              assertThat(id).isEqualTo(ACCOUNT_ID.toString());
+              var profileData = civiFormProfile.orElseThrow().getProfileData();
+              assertThat(profileData.getId()).isEqualTo(ACCOUNT_ID.toString());
               assertThat(profile).isEqualTo(oidcProfile);
-              return USER_PROFILE;
+              return userProfile;
             });
     verify(repository).mergeApplicants(eq(applicant), eq(applicant), eq(account));
-    assertThat(merged).hasValue(USER_PROFILE);
+    assertThat(merged).hasValue(userProfile);
   }
 }

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -62,8 +62,8 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   public void mergeProfiles_succeeds_noExistingApplicantAndNoExistingProfile() {
     var merged =
         civiFormProfileMerger.mergeProfiles(
-            /* applicantInDatabase= */ Optional.empty(),
-            /* guestProfile= */ Optional.empty(),
+            /* applicantInDatabase = */ Optional.empty(),
+            /* guestProfile = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               assertThat(civiFormProfile).isEmpty();
@@ -77,8 +77,8 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   public void mergeProfiles_succeeds_noExistingProfile() {
     var merged =
         civiFormProfileMerger.mergeProfiles(
-            /* applicantInDatabase= */ Optional.of(applicant),
-            /* guestProfile= */ Optional.empty(),
+            Optional.of(applicant),
+            /* guestProfile = */ Optional.empty(),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();
@@ -93,8 +93,8 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   public void mergeProfiles_succeeds_noExistingApplicant() {
     var merged =
         civiFormProfileMerger.mergeProfiles(
-            Optional.empty(),
-            /* guestProfile= */ Optional.of(profileFactory.wrapProfileData(civiFormProfileData)),
+            /* applicantInDatabase = */ Optional.empty(),
+            Optional.of(profileFactory.wrapProfileData(civiFormProfileData)),
             oidcProfile,
             (civiFormProfile, profile) -> {
               var profileData = civiFormProfile.orElseThrow().getProfileData();

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -2,7 +2,6 @@ package auth;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -1,0 +1,135 @@
+package auth;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.Optional;
+import models.Account;
+import models.Applicant;
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.UserProfile;
+import org.pac4j.oidc.profile.OidcProfile;
+import repository.ResetPostgres;
+import repository.UserRepository;
+
+public class CiviFormProfileMergerTest extends ResetPostgres {
+
+  private static final String EMAIL_ATTR = "user_emailid";
+  private static final String EMAIL1 = "foo@bar.com";
+  private static final String EMAIL2 = "bar@foo.com";
+  private static final Long ACCOUNT_ID = 12345L;
+  private static final UserProfile USER_PROFILE = new CommonProfile();
+
+  private UserRepository repository;
+  private ProfileFactory profileFactory;
+
+  private OidcProfile oidcProfile;
+  private CiviFormProfileData civiFormProfileData;
+  private Applicant applicant;
+  private Account account;
+
+  private CiviFormProfileMerger civiFormProfileMerger;
+
+  @Before
+  public void setup() {
+    profileFactory = spy(instanceOf(ProfileFactory.class));
+    repository = spy(instanceOf(UserRepository.class));
+    civiFormProfileMerger = new CiviFormProfileMerger(profileFactory, () -> repository);
+
+    oidcProfile = new OidcProfile();
+    oidcProfile.addAttribute(EMAIL_ATTR, EMAIL1);
+
+    civiFormProfileData = new CiviFormProfileData();
+    civiFormProfileData.setId(ACCOUNT_ID.toString());
+    civiFormProfileData.addAttribute(EMAIL_ATTR, EMAIL2);
+
+    account = new Account();
+    account.id = ACCOUNT_ID;
+
+    applicant = spy(new Applicant());
+    applicant.setAccount(account);
+    account.setApplicants(Collections.singletonList(applicant));
+  }
+
+  @Test
+  public void threeWayMerge_succeeds_noExistingApplicantAndNoExistingProfile() {
+    var merged =
+        civiFormProfileMerger.threeWayMerge(
+            Optional.empty(),
+            Optional.empty(),
+            oidcProfile,
+            (civiFormProfile, profile) -> {
+              assertThat(civiFormProfile).isEmpty();
+              assertThat(profile).isEqualTo(oidcProfile);
+              return USER_PROFILE;
+            });
+    assertThat(merged).hasValue(USER_PROFILE);
+  }
+
+  @Test
+  public void threeWayMerge_succeeds_noExistingProfile() {
+    var merged =
+        civiFormProfileMerger.threeWayMerge(
+            Optional.of(applicant),
+            Optional.empty(),
+            oidcProfile,
+            (civiFormProfile, profile) -> {
+              var profileData = civiFormProfile.orElseThrow().getProfileData();
+              assertThat(profileData.getId()).isEqualTo(ACCOUNT_ID.toString());
+              assertThat(profile).isEqualTo(oidcProfile);
+              return USER_PROFILE;
+            });
+    assertThat(merged).hasValue(USER_PROFILE);
+  }
+
+  @Test
+  public void threeWayMerge_succeeds_noExistingApplicant() {
+    var merged =
+        civiFormProfileMerger.threeWayMerge(
+            Optional.empty(),
+            Optional.of(profileFactory.wrapProfileData(civiFormProfileData)),
+            oidcProfile,
+            (civiFormProfile, profile) -> {
+              var profileData = civiFormProfile.orElseThrow().getProfileData();
+              assertThat(profileData.getAttribute(EMAIL_ATTR)).isEqualTo(EMAIL2);
+              assertThat(profile).isEqualTo(oidcProfile);
+              return USER_PROFILE;
+            });
+    assertThat(merged).hasValue(USER_PROFILE);
+  }
+
+  @Test
+  public void threeWayMerge_succeeds_afterTwoWayMerge() {
+    var existingProfile = spy(profileFactory.wrapProfileData(civiFormProfileData));
+    doReturn(completedFuture(account)).when(existingProfile).getAccount();
+
+    var expectedApplicant = new Applicant();
+    expectedApplicant.setAccount(new Account());
+    expectedApplicant.getAccount().id = ACCOUNT_ID;
+    doReturn(completedFuture(expectedApplicant))
+        .when(repository)
+        .mergeApplicants(applicant, applicant, account);
+
+    var merged =
+        civiFormProfileMerger.threeWayMerge(
+            Optional.of(applicant),
+            Optional.of(existingProfile),
+            oidcProfile,
+            (civiFormProfile, profile) -> {
+              var id = civiFormProfile.orElseThrow().getId();
+              assertThat(id).isEqualTo(ACCOUNT_ID.toString());
+              assertThat(profile).isEqualTo(oidcProfile);
+              return USER_PROFILE;
+            });
+    verify(repository).mergeApplicants(eq(applicant), eq(applicant), eq(account));
+    assertThat(merged).hasValue(USER_PROFILE);
+  }
+}

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -83,7 +83,8 @@ public class ProfileMergeTest extends ResetPostgres {
     OidcProfile oidcProfile = createOidcProfile("foo@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -99,7 +100,8 @@ public class ProfileMergeTest extends ResetPostgres {
         createOidcProfile("foo@example.com", "issuer to delete", "subject to delete");
 
     CiviFormProfileData existingProfileWithoutAuthority =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
     Account account =
         database.find(Account.class).where().eq("email_address", "foo@example.com").findOne();
     account.setAuthorityId(null);
@@ -123,7 +125,8 @@ public class ProfileMergeTest extends ResetPostgres {
     OidcProfile oidcProfile = createOidcProfile("foo@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThat(
             idcsProfileAdapter
@@ -142,7 +145,8 @@ public class ProfileMergeTest extends ResetPostgres {
     newProfile.setId("subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -160,7 +164,8 @@ public class ProfileMergeTest extends ResetPostgres {
     newProfile.addAttribute("iss", "issuer");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -178,7 +183,8 @@ public class ProfileMergeTest extends ResetPostgres {
     newProfile.setId("subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -193,7 +199,8 @@ public class ProfileMergeTest extends ResetPostgres {
     OidcProfile conflictingProfile = createOidcProfile("bar@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -209,7 +216,8 @@ public class ProfileMergeTest extends ResetPostgres {
         createOidcProfile("foo@example.com", "issuer", "a different subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -225,7 +233,8 @@ public class ProfileMergeTest extends ResetPostgres {
         createOidcProfile("foo@example.com", "a different issuer", "subject");
 
     CiviFormProfileData profileData =
-        idcsProfileAdapter.mergeCiviFormProfile(Optional.empty(), oidcProfile);
+        idcsProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -239,7 +248,8 @@ public class ProfileMergeTest extends ResetPostgres {
     SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -252,7 +262,8 @@ public class ProfileMergeTest extends ResetPostgres {
     SAML2Profile saml2Profile = createSamlProfile("foo@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
 
     assertThat(
             samlProfileAdapter
@@ -268,7 +279,8 @@ public class ProfileMergeTest extends ResetPostgres {
     SAML2Profile conflictingProfile = createSamlProfile("bar@example.com", "issuer", "subject");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -286,7 +298,8 @@ public class ProfileMergeTest extends ResetPostgres {
     newProfile.addAuthenticationAttribute("issuerId", "issuer");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -304,7 +317,8 @@ public class ProfileMergeTest extends ResetPostgres {
     newProfile.setId("subject");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -320,7 +334,8 @@ public class ProfileMergeTest extends ResetPostgres {
         createSamlProfile("foo@example.com", "issuer", "a different subject");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -336,7 +351,8 @@ public class ProfileMergeTest extends ResetPostgres {
         createSamlProfile("foo@example.com", "a different issuer", "subject");
 
     CiviFormProfileData profileData =
-        samlProfileAdapter.mergeCiviFormProfile(Optional.empty(), saml2Profile);
+        samlProfileAdapter.mergeCiviFormProfile(
+            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -84,7 +84,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -101,7 +101,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData existingProfileWithoutAuthority =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
     Account account =
         database.find(Account.class).where().eq("email_address", "foo@example.com").findOne();
     account.setAuthorityId(null);
@@ -126,7 +126,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThat(
             idcsProfileAdapter
@@ -146,7 +146,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -165,7 +165,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -184,7 +184,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -200,7 +200,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -217,7 +217,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -234,7 +234,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         idcsProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), oidcProfile);
+            /* maybeCiviFormProfile = */ Optional.empty(), oidcProfile);
 
     assertThatThrownBy(
             () ->
@@ -249,7 +249,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
     CiviFormProfile profile = profileFactory.wrapProfileData(profileData);
 
     assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
@@ -263,7 +263,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
 
     assertThat(
             samlProfileAdapter
@@ -280,7 +280,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -299,7 +299,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -318,7 +318,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -335,7 +335,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->
@@ -352,7 +352,7 @@ public class ProfileMergeTest extends ResetPostgres {
 
     CiviFormProfileData profileData =
         samlProfileAdapter.mergeCiviFormProfile(
-            /* maybeCiviformProfile = */ Optional.empty(), saml2Profile);
+            /* maybeCiviFormProfile = */ Optional.empty(), saml2Profile);
 
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
### Description
SamlCiviFormProfileAdapter and OidcCiviFormProfileAdapter both conduct a 3 way merge between the database, session context, and authentication provider. This PR extracts the 3 way merge logic into a new class, CiviFormProfileAdapterHelper

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #2229 
