### PR TITLE
Adding assertion to run-test-ci that test targets are actually found.

### DIFF
--- a/bin/run-test-ci
+++ b/bin/run-test-ci
@@ -18,5 +18,5 @@ ${COMPOSE_CMD} exec civiform sbt test
 # This serves as a regression test for
 # https://github.com/seattle-uat/civiform/pull/2459.
 echo "[$(date)] Searching for MessageKeyTest in defined tests..."
-${COMPOSE_CMD} exec civiform sbt "show Test/definedTestNames" | grep -iq "services.MessageKeyTestABC123"
+${COMPOSE_CMD} exec civiform sbt "show Test/definedTestNames" | grep -iq "services.MessageKeyTest"
 ${COMPOSE_CMD} down

--- a/bin/run-test-ci
+++ b/bin/run-test-ci
@@ -9,7 +9,7 @@ readonly COMPOSE_CMD="${DOCKER_COMPOSE_UNIT_TEST}"
 
 ${COMPOSE_CMD} up -d
 ${COMPOSE_CMD} exec civiform sbt test
-# Upon a successful test run (non-zero exit code), we also
+# Upon a successful test run (exit code zero), we also
 # assert that SBT actually ran the test suite by evaluating
 # whether a well-known test name exists in the set of
 # evaluated test targets. Note that moving / deleting

--- a/bin/run-test-ci
+++ b/bin/run-test-ci
@@ -18,5 +18,5 @@ ${COMPOSE_CMD} exec civiform sbt test
 # This serves as a regression test for
 # https://github.com/seattle-uat/civiform/pull/2459.
 echo "[$(date)] Searching for MessageKeyTest in defined tests..."
-${COMPOSE_CMD} exec civiform sbt "show Test/definedTestNames" | grep -iq "services.MessageKeyTest"
+${COMPOSE_CMD} exec civiform sbt "show Test/definedTestNames" | grep -iq "services.MessageKeyTestABC123"
 ${COMPOSE_CMD} down

--- a/bin/run-test-ci
+++ b/bin/run-test-ci
@@ -9,4 +9,14 @@ readonly COMPOSE_CMD="${DOCKER_COMPOSE_UNIT_TEST}"
 
 ${COMPOSE_CMD} up -d
 ${COMPOSE_CMD} exec civiform sbt test
+# Upon a successful test run (non-zero exit code), we also
+# assert that SBT actually ran the test suite by evaluating
+# whether a well-known test name exists in the set of
+# evaluated test targets. Note that moving / deleting
+# MessageKeyTest will cause this to fail. If that happens,
+# a new target can be used.
+# This serves as a regression test for
+# https://github.com/seattle-uat/civiform/pull/2459.
+echo "[$(date)] Searching for MessageKeyTest in defined tests..."
+${COMPOSE_CMD} exec civiform sbt "show Test/definedTestNames" | grep -iq "services.MessageKeyTest"
 ${COMPOSE_CMD} down

--- a/server/test/services/MessageKeyTest.java
+++ b/server/test/services/MessageKeyTest.java
@@ -31,7 +31,7 @@ public class MessageKeyTest extends ResetPostgres {
   @Test
   @Parameters(source = MessageKey.class)
   public void messageKey_isValid(MessageKey messageKey) {
-    assertThat(messagesApi.isDefinedAt(Lang.defaultLang(), messageKey.getKeyName())).isFalse();
+    assertThat(messagesApi.isDefinedAt(Lang.defaultLang(), messageKey.getKeyName())).isTrue();
   }
 
   @Test

--- a/server/test/services/MessageKeyTest.java
+++ b/server/test/services/MessageKeyTest.java
@@ -31,7 +31,7 @@ public class MessageKeyTest extends ResetPostgres {
   @Test
   @Parameters(source = MessageKey.class)
   public void messageKey_isValid(MessageKey messageKey) {
-    assertThat(messagesApi.isDefinedAt(Lang.defaultLang(), messageKey.getKeyName())).isTrue();
+    assertThat(messagesApi.isDefinedAt(Lang.defaultLang(), messageKey.getKeyName())).isFalse();
   }
 
   @Test

--- a/server/test/services/MessageKeyTest.java
+++ b/server/test/services/MessageKeyTest.java
@@ -14,6 +14,9 @@ import play.i18n.Lang;
 import play.i18n.MessagesApi;
 import repository.ResetPostgres;
 
+// Note: If this test is removed / renamed, the assertion
+// in bin/run-test-ci will need to be updated.
+
 @RunWith(JUnitParamsRunner.class)
 public class MessageKeyTest extends ResetPostgres {
 

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "db:database"
       - "oidc"
     volumes:
+      - ./server:/usr/src/server
       - ./sbt_cache/coursier:/root/.cache/coursier
       - ~/.sbt:/root/.sbt
       - ~/.ivy:/root/.ivy2

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - "db:database"
       - "oidc"
     volumes:
-      - ./server:/usr/src/server
       - ./sbt_cache/coursier:/root/.cache/coursier
       - ~/.sbt:/root/.sbt
       - ~/.ivy:/root/.ivy2


### PR DESCRIPTION
### Description
This serves as a regression test for the issue fixed by https://github.com/seattle-uat/civiform/pull/2459, where `sbt test` returned successful immediately when it couldn't find any files to build. Here we ensure that the evaluated targets includes a well-known test.

Even though the compile steps are cached between invocations of `docker exec sbt`, it still adds ~1 minute to the successful case on my machine. In my opinion, this is acceptable since 1) unit tests still take a fraction of the time for browser tests and 2) we're only performing this assertion in CI (not in `bin/run-test`).

Alternative considered:
  * Modifying the GitHub action to have an extra step that performs the grep on the output of the `run-test-ci` command. While possible, this involved some combination of `tee`, piping, and saving off the command output. This felt like it would be harder to convince ourselves of correctness than an assertion inline in the `run-test-ci` script itself

### Testing
* Introduced unit test failure and confirmed the action still fails ([540720e](https://github.com/seattle-uat/civiform/pull/2474/commits/540720e865f9ef7c721ccf47197b92735a3f251e)) - [results](https://github.com/seattle-uat/civiform/runs/6393384927?check_suite_focus=true)
* Updated the assertion to not match an existing test and confirmed the action fails ([e485610](https://github.com/seattle-uat/civiform/pull/2474/commits/e48561074eb0aad55b6c8a73a15934037104c54b)) - [results](https://github.com/seattle-uat/civiform/runs/6393454159?check_suite_focus=true)
* Reintroduced failure causing `sbt test` to not find any targets ([6588bd6](https://github.com/seattle-uat/civiform/pull/2474/commits/6588bd63d7172165250eb6558cb2dbba18a036e7)) - [results](https://github.com/seattle-uat/civiform/runs/6393604286?check_suite_focus=true)