### PR TITLE
Use the civiform-dev image for local browsertest

### DIFF
--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -3,6 +3,8 @@
 version: '3.4'
 services:
   civiform:
+    image: civiform-dev
+    build: .. # build the civiform-dev image.
     volumes:
       - ./server:/usr/src/server
       - target:/usr/src/server/target


### PR DESCRIPTION
### Description
Running browser-tests locally should use the civiform-dev container, to allow java debugging ports to connect.

### Checklist
- Tested locally by purging all docker images & running

### Issue(s)
Fixes error introduced in #2297
