### PR TITLE
Make DB connection pool size configurable

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -412,6 +412,7 @@ play.evolutions {
 #
 # db connections = ((physical_core_count * 2) + effective_spindle_count)
 fixedConnectionPool = 9
+fixedConnectionPool = ${?DATABASE_CONNECTION_POOL_SIZE}
 
 play.db {
   # The combination of these two settings results in "db.default" as the


### PR DESCRIPTION
Allows configuring the database connection pool size with an environment variable: DATABASE_CONNECTION_POOL_SIZE