### PR TITLE
Updating browser tests to better handle the warning toast

### DIFF
--- a/browser-test/src/admin_predicates.test.ts
+++ b/browser-test/src/admin_predicates.test.ts
@@ -1,3 +1,4 @@
+import { Browser, Page } from 'playwright'
 import {
   AdminPredicates,
   AdminPrograms,
@@ -11,11 +12,28 @@ import {
   selectApplicantLanguage,
   startSession,
   userDisplayName,
+  closeWarningMessage,
 } from './support'
 
 describe('create and edit predicates', () => {
-  it('add a hide predicate', async () => {
+  let browserObject : Browser
+  let pageObject : Page
+
+  beforeEach(async () => {
     const { browser, page } = await startSession()
+
+    browserObject = browser
+    pageObject = page
+
+    await closeWarningMessage(page)
+  })
+
+  afterEach(async () =>{
+    await endSession(browserObject)
+  })
+
+  it('add a hide predicate', async () => {
+    const page = pageObject
 
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page)
@@ -97,13 +115,10 @@ describe('create and edit predicates', () => {
       .locator('#application-view')
       .innerText()
     expect(applicationText).not.toContain('Screen 2')
-
-    await endSession(browser)
   })
 
   it('add a show predicate', async () => {
-    const { browser, page } = await startSession()
-
+    const page = pageObject
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page)
     const adminPrograms = new AdminPrograms(page)
@@ -184,13 +199,10 @@ describe('create and edit predicates', () => {
     await page.screenshot({ path: "tmp/screenshot.png", fullPage: true })
     await adminPrograms.viewApplicationForApplicant(userDisplayName())
     expect(await adminPrograms.applicationFrame().locator('#application-view').innerText()).toContain('Screen 2')
-
-    await endSession(browser)
   })
 
   it('every right hand type evaluates correctly', async () => {
-    const { browser, page } = await startSession()
-
+    const page = pageObject
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page)
     const adminPrograms = new AdminPrograms(page)
@@ -317,6 +329,5 @@ describe('create and edit predicates', () => {
 
     // We should now be on the summary page
     await applicant.submitFromReviewPage(programName)
-    await endSession(browser)
   })
 })

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -126,3 +126,22 @@ export const dropTables = async (page: Page) => {
   await page.goto(BASE_URL + '/dev/seed')
   await page.click('#clear')
 }
+
+export const closeWarningMessage = async (page: Page) => {
+  // The warning message may be in the way of this link
+  var element = await page.$('#warning-message-dismiss')
+
+  if (element !== null){
+    await element
+      .click()
+      .then(() => console.log("Found: #warning-message-dismiss"))
+      .catch(() => console.log("Didn't find a warning toast message to dismiss, which is fine."))
+  } else {
+    console.log("Not found: #warning-message-dismiss")
+  }
+
+
+  // await page
+  //   .click('#warning-message-dismiss', { timeout: 500 })
+  //   .catch(() => console.log("Didn't find a warning toast message to dismiss, which is fine."))
+}


### PR DESCRIPTION
### Description

In trying to migrating the staging to deployment to seattle-uat/civiform-deploy I kept getting timeout failures of browser tests. The warning message toast may or may not exist in the DOM. When code tries to click the [x] to dismiss the toast and it isn't there the click timeout default is 30 seconds.

There are two options to address the clicking of element

**Option 1: Add a timeout to the click event**
```
await page.click('#warning-message-dismiss', { timeout: 500 })
```

**Option 2: Use a selector to find the element, and call the click method if the element was found**
```
var element = await page.$('#warning-message-dismiss')

if (element !== null){
  await element.click()
} 
```

I've tried both options and they work locally and against staging. I'm liking Option 2 better since it doesn't rely on hard coding a timeout value.

The changes in the admin_predicates.test.ts is an example of what I'm proposing I go do to all the test files.
