### PR TITLE
Allow the stdout to be seen when a test fails

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -103,7 +103,7 @@ lazy val root = (project in file("."))
     incOptions := incOptions.value.withTransitiveStep(2),
 
     // Make verbose tests
-    Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
+    Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q")),
     // Use test config for tests
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     // Turn off scaladoc link warnings


### PR DESCRIPTION
### Description
Adds the -q flag to tests, which allows standard out to be printed to the command line if a test fails 

[docs](https://github.com/sbt/junit-interface)

