### PR TITLE
Fix vscode-setup to use the docker compose name.

### DIFF
--- a/bin/vscode-setup
+++ b/bin/vscode-setup
@@ -17,7 +17,7 @@ bin/sbt makePom
 
 # Copy the generated target directory from the docker container to a local dir
 # so that we can use globs to copy the correct file out.
-docker cp civiform-shell:/usr/src/server/target server/temp
+docker cp ${COMPOSE_PROJECT_NAME}-civiform-shell-1:/usr/src/server/target server/temp
 
 cp server/temp/scala-*/*.pom \
   server/pom.xml

--- a/bin/vscode-setup
+++ b/bin/vscode-setup
@@ -6,6 +6,7 @@
 
 source bin/lib.sh
 docker::set_project_name_dev
+readonly COMPOSE_CMD="${DOCKER_COMPOSE_DEV} --profile shell"
 
 bin/pull-image
 
@@ -17,7 +18,7 @@ bin/sbt makePom
 
 # Copy the generated target directory from the docker container to a local dir
 # so that we can use globs to copy the correct file out.
-docker cp ${COMPOSE_PROJECT_NAME}-civiform-shell-1:/usr/src/server/target server/temp
+${COMPOSE_CMD} cp civiform-shell:/usr/src/server/target server/temp
 
 cp server/temp/scala-*/*.pom \
   server/pom.xml

--- a/bin/vscode-setup
+++ b/bin/vscode-setup
@@ -6,7 +6,7 @@
 
 source bin/lib.sh
 docker::set_project_name_dev
-readonly COMPOSE_CMD="${DOCKER_COMPOSE_DEV} --profile shell"
+readonly COMPOSE_CMD="${DOCKER_COMPOSE_DEV}"
 
 bin/pull-image
 
@@ -18,7 +18,7 @@ bin/sbt makePom
 
 # Copy the generated target directory from the docker container to a local dir
 # so that we can use globs to copy the correct file out.
-${COMPOSE_CMD} cp civiform-shell:/usr/src/server/target server/temp
+${COMPOSE_CMD} --profile shell cp civiform-shell:/usr/src/server/target server/temp
 
 cp server/temp/scala-*/*.pom \
   server/pom.xml


### PR DESCRIPTION
### Description
Adapts the `bin/vscode-setup` script to handle that containers generated by `bin/sbt` have a new naming convention since https://github.com/seattle-uat/civiform/pull/2297. 