### PR TITLE
Prevent double-clicking the submit button from submitting multiple applications

### DIFF
--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -351,12 +351,9 @@ function attachFormDebouncers() {
       return
     }
     // Prevent double-clicks from submitting the form multiple times by
-    // disabling the button for a short period after the initial click.
+    // disabling the submit button after the initial click.
     el.addEventListener('submit', () => {
       submitEl.setAttribute('disabled', '')
-      setTimeout(() => {
-        submitEl.removeAttribute('disabled')
-      }, 5000)
     })
   })
 }

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -350,8 +350,13 @@ function attachFormDebouncers() {
     if (!submitEl) {
       return
     }
+    // Prevent double-clicks from submitting the form multiple times by
+    // disabling the button for a short period after the initial click.
     el.addEventListener('submit', () => {
       submitEl.setAttribute('disabled', '')
+      setTimeout(() => {
+        submitEl.removeAttribute('disabled')
+      }, 5000)
     })
   })
 }

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -345,14 +345,14 @@ function configurePredicateFormOnOperatorChange(event: Event) {
 }
 
 function attachFormDebouncers() {
-  Array.from(document.querySelectorAll('.cf-debounced-form')).forEach((el) => {
-    const submitEl = el.querySelector('button[type="submit"]')
+  Array.from(document.querySelectorAll('.cf-debounced-form')).forEach((formEl) => {
+    const submitEl = formEl.querySelector('button[type="submit"]')
     if (!submitEl) {
       return
     }
     // Prevent double-clicks from submitting the form multiple times by
     // disabling the submit button after the initial click.
-    el.addEventListener('submit', () => {
+    formEl.addEventListener('submit', () => {
       submitEl.setAttribute('disabled', '')
     })
   })

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -344,6 +344,18 @@ function configurePredicateFormOnOperatorChange(event: Event) {
   )
 }
 
+function attachFormDebouncers() {
+  Array.from(document.querySelectorAll('.cf-debounced-form')).forEach((el) => {
+    const submitEl = el.querySelector('button[type="submit"]')
+    if (!submitEl) {
+      return
+    }
+    el.addEventListener('submit', () => {
+      submitEl.setAttribute('disabled', '')
+    })
+  })
+}
+
 window.addEventListener('load', (event) => {
   attachDropdown('create-question-button')
 
@@ -411,6 +423,8 @@ window.addEventListener('load', (event) => {
   Array.from(document.querySelectorAll('.cf-enumerator-delete-button')).forEach(
     (el) => el.addEventListener('click', removeExistingEnumeratorField)
   )
+
+  attachFormDebouncers()
 
   // Advertise (e.g., for browser tests) that main.ts initialization is done
   document.body.dataset.loadMain = 'true'

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -112,6 +112,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
             .with(applicationSummary)
             .with(
                 form()
+                    .withClasses(ReferenceClasses.DEBOUNCED_FORM)
                     .withAction(submitLink)
                     .withMethod(Http.HttpVerbs.POST)
                     .with(makeCsrfTokenInputTag(params.request()))

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -13,6 +13,7 @@ public final class ReferenceClasses {
   public static final String ADMIN_QUESTION_TABLE_ROW = "cf-admin-question-table-row";
   public static final String ADMIN_TI_GROUP_ROW = "cf-ti-row";
   public static final String ADMIN_VERSION_CARD = "cf-admin-version-card";
+  public static final String DEBOUNCED_FORM = "cf-debounced-form";
   public static final String QUESTION_CONFIG = "cf-question-config";
   public static final String EDIT_PREDICATE_BUTTON = "cf-edit-predicate";
   public static final String PREDICATE_DISPLAY = "cf-display-predicate";


### PR DESCRIPTION
### Description
This change disables the submit button on the application review page for 5 seconds after it has been clicked.

See https://github.com/seattle-uat/civiform/issues/2469#issuecomment-1124077383 for rationale.

Note: A nice cleanup on the server side would also be to throw a 500 in these cases rather than creating duplicate applications. That said, we'd still want to prevent the bad data from coming in from the client-side so that the applicant doesn't see a 500.

### Issue(s)
Fixes #2469
