### PR TITLE
Disabled requiring secrets to run CI tests, which should allow the tests to be run from a fork.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     secrets:
       DOCKER_HUB_ACCESS_TOKEN:
-        required: true
+        required: false
       DOCKER_HUB_USERNAME:
-        required: true
+        required: false
 
   # Setting this enables manually triggering workflow in the GitHub UI
   # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow


### PR DESCRIPTION
### Description
It looks like the browser tests can't be run from a fork because the fork doesn't have access to the right secrets. This PR disables requiring secrets to see if that fixes it.

See Slack thread: https://civiform.slack.com/archives/C01QKN2UNMA/p1653350605357309

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes Slack thread: https://civiform.slack.com/archives/C01QKN2UNMA/p1653350605357309