### PR TITLE
Bump pac4j patch version

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -54,13 +54,14 @@ lazy val root = (project in file("."))
       // Security libraries
       // pac4j core (https://github.com/pac4j/play-pac4j)
       "org.pac4j" %% "play-pac4j" % "11.1.0-PLAY2.8",
-      "org.pac4j" % "pac4j-core" % "5.4.2",
+      "org.pac4j" % "pac4j-core" % "5.4.3",
       // basic http authentication (for the anonymous client)
-      "org.pac4j" % "pac4j-http" % "5.4.2",
+      "org.pac4j" % "pac4j-http" % "5.4.3",
       // OIDC authentication
-      "org.pac4j" % "pac4j-oidc" % "5.4.2",
+      "org.pac4j" % "pac4j-oidc" % "5.4.3",
       // SAML authentication
-      "org.pac4j" % "pac4j-saml" % "5.4.2",
+      "org.pac4j" % "pac4j-saml" % "5.4.3",
+
       // Encrypted cookies require encryption.
       "org.apache.shiro" % "shiro-crypto-cipher" % "1.9.0",
 


### PR DESCRIPTION
fixes a CVE related to spring, which we don't use: https://github.com/pac4j/pac4j/blob/master/documentation/docs/release-notes.md