### PR TITLE
Update CI Github Action to use ubuntu-latest

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -25,7 +25,7 @@ jobs:
         run: python3 cloud/shared/validate_variable_definitions_test.py
 
   build_container:
-    runs-on: ubuntu-18.04 # for older version of awscli.
+    runs-on: ubuntu-latest
     steps:
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4


### PR DESCRIPTION
Checking to see if using ubuntu-latest over ubuntu-18.04 will fix the timeouts in the CI main branch.

Environment Version|Docker Version|Docker Compose Version
-|-|-
ubuntu-18.04|v20.10.15|v2.4.1
ubuntu-latest (ubuntu-20.04)|v20.10.14|v2.4.1

Yes, the latest version of ubuntu has an older build of docker.

I had similar timeouts locally that finally disappeared when I updated docker from v20.10.15 to v20.10.16 and docker-compose to v2.3.4 to v.2.5.0.