### PR TITLE
Don't export screens. Reduces css from 1.7Mb to 0.5Mb

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -999,9 +999,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1128,9 +1128,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
       "dev": true,
       "funding": [
         {
@@ -1143,7 +1143,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -2257,9 +2257,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true
     },
     "node-emoji": {
@@ -2356,12 +2356,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }

--- a/server/tailwind.config.js
+++ b/server/tailwind.config.js
@@ -49,6 +49,10 @@ module.exports = {
         },
       },
     },
+    screens: {
+     // Don't export any. Revisit if we start using screens.
+     // https://tailwindcss.com/docs/screens
+     },
   },
   variants: {
     extend: {


### PR DESCRIPTION
### Description
By default tailwinds exports 5 screens: sm, md, lg, xl, 2xl (https://tailwindcss.com/docs/screens). This means that most classes have 5 versions. 
We are not currently using this functionality.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
