### PR TITLE
Set authority_id for fake admins

### DIFF
--- a/server/app/auth/FakeAdminClient.java
+++ b/server/app/auth/FakeAdminClient.java
@@ -13,7 +13,7 @@ import org.pac4j.core.util.HttpActionHelper;
 
 /**
  * This class implements a special client that allows logging in without logging in to a real AD
- * account. The feature is only enabled in development environment.
+ * account. The feature is only enabled in demo mode.
  */
 public class FakeAdminClient extends IndirectClient {
 
@@ -61,7 +61,7 @@ public class FakeAdminClient extends IndirectClient {
             throw new IllegalArgumentException("no admin type provided.");
           }
           if (adminType.get().equals(GLOBAL_ADMIN)) {
-            cred.setUserProfile(profileFactory.createNewAdmin());
+            cred.setUserProfile(profileFactory.createNewFakeAdmin());
           } else if (adminType.get().equals(PROGRAM_ADMIN)) {
             cred.setUserProfile(profileFactory.createFakeProgramAdmin());
           } else if (adminType.get().equals(DUAL_ADMIN)) {

--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -7,6 +7,7 @@ import javax.inject.Provider;
 import models.Account;
 import models.ApiKey;
 import models.Applicant;
+import org.apache.commons.lang3.RandomStringUtils;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.DatabaseExecutionContext;
 import repository.VersionRepository;
@@ -45,7 +46,7 @@ public class ProfileFactory {
   }
 
   public CiviFormProfileData createNewFakeAdmin() {
-    return createNewAdmin(Optional.of(FAKE_ADMIN_AUTHORITY_ID));
+    return createNewAdmin(Optional.of(generateFakeAdminAuthorityId()));
   }
 
   public CiviFormProfileData createNewAdmin(Optional<String> maybeAuthorityId) {
@@ -117,7 +118,7 @@ public class ProfileFactory {
                   .forEach(
                       program -> account.addAdministeredProgram(program.getProgramDefinition()));
               account.setEmailAddress(String.format("fake-local-admin-%d@example.com", account.id));
-              account.setAuthorityId(FAKE_ADMIN_AUTHORITY_ID);
+              account.setAuthorityId(generateFakeAdminAuthorityId());
               account.save();
             })
         .join();
@@ -136,7 +137,7 @@ public class ProfileFactory {
         .thenAccept(
             account -> {
               account.setGlobalAdmin(true);
-              account.setAuthorityId(FAKE_ADMIN_AUTHORITY_ID);
+              account.setAuthorityId(generateFakeAdminAuthorityId());
               versionRepositoryProvider
                   .get()
                   .getActiveVersion()
@@ -148,5 +149,11 @@ public class ProfileFactory {
             })
         .join();
     return p;
+  }
+
+  private static String generateFakeAdminAuthorityId() {
+    return FAKE_ADMIN_AUTHORITY_ID
+        + "-"
+        + RandomStringUtils.random(12, /* letters= */ true, /* numbers= */ true);
   }
 }


### PR DESCRIPTION
Some features, such as creating API keys, require user profiles to have an authority_id, even in demo mode. This PR sets a randomized authority_id with the prefix "fake-admin-" so that the value is present in demo mode. The randomness is to prevent collisions when logging in repeatedly as a fake admin.