### PR TITLE
Make sure all docker containers get refreshed

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -5,6 +5,8 @@
 source bin/lib.sh
 docker::set_project_name_dev
 
+bin/pull-image
+
 docker run --rm -it \
   -v "$(pwd)/server/:/code" \
   civiform/formatter:latest

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -15,6 +15,10 @@ if [[ -z "${USE_LOCAL_CIVIFORM}" ]]; then
   docker pull -q docker.io/civiform/oidc-provider:latest
   docker pull -q mcr.microsoft.com/azure-storage/azurite
   docker pull -q localstack/localstack
+
+  docker pull -q civiform/formatter:latest
+  docker pull -q civiform/civiform-browser-test:latest
+
 else
   echo "Using local civiform and dependency docker images"
 fi

--- a/bin/refresh-styles
+++ b/bin/refresh-styles
@@ -4,11 +4,13 @@
 
 source bin/lib.sh
 
+bin/pull-image
+
 docker run -it --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(pwd)/server:/usr/src/server \
   --entrypoint npx \
-  civiform/civiform-dev:latest \
+  civiform-dev \
   tailwindcss build \
   -i ./app/assets/stylesheets/styles.css \
   -o ./public/stylesheets/tailwind.css

--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -4,6 +4,7 @@
 
 source bin/lib.sh
 docker::set_project_name_browser_tests
+bin/pull-image
 
 docker run --ipc=host --rm -it \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \

--- a/bin/run-prober
+++ b/bin/run-prober
@@ -3,6 +3,7 @@
 # DOC: Run the browser test suite in Docker against the staging environment.
 
 source bin/lib.sh
+bin/pull-image
 
 docker run \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \

--- a/browser-test/bin/fmt
+++ b/browser-test/bin/fmt
@@ -4,8 +4,10 @@ pushd $(git rev-parse --show-toplevel)/browser-test
 
 CMD="cd /code; npx prettier --write --config /.prettierrc.js --ignore-path /.prettierignore /code"
 
+bin/pull-image
+
 docker run --rm -it \
   -v "$(pwd)/src:/code" \
-  docker.io/civiform/formatter:latest sh -c "$CMD"
+  civiform/formatter:latest sh -c "$CMD"
 
 popd

--- a/browser-test/bin/fmt
+++ b/browser-test/bin/fmt
@@ -8,6 +8,6 @@ bin/pull-image
 
 docker run --rm -it \
   -v "$(pwd)/src:/code" \
-  civiform/formatter:latest sh -c "$CMD"
+  civiform/formatter sh -c "$CMD"
 
 popd


### PR DESCRIPTION
### Description
The browser-test and formatter images don't get auto-refreshed.  Add them to the pull-image command and use the pull-image command in their respective scripts.
