### PR TITLE
Prevent program name slug collisions

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -5,11 +5,13 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
 import io.ebean.Database;
 import io.ebean.ExpressionList;
 import io.ebean.PagedList;
 import io.ebean.Query;
+import io.ebean.SqlRow;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import java.util.List;
@@ -64,6 +66,17 @@ public class ProgramRepository {
   public Program updateProgramSync(Program program) {
     database.update(program);
     return program;
+  }
+
+  public ImmutableSet<String> getAllProgramNames() {
+    ImmutableSet.Builder<String> names = ImmutableSet.builder();
+    List<SqlRow> rows = database.sqlQuery("SELECT DISTINCT name FROM programs").findList();
+
+    for (SqlRow row : rows) {
+      names.add(row.getString("name"));
+    }
+
+    return names.build();
   }
 
   /**

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -215,18 +215,15 @@ public class ProgramServiceImpl implements ProgramService {
             .join());
   }
 
+  // Program names and program URL slugs must be unique in a given CiviForm
+  // system. If the slugs of two names collide, the names also collide, so
+  // we can check both by just checking for slug collisions.
+  // For more info on URL slugs see: https://en.wikipedia.org/wiki/Clean_URL#Slug
   private boolean hasProgramNameCollision(String programName) {
-    ImmutableSet<String> programNames = getActiveAndDraftPrograms().getProgramNames();
-
-    if (programNames.contains(programName)) {
-      return true;
-    }
-
     Slugify slugifier = new Slugify();
-    ImmutableSet<String> programSlugs =
-        programNames.stream().map(slugifier::slugify).collect(ImmutableSet.toImmutableSet());
-
-    return programSlugs.contains(slugifier.slugify(programName));
+    return getActiveAndDraftPrograms().getProgramNames().stream()
+        .map(slugifier::slugify)
+        .anyMatch(slugifier.slugify(programName)::equals);
   }
 
   private void validateProgramText(

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -221,7 +221,7 @@ public class ProgramServiceImpl implements ProgramService {
   // For more info on URL slugs see: https://en.wikipedia.org/wiki/Clean_URL#Slug
   private boolean hasProgramNameCollision(String programName) {
     Slugify slugifier = new Slugify();
-    return getActiveAndDraftPrograms().getProgramNames().stream()
+    return programRepository.getAllProgramNames().stream()
         .map(slugifier::slugify)
         .anyMatch(slugifier.slugify(programName)::equals);
   }

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -2,6 +2,7 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
 import java.util.Locale;
 import java.util.Optional;
@@ -125,6 +126,17 @@ public class ProgramRepositoryTest extends ResetPostgres {
     assertThat(updated.getProgramDefinition().id()).isEqualTo(existing.id);
     assertThat(updated.getProgramDefinition().localizedName())
         .isEqualTo(LocalizedStrings.of(Locale.US, "new name"));
+  }
+
+  @Test
+  public void getAllProgramNames() {
+    resourceCreator.insertActiveProgram("old name");
+    resourceCreator.insertDraftProgram("old name");
+    resourceCreator.insertDraftProgram("new name");
+
+    ImmutableSet<String> result = repo.getAllProgramNames();
+
+    assertThat(result).isEqualTo(ImmutableSet.of("old name", "new name"));
   }
 
   @Test

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -178,6 +178,34 @@ public class ProgramServiceImplTest extends ResetPostgres {
   }
 
   @Test
+  public void createProgram_protectsAgainstProgramSlugCollisions() {
+    ps.createProgramDefinition(
+        "name  one",
+        "description",
+        "display name",
+        "display description",
+        "",
+        DisplayMode.PUBLIC.getValue());
+
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.createProgramDefinition(
+            // Program name here is missing the extra space
+            // so that the names are different but the resulting
+            // slug is the same.
+            "name one",
+            "description",
+            "display name",
+            "display description",
+            "",
+            DisplayMode.PUBLIC.getValue());
+
+    assertThat(result.hasResult()).isFalse();
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors())
+        .containsExactly(CiviFormError.of("a program named name one already exists"));
+  }
+
+  @Test
   public void updateProgram_withNoProgram_throwsProgramNotFoundException() {
     assertThatThrownBy(
             () ->

--- a/server/test/services/program/ProgramServiceImplTest.java
+++ b/server/test/services/program/ProgramServiceImplTest.java
@@ -179,8 +179,9 @@ public class ProgramServiceImplTest extends ResetPostgres {
 
   @Test
   public void createProgram_protectsAgainstProgramSlugCollisions() {
+    // Two programs with names that are different but slugify to same value.
     ps.createProgramDefinition(
-        "name  one",
+        "name one",
         "description",
         "display name",
         "display description",
@@ -192,7 +193,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
             // Program name here is missing the extra space
             // so that the names are different but the resulting
             // slug is the same.
-            "name one",
+            "name  one",
             "description",
             "display name",
             "display description",
@@ -202,7 +203,7 @@ public class ProgramServiceImplTest extends ResetPostgres {
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
     assertThat(result.getErrors())
-        .containsExactly(CiviFormError.of("a program named name one already exists"));
+        .containsExactly(CiviFormError.of("a program named name  one already exists"));
   }
 
   @Test


### PR DESCRIPTION
When a program is created, CiviForm checks to ensure there isn't already a program with the same name. This is critical because the program name is immutable, and used to link multiple program records as versions of the same program.

The program slug -- the name formatted for use in a URL -- must also be unique for the deep link feature to work. However it is possible to have two name strings that are different that slugify to the same value. This change adds a validation check to ensure new program names do not slugify to slugs that collide with existing program slugs.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary


