### PR TITLE
Add aria-describedBy and aria-invalid attributes for FieldWithLabel errors.

### DIFF
--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -252,6 +252,7 @@ public class FieldWithLabel {
     if (this.id.isEmpty()) {
       this.id = RandomStringUtils.randomAlphabetic(8);
     }
+    String fieldErrorsId = String.format("%s-errors", this.id);
     if (fieldTag.getTagName().equals("textarea")) {
       // Have to recreate the field here in case the value is modified.
       ContainerTag textAreaTag = textarea().withType("text").withText(this.fieldValue);
@@ -282,6 +283,11 @@ public class FieldWithLabel {
     }
 
     boolean hasFieldErrors = !fieldErrors.isEmpty() && showFieldErrors;
+    if (hasFieldErrors) {
+      fieldTag.attr("aria-invalid", "true");
+      fieldTag.attr("aria-describedBy", fieldErrorsId);
+    }
+
     fieldTag
         .withClasses(
             StyleUtils.joinStyles(
@@ -306,7 +312,8 @@ public class FieldWithLabel {
 
     return div(
             labelTag,
-            div(fieldTag, buildFieldErrorsTag()).withClasses(Styles.FLEX, Styles.FLEX_COL))
+            div(fieldTag, buildFieldErrorsTag(fieldErrorsId))
+                .withClasses(Styles.FLEX, Styles.FLEX_COL))
         .withClasses(
             StyleUtils.joinStyles(referenceClassesBuilder.build().toArray(new String[0])),
             BaseStyles.FORM_FIELD_MARGIN_BOTTOM);
@@ -332,10 +339,11 @@ public class FieldWithLabel {
         .withText(this.labelText);
   }
 
-  private Tag buildFieldErrorsTag() {
+  private Tag buildFieldErrorsTag(String id) {
     String[] referenceClasses =
         referenceClassesBuilder.build().stream().map(ref -> ref + "-error").toArray(String[]::new);
     return div(each(fieldErrors, error -> div(error.format(messages))))
+        .withId(id)
         .withClasses(
             StyleUtils.joinStyles(referenceClasses),
             StyleUtils.joinStyles(BaseStyles.FORM_ERROR_TEXT_XS, Styles.P_1),

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -1,12 +1,20 @@
 package views.components;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static play.test.Helpers.stubMessagesApi;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import org.junit.Test;
+import play.data.validation.ValidationError;
+import play.i18n.Lang;
+import play.i18n.Messages;
 
 public class FieldWithLabelTest {
+
+  private final Messages messages =
+      stubMessagesApi().preferred(ImmutableSet.of(Lang.defaultLang()));
 
   @Test
   public void createInput_rendersInput() {
@@ -71,6 +79,28 @@ public class FieldWithLabelTest {
   public void number_setsStepAnyDefault() {
     FieldWithLabel fieldWithLabel = FieldWithLabel.number().setMax(OptionalLong.of(5L));
     assertThat(fieldWithLabel.getContainer().render()).contains("step=\"any\"");
+  }
+
+  @Test
+  public void withNoErrors_DoesNotContainAriaAttributes() {
+    FieldWithLabel fieldWithLabel = FieldWithLabel.number().setId("field-id");
+    String rendered = fieldWithLabel.getContainer().render();
+
+    assertThat(rendered).doesNotContain("aria-");
+  }
+
+  @Test
+  public void withErrors() {
+    FieldWithLabel fieldWithLabel =
+        FieldWithLabel.number()
+            .setId("field-id")
+            .setFieldErrors(messages, new ValidationError("", "an error message"));
+    String rendered = fieldWithLabel.getContainer().render();
+
+    assertThat(rendered).contains("aria-invalid=\"true\"");
+    assertThat(rendered).contains("aria-describedBy=\"field-id-errors\"");
+    assertThat(rendered).contains("id=\"field-id-errors\"");
+    assertThat(rendered).contains("an error message");
   }
 
   @Test


### PR DESCRIPTION
### Description
This pattern is described here: https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21

Before: When using VoiceOver on Mac, a field with validation errors wouldn't be announced.
After: A field with validation errors is announced as "invalid data".

### Checklist
- [X] Created tests which fail without the change (if possible)

### Issue(s)
Fixes #1878
