### PR TITLE
Don't show the skip button in Azure for required questions for file uploads

### DIFF
--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -53,6 +53,14 @@ describe('file upload applicant flow', () => {
       expect(await error.isHidden()).toEqual(true)
     })
 
+    it('does not show skip button for required question', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      expect(await pageObject.$('#fileupload-skip-button')).toBeNull()
+    })
+
     it('with valid file does submit', async () => {
       await loginAsGuest(pageObject)
       await selectApplicantLanguage(pageObject, 'English')

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -112,6 +112,10 @@ public class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
 
   @Override
   protected Optional<ContainerTag> maybeRenderSkipOrDeleteButton(Params params) {
+    if (hasAtLeastOneRequiredQuestion(params)) {
+      // If the file question is required, skip or delete is not allowed.
+      return Optional.empty();
+    }
     String buttonText = params.messages().at(MessageKey.BUTTON_SKIP_FILEUPLOAD.getKeyName());
     String buttonId = FILEUPLOAD_SKIP_BUTTON_ID;
     Optional<ContainerTag> footer = Optional.empty();


### PR DESCRIPTION
### Description
We could likely leverage some code sharing here to reduce the overall code duplication. I didn't pursue that here. We'll likely want to consider that as a separate workstream. Added a regression browser test.

### Checklist
- [X] Created tests which fail without the change (if possible)

### Issue(s)
Fixes #2472
