### PR TITLE
Fix upload-sarif version

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -50,6 +50,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2.1.10
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
I got the version wrong in trying to pin digest hashes to version numbers.  Note this is 1 incremental version behind just to verify depend bot will do the right thing with these version numbers.
