### PR TITLE
Update link styling from light gray to action color

### DIFF
--- a/server/app/assets/stylesheets/styles.css
+++ b/server/app/assets/stylesheets/styles.css
@@ -40,7 +40,7 @@
     -webkit-appearance: none;
     margin: 0;
   }
-  input[type=number] {
+  input[type='number'] {
     -moz-appearance: textfield;
   }
 }

--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import views.style.BaseStyles;
 import views.style.Styles;
 
 /**
@@ -78,7 +79,7 @@ public class TextFormatter {
       contentBuilder.add(
           a().withText(url.getOriginalUrl())
               .withHref(url.getFullUrl())
-              .withClasses(Styles.OPACITY_75));
+              .withClasses(BaseStyles.TEXT_SEATTLE_BLUE));
       content = content.substring(index + url.getOriginalUrl().length());
     }
     // If there's content leftover, add it.

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -17,12 +17,12 @@ public class TextFormatterTest {
     assertThat(content).hasSize(4);
     assertThat(content.get(0).render()).isEqualTo(new Text("hello ").render());
     assertThat(content.get(1).render())
-        .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
+        .isEqualTo("<a href=\"http://google.com/\" class=\"text-seattle-blue\">google.com</a>");
     assertThat(content.get(2).render()).isEqualTo(new Text(" ").render());
     assertThat(content.get(3).render())
         .isEqualTo(
             "<a href=\"http://internet.website/\""
-                + " class=\"opacity-75\">http://internet.website</a>");
+                + " class=\"text-seattle-blue\">http://internet.website</a>");
   }
 
   @Test
@@ -34,13 +34,13 @@ public class TextFormatterTest {
     assertThat(content).hasSize(7);
     assertThat(content.get(0).render()).isEqualTo(new Text("Hello ").render());
     assertThat(content.get(1).render())
-        .isEqualTo("<a href=\"http://google.com/\" class=\"opacity-75\">google.com</a>");
+        .isEqualTo("<a href=\"http://google.com/\" class=\"text-seattle-blue\">google.com</a>");
     assertThat(content.get(2).render()).isEqualTo(new Text(", crawl (").render());
     assertThat(content.get(3).render())
-        .isEqualTo("<a href=\"http://seattle.gov/\" class=\"opacity-75\">http://seattle.gov/</a>");
+        .isEqualTo("<a href=\"http://seattle.gov/\" class=\"text-seattle-blue\">http://seattle.gov/</a>");
     assertThat(content.get(4).render()).isEqualTo(new Text("); and ").render());
     assertThat(content.get(5).render())
-        .isEqualTo("<a href=\"http://mysite.com/\" class=\"opacity-75\">http://mysite.com</a>");
+        .isEqualTo("<a href=\"http://mysite.com/\" class=\"text-seattle-blue\">http://mysite.com</a>");
     assertThat(content.get(6).render()).isEqualTo(new Text("...!").render());
   }
 
@@ -129,7 +129,7 @@ public class TextFormatterTest {
     // ...and a link.
     assertThat(contentStrings[2])
         .contains(
-            "<a href=\"http://epicurious.com/\"" + " class=\"opacity-75\">epicurious.com</a>");
+            "<a href=\"http://epicurious.com/\"" + " class=\"text-seattle-blue\">epicurious.com</a>");
   }
 
   @Test

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -37,10 +37,12 @@ public class TextFormatterTest {
         .isEqualTo("<a href=\"http://google.com/\" class=\"text-seattle-blue\">google.com</a>");
     assertThat(content.get(2).render()).isEqualTo(new Text(", crawl (").render());
     assertThat(content.get(3).render())
-        .isEqualTo("<a href=\"http://seattle.gov/\" class=\"text-seattle-blue\">http://seattle.gov/</a>");
+        .isEqualTo(
+            "<a href=\"http://seattle.gov/\" class=\"text-seattle-blue\">http://seattle.gov/</a>");
     assertThat(content.get(4).render()).isEqualTo(new Text("); and ").render());
     assertThat(content.get(5).render())
-        .isEqualTo("<a href=\"http://mysite.com/\" class=\"text-seattle-blue\">http://mysite.com</a>");
+        .isEqualTo(
+            "<a href=\"http://mysite.com/\" class=\"text-seattle-blue\">http://mysite.com</a>");
     assertThat(content.get(6).render()).isEqualTo(new Text("...!").render());
   }
 
@@ -129,7 +131,8 @@ public class TextFormatterTest {
     // ...and a link.
     assertThat(contentStrings[2])
         .contains(
-            "<a href=\"http://epicurious.com/\"" + " class=\"text-seattle-blue\">epicurious.com</a>");
+            "<a href=\"http://epicurious.com/\""
+                + " class=\"text-seattle-blue\">epicurious.com</a>");
   }
 
   @Test


### PR DESCRIPTION
### Description
Per #1903, light gray isn't accessible. This updates ALL links rendered through the text formatter, including links in:
  * Static question content rendered on a "screen"
  * Question text / help text
  * Program description shown in the list view for applicants

Before: 
<img width="1091" alt="Screen Shot 2022-05-23 at 5 01 57 PM" src="https://user-images.githubusercontent.com/1870301/169922944-92c99a42-795d-4631-b308-aee717098bd3.png">


After:
<img width="1121" alt="Screen Shot 2022-05-23 at 5 02 10 PM" src="https://user-images.githubusercontent.com/1870301/169922931-516478f4-f304-4ef5-8ff8-f129a95e8de4.png">


### Issue(s)
Fixes #1903
