### PR TITLE
Fix cloud/shared/bin/doctor checks based on selected cloud provider.

### DIFF
--- a/cloud/shared/bin/doctor_impl
+++ b/cloud/shared/bin/doctor_impl
@@ -77,7 +77,7 @@ class AwsCliCheck(Check):
 
     def should_skip(self):
         # AWS SES is used for both Azure and AWS deployments.
-        return self._get_cloud_provider() in ['aws', 'azure']
+        return self._get_cloud_provider() not in ['aws', 'azure']
 
     def is_ok(self):
         return self._check_command_succeeds(["aws", "help"])

--- a/cloud/shared/bin/doctor_impl
+++ b/cloud/shared/bin/doctor_impl
@@ -13,9 +13,6 @@ if not is_linux and not is_mac:
 class DockerCheck(Check):
     remedy = "Need to install Docker CLI: https://docs.docker.com/engine/install/"
 
-    def should_skip(self):
-        return self._get_cloud_provider() == 'azure'
-
     def name(self):
         return "Docker CLI"
 
@@ -79,7 +76,7 @@ class AwsCliCheck(Check):
         return "AWS CLI"
 
     def should_skip(self):
-        return self._get_cloud_provider() in ['aws', 'azure']
+        return self._get_cloud_provider() != 'aws'
 
     def is_ok(self):
         return self._check_command_succeeds(["aws", "help"])
@@ -133,7 +130,7 @@ class AwsLoginCheck(Check):
         return "AWS login"
 
     def should_skip(self):
-        return self._get_cloud_provider() not in ['aws', 'azure']
+        return self._get_cloud_provider() != 'aws'
 
     def is_ok(self):
         output = self._get_command_output(["aws", "configure", "list-profiles"])

--- a/cloud/shared/bin/doctor_impl
+++ b/cloud/shared/bin/doctor_impl
@@ -76,7 +76,8 @@ class AwsCliCheck(Check):
         return "AWS CLI"
 
     def should_skip(self):
-        return self._get_cloud_provider() != 'aws'
+        # AWS SES is used for both Azure and AWS deployments.
+        return self._get_cloud_provider() in ['aws', 'azure']
 
     def is_ok(self):
         return self._check_command_succeeds(["aws", "help"])
@@ -130,7 +131,8 @@ class AwsLoginCheck(Check):
         return "AWS login"
 
     def should_skip(self):
-        return self._get_cloud_provider() != 'aws'
+        # AWS SES is used for both Azure and AWS deployments.
+        return self._get_cloud_provider() not in ['aws', 'azure']
 
     def is_ok(self):
         output = self._get_command_output(["aws", "configure", "list-profiles"])


### PR DESCRIPTION
- Check for Docker installation in cloud/shared/bin/doctor for both AWS and Azure.
- Fix should_skip check for AWS CLI. Previously, we were skipping this check for AWS and Azure. We should be checking this for both.