### PR TITLE
Remove number steppers for input[type='number']

### DIFF
--- a/server/app/assets/stylesheets/styles.css
+++ b/server/app/assets/stylesheets/styles.css
@@ -33,4 +33,14 @@
   .cf-accordion-visible > .cf-accordion-content {
     @apply h-auto mt-2 mb-1;
   }
+
+  /* Remove number steppers */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  input[type=number] {
+    -moz-appearance: textfield;
+  }
 }

--- a/server/app/assets/stylesheets/styles.css
+++ b/server/app/assets/stylesheets/styles.css
@@ -34,7 +34,7 @@
     @apply h-auto mt-2 mb-1;
   }
 
-  /* Remove number steppers */
+  /* Remove number steppers (https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp) */
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;


### PR DESCRIPTION
### Description
Note: This removes the steppers globally since the original concern was expressed both for applicant UI and admin-facing UI.

Before: <img width="1101" alt="Screen Shot 2022-05-23 at 10 42 07 AM" src="https://user-images.githubusercontent.com/1870301/169877043-39a36f3f-a092-413d-8ac8-51ebb94f2f79.png">
After: 
<img width="1103" alt="Screen Shot 2022-05-23 at 10 40 41 AM" src="https://user-images.githubusercontent.com/1870301/169877130-6faf3efc-43a2-448f-8d1e-0ea1ea268bf0.png">



### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1900
