### PR TITLE
Fix rendering applicant name in program application review

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -55,7 +55,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1
@@ -55,7 +55,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -36,7 +36,7 @@ services:
       - 8033:3380
 
   civiform:
-    image: civiform-dev
+    image: civiform
     restart: always
     container_name: civiform-test
     links:

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -93,7 +93,7 @@ export const userDisplayName = () => {
   if (isTestUser()) {
     return 'TEST, UATAPP'
   } else {
-    return '<Anonymous Applicant>'
+    return 'Guest'
   }
 }
 

--- a/server/app/views/ApplicantUtils.java
+++ b/server/app/views/ApplicantUtils.java
@@ -1,10 +1,31 @@
 package views;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import java.util.Optional;
+import play.i18n.Lang;
 import play.i18n.Messages;
+import play.i18n.MessagesApi;
 import services.MessageKey;
 
 public final class ApplicantUtils {
+
+  private final MessagesApi messagesApi;
+
+  @Inject
+  public ApplicantUtils(MessagesApi messagesApi) {
+    this.messagesApi = checkNotNull(messagesApi);
+  }
+
+  /** Get the applicant's name or the GUEST message with en-US lang. */
+  public String getApplicantNameEnUs(Optional<String> maybeName) {
+    Messages messages = messagesApi.preferred(ImmutableList.of(Lang.forCode("en-US")));
+    return ApplicantUtils.getApplicantName(maybeName, messages);
+  }
+
+  /** Get the applicant's name or the GUEST message in the provided messages. */
   public static String getApplicantName(Optional<String> maybeName, Messages messages) {
     return maybeName.orElse(messages.at(MessageKey.GUEST.getKeyName()));
   }

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -22,6 +22,7 @@ import play.mvc.Http;
 import play.twirl.api.Content;
 import services.PaginationResult;
 import services.program.ProgramDefinition;
+import views.ApplicantUtils;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -32,11 +33,13 @@ import views.style.Styles;
 /** Renders a page for viewing applications to a program. */
 public final class ProgramApplicationListView extends BaseHtmlView {
   private final AdminLayout layout;
+  private final ApplicantUtils applicantUtils;
   private final Logger log = LoggerFactory.getLogger(ProgramApplicationListView.class);
 
   @Inject
-  public ProgramApplicationListView(AdminLayout layout) {
+  public ProgramApplicationListView(AdminLayout layout, ApplicantUtils applicantUtils) {
     this.layout = checkNotNull(layout).setOnlyProgramAdminType();
+    this.applicantUtils = checkNotNull(applicantUtils);
   }
 
   public Content render(
@@ -113,7 +116,10 @@ public final class ProgramApplicationListView extends BaseHtmlView {
 
   private Tag renderApplicationListItem(Application application) {
     String applicantNameWithApplicationId =
-        String.format("%s (%d)", application.getApplicantData().getApplicantName(), application.id);
+        String.format(
+            "%s (%d)",
+            applicantUtils.getApplicantNameEnUs(application.getApplicantData().getApplicantName()),
+            application.id);
     String viewLinkText = "View →";
 
     Tag topContent =


### PR DESCRIPTION
The program application review page displays a list of applications identified by applicant name and application ID. [A previous PR](https://github.com/seattle-uat/civiform/pull/2353) changed the way applicant name is handled in the system, which introduced a bug where a missing applicant name is displayed as `optional.empty`:

![screenshot](https://user-images.githubusercontent.com/473671/166391805-a58378a7-7444-4fe6-b36b-1feac1aeae3b.png)

This PR fixes that to display the en-US message for `GUEST` when the applicant name is missing:

![shot{applicantName}](https://user-images.githubusercontent.com/473671/166391875-6ffdbf68-bf8f-4d28-a4d6-6653d65580e6.png)

Additionally, [another recent PR](https://github.com/seattle-uat/civiform/pull/2348) changed the browser test compose to using the `civiform-dev` image, which doesn't match what CI builds to run the server for browser tests. This prevented the correct code from running in the server for the test run, allowing the tests to pass on the PR that introduced the regression.
