### PR TITLE
Change the terraform command to use arrays so it evaluates properly

### DIFF
--- a/cloud/shared/bin/lib/terraform.sh
+++ b/cloud/shared/bin/lib/terraform.sh
@@ -18,11 +18,11 @@ function terraform::perform_apply() {
     "cloud/${CIVIFORM_CLOUD_PROVIDER}/bin/setup_tf_shared_state" \
       "${TERRAFORM_TEMPLATE_DIR}/${BACKEND_VARS_FILENAME}"
 
-      terraform "${TERRAFORM_DIR}" \
-        init \
-        -input=false \
-        -upgrade \
-        -backend-config="${BACKEND_VARS_FILENAME}"
+    terraform "${TERRAFORM_DIR}" \
+      init \
+      -input=false \
+      -upgrade \
+      -backend-config="${BACKEND_VARS_FILENAME}"
   fi
 
   if azure::is_service_principal; then

--- a/cloud/shared/bin/lib/terraform.sh
+++ b/cloud/shared/bin/lib/terraform.sh
@@ -1,12 +1,7 @@
 #! /usr/bin/env bash
 
-readonly TERRAFORM_BASE_COMMAND="terraform \
-        -chdir=${TERRAFORM_TEMPLATE_DIR}"
-
-readonly TERRAFORM_APPLY="${TERRAFORM_BASE_COMMAND} \
-        apply \
-        -input=false \
-        -var-file=${TF_VAR_FILENAME}"
+readonly TERRAFORM_BASE=("terraform" "-chdir=${TERRAFORM_TEMPLATE_DIR}")
+readonly TERRAFORM_APPLY=(${TERRAFORM_BASE[@]} "apply" "-input=false" "-var-file=${TF_VAR_FILENAME}")
 
 #######################################
 # Generates terraform variable files and runs terraform init and apply.
@@ -18,24 +13,22 @@ readonly TERRAFORM_APPLY="${TERRAFORM_BASE_COMMAND} \
 #######################################
 function terraform::perform_apply() {
   if [[ "${CIVIFORM_MODE}" == "dev" ]]; then
-    "$(${TERRAFORM_BASE_COMMAND} init -upgrade)"
+    terraform "${TERRAFORM_DIR}" init -upgrade
   else
     "cloud/${CIVIFORM_CLOUD_PROVIDER}/bin/setup_tf_shared_state" \
       "${TERRAFORM_TEMPLATE_DIR}/${BACKEND_VARS_FILENAME}"
 
-    "$(
-      ${TERRAFORM_BASE_COMMAND}
-      init \
+      terraform "${TERRAFORM_DIR}" \
+        init \
         -input=false \
         -upgrade \
         -backend-config="${BACKEND_VARS_FILENAME}"
-    )"
   fi
 
   if azure::is_service_principal; then
-    "$(${TERRAFORM_APPLY} -auto-approve)"
+    "${TERRAFORM_APPLY[@]}" -auto-approve
   else
-    "$(${TERRAFORM_APPLY})"
+    "${TERRAFORM_APPLY[@]}"
   fi
 }
 

--- a/cloud/shared/bin/lib/terraform.sh
+++ b/cloud/shared/bin/lib/terraform.sh
@@ -1,7 +1,8 @@
 #! /usr/bin/env bash
 
-readonly TERRAFORM_BASE=("terraform" "-chdir=${TERRAFORM_TEMPLATE_DIR}")
-readonly TERRAFORM_APPLY=(${TERRAFORM_BASE[@]} "apply" "-input=false" "-var-file=${TF_VAR_FILENAME}")
+# https://www.baeldung.com/linux/store-command-in-variable
+readonly TERRAFORM_CMD=("terraform" "${TERRAFORM_DIR}")
+readonly TERRAFORM_APPLY=(${TERRAFORM_CMD[@]} "apply" "-input=false" "-var-file=${TF_VAR_FILENAME}")
 
 #######################################
 # Generates terraform variable files and runs terraform init and apply.
@@ -13,12 +14,12 @@ readonly TERRAFORM_APPLY=(${TERRAFORM_BASE[@]} "apply" "-input=false" "-var-file
 #######################################
 function terraform::perform_apply() {
   if [[ "${CIVIFORM_MODE}" == "dev" ]]; then
-    terraform "${TERRAFORM_DIR}" init -upgrade
+    "${TERRAFORM_CMD[@]}" init -upgrade
   else
     "cloud/${CIVIFORM_CLOUD_PROVIDER}/bin/setup_tf_shared_state" \
       "${TERRAFORM_TEMPLATE_DIR}/${BACKEND_VARS_FILENAME}"
 
-    terraform "${TERRAFORM_DIR}" \
+    "${TERRAFORM_CMD[@]}" \
       init \
       -input=false \
       -upgrade \


### PR DESCRIPTION
### Description
The quotes and command substitution `$()` weren't allowing the terraform command to execute correctly.  Instead, it was trying to run (as a command) the results of the terraform command (which was an error, due to a stray missing `\`).

Instead, lets use the recommended solution for storing simple commands, which is bash arrays, evaluated using `"${CMD[@]}"`

### Checklist
- Tested scripts using the github/civiform/civiform-deploy deploy script
