### PR TITLE
Add a script for sbt to run in the unit test environment

### DIFF
--- a/bin/remove-test-env
+++ b/bin/remove-test-env
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# DOC: Stop and delete the running browser test environment.
+# DOC: Stop and delete the running unit test environment.
 
 source bin/lib.sh
 docker::set_project_name_unit_tests

--- a/bin/remove-test-env
+++ b/bin/remove-test-env
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+# DOC: Stop and delete the running browser test environment.
+
+source bin/lib.sh
+docker::set_project_name_unit_tests
+
+${DOCKER_COMPOSE_UNIT_TEST_DEV} down --remove-orphans

--- a/bin/sbt-test
+++ b/bin/sbt-test
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# DOC: Run the Java test suite in Docker.
+# DOC: Open an sbt CLI in the Unit Test environment container.
 
 source bin/lib.sh
 docker::set_project_name_unit_tests

--- a/bin/sbt-test
+++ b/bin/sbt-test
@@ -7,5 +7,7 @@ docker::set_project_name_unit_tests
 
 bin/pull-image
 
-bin/sbt-test test
-bin/remove-test-env
+readonly COMPOSE_CMD="${DOCKER_COMPOSE_UNIT_TEST_DEV}"
+
+${COMPOSE_CMD} up -d
+${COMPOSE_CMD} exec civiform sbt "$@"


### PR DESCRIPTION
### Description
Adds a script for sbt to run in the unit test environment, and changes `bin/run-test` to use it.

You can run this using `bin/sbt-test` to get the command line, or pass arguments like `bin/sbt-test testOnly <test name>`.

It will start the docker containers needed for the tests in the background, and keep them running so you can do multiple commands without re-loading.  

Run `bin/remove-test-env` to shut down the docker containers.

### Checklist
- Ran scripts to test