### PR TITLE
Make sure to map dev-oidc to a fixed port when running locally

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,10 @@ x-sbt-volumes:
     - m2-data:/root/.m2
 
 services:
+  dev-oidc:
+    ports:
+      - 3390:3390
+
   civiform:
     build: .
     volumes: *sbt-volumes


### PR DESCRIPTION
### Description
In order for your browser to access dev-oidc, it needs to expose a fixed port to the host.  Added this to the dev docker-compose overrides.

### Checklist
- [x] Ran locally

