### PR TITLE
Give the cloud formation step perms to write to PR

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,6 +34,8 @@ jobs:
 
   cloudformation:
     runs-on: ubuntu-18.04 # for older version of awscli.
+    permissions:
+      pull-requests: write # to allow for mshick/add-pr-comment to add comments
     steps:
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4


### PR DESCRIPTION
[GH Permissions Docs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

The github action cloud formation job fails because it can't write to the PR after permissions were changed to read only. This give that specific job write access to pull requests.