### PR TITLE
Order programs by the last modification date in the program admin view

### DIFF
--- a/browser-test/src/admin_program_list.test.ts
+++ b/browser-test/src/admin_program_list.test.ts
@@ -1,0 +1,53 @@
+import {
+  startSession,
+  loginAsAdmin,
+  AdminQuestions,
+  AdminPrograms,
+  endSession,
+} from './support'
+
+describe('Most recently updated program is at top of list.', () => {
+  it('sorts by last updated, preferring draft over active', async () => {
+    const { browser, page } = await startSession()
+
+    await loginAsAdmin(page)
+    const adminQuestions = new AdminQuestions(page)
+    const adminPrograms = new AdminPrograms(page)
+
+    const programOne = 'list test program one'
+    const programTwo = 'list test program two'
+    await adminPrograms.addProgram(programOne)
+    await adminPrograms.addProgram(programTwo)
+
+    // Note: CI tests already have test programs
+    // available. As such, we only assert the order
+    // of the programs added in this test.
+
+    // Most recently added program is on top.
+    let programNames = await adminPrograms.programNames()
+    expect(programNames.length).toBeGreaterThanOrEqual(2)
+    expect(programNames.slice(0, 2)).toEqual([programTwo, programOne])
+
+    // Publish all programs, order should be maintained.
+    await adminPrograms.publishAllPrograms()
+    programNames = await adminPrograms.programNames()
+    expect(programNames.length).toBeGreaterThanOrEqual(2)
+    expect(programNames.slice(0, 2)).toEqual([programTwo, programOne])
+
+    // Now create a draft version of the previously last program. After,
+    // it should be on top.
+    await adminPrograms.createNewVersion(programOne)
+    programNames = await adminPrograms.programNames()
+    expect(programNames.length).toBeGreaterThanOrEqual(2)
+    expect(programNames.slice(0, 2)).toEqual([programOne, programTwo])
+
+    // Now create a new program, which should be on top.
+    const programThree = 'list test program three'
+    await adminPrograms.addProgram(programThree)
+    programNames = await adminPrograms.programNames()
+    expect(programNames.length).toBeGreaterThanOrEqual(3)
+    expect(programNames.slice(0, 3)).toEqual([programThree, programOne, programTwo])
+
+    await endSession(browser)
+  })
+})

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -57,6 +57,12 @@ export class AdminPrograms {
     await this.expectProgramExist(programName, description)
   }
 
+  async programNames() {
+    await this.gotoAdminProgramsPage()
+    const titles = this.page.locator('.cf-admin-program-card .cf-program-title')
+    return titles.allTextContents()
+  }
+
   selectProgramCard(programName: string, lifecycle: string) {
     return `.cf-admin-program-card:has(:text("${programName}")):has(:text("${lifecycle}"))`
   }

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -1,0 +1,66 @@
+class AdminPrograms {
+  private static PROGRAM_ADIN_LIST_SELECTOR = '.cf-admin-program-card-list'
+  private static PROGRAM_CARDS_SELECTOR = '.cf-admin-program-card'
+  private static PROGRAM_CARDS_PLACEHOLDER_SELECTOR =
+    '.cf-admin-program-card-list-placeholder'
+  private static NAME_ATTRIBUTE = 'data-name'
+  private static LAST_UPDATED_MILLIS = 'data-last-updated-millis'
+
+  constructor() {
+    const cardsParent = document.querySelector(
+      AdminPrograms.PROGRAM_ADIN_LIST_SELECTOR
+    )
+    if (!cardsParent) {
+      return
+    }
+    const cardsPlaceholder = cardsParent.querySelector(
+      AdminPrograms.PROGRAM_CARDS_PLACEHOLDER_SELECTOR
+    )
+    try {
+      this.sortCards(cardsParent as HTMLElement)
+    } finally {
+      // Make sure to always show the cards, even
+      // if there was an error while sorting.
+      cardsParent.classList.remove('invisible')
+      if (cardsPlaceholder) {
+        cardsPlaceholder.classList.add('hidden')
+      }
+    }
+  }
+
+  sortCards(cardsParent: HTMLElement) {
+    const cards = Array.from(
+      cardsParent.querySelectorAll(
+        AdminPrograms.PROGRAM_CARDS_SELECTOR
+      ) as any as Array<HTMLElement>
+    )
+    cards.sort((first, second) => {
+      const firstComparator = this.comparatorObject(first)
+      const secondComparator = this.comparatorObject(second)
+
+      return (
+        secondComparator.lastUpdatedMillis -
+          firstComparator.lastUpdatedMillis ||
+        firstComparator.name.localeCompare(secondComparator.name)
+      )
+    })
+    cards.forEach((el) => {
+      // Note: Calling appendChild on this element will reuse
+      // the existing element since it's already in the DOM.
+      // This means that any attached event handlers will remain.
+      cardsParent.appendChild(el)
+    })
+  }
+
+  comparatorObject(el: HTMLElement) {
+    const lastUpdatedMillisString =
+      el.getAttribute(AdminPrograms.LAST_UPDATED_MILLIS) || ''
+    const lastUpdatedMillis = Number(lastUpdatedMillisString)
+    return {
+      name: el.getAttribute(AdminPrograms.NAME_ATTRIBUTE) || '',
+      lastUpdatedMillis,
+    }
+  }
+}
+
+window.addEventListener('load', () => new AdminPrograms())

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -14,6 +14,7 @@ import com.typesafe.config.Config;
 import controllers.admin.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
@@ -72,14 +73,19 @@ public final class ProgramIndexView extends BaseHtmlView {
                     .with(renderNewProgramButton())
                     .with(div().withClass(Styles.FLEX_GROW))
                     .condWith(programs.anyDraft(), publishAllModal.getButton()),
-                each(
-                    programs.getProgramNames(),
-                    name ->
-                        this.renderProgramListItem(
-                            programs.getActiveProgramDefinition(name),
-                            programs.getDraftProgramDefinition(name),
-                            request,
-                            profile)))
+                div()
+                    .withClasses(ReferenceClasses.ADMIN_PROGRAM_CARD_LIST, Styles.INVISIBLE)
+                    .with(
+                        p("Loading")
+                            .withClasses(ReferenceClasses.ADMIN_PROGRAM_CARD_LIST_PLACEHOLDER),
+                        each(
+                            programs.getProgramNames(),
+                            name ->
+                                this.renderProgramListItem(
+                                    programs.getActiveProgramDefinition(name),
+                                    programs.getDraftProgramDefinition(name),
+                                    request,
+                                    profile))))
             .with(renderDownloadExportCsvButton());
 
     HtmlBundle htmlBundle =
@@ -87,7 +93,8 @@ public final class ProgramIndexView extends BaseHtmlView {
             .getBundle()
             .setTitle(pageTitle)
             .addMainContent(contentDiv)
-            .addModals(publishAllModal);
+            .addModals(publishAllModal)
+            .addFooterScripts(layout.viewUtils.makeLocalJsTag("admin_programs"));
     return layout.renderCentered(htmlBundle);
   }
 
@@ -154,7 +161,11 @@ public final class ProgramIndexView extends BaseHtmlView {
                     p(programStatusText).withClasses(Styles.TEXT_SM, Styles.TEXT_GRAY_700),
                     div(programTitleText)
                         .withClasses(
-                            Styles.TEXT_BLACK, Styles.FONT_BOLD, Styles.TEXT_XL, Styles.MB_2)),
+                            ReferenceClasses.ADMIN_PROGRAM_CARD_TITLE,
+                            Styles.TEXT_BLACK,
+                            Styles.FONT_BOLD,
+                            Styles.TEXT_XL,
+                            Styles.MB_2)),
                 p().withClasses(Styles.FLEX_GROW),
                 div(p(blockCountText), p(questionCountText))
                     .withClasses(
@@ -200,7 +211,23 @@ public final class ProgramIndexView extends BaseHtmlView {
 
     return div(innerDiv)
         .withClasses(
-            ReferenceClasses.ADMIN_PROGRAM_CARD, Styles.W_FULL, Styles.SHADOW_LG, Styles.MB_4);
+            ReferenceClasses.ADMIN_PROGRAM_CARD, Styles.W_FULL, Styles.SHADOW_LG, Styles.MB_4)
+        // Add data attributes used for client-side sorting.
+        .withData(
+            "last-updated-millis",
+            Long.toString(extractLastUpdated(draftProgram, activeProgram).toEpochMilli()))
+        .withData("name", programTitleText);
+  }
+
+  private static Instant extractLastUpdated(
+      Optional<ProgramDefinition> draftProgram, Optional<ProgramDefinition> activeProgram) {
+    // Prefer when the draft was last updated, since active versions should be immutable after
+    // being published.
+    if (draftProgram.isEmpty() && activeProgram.isEmpty()) {
+      throw new IllegalArgumentException("Program neither active nor draft.");
+    }
+    ProgramDefinition program = draftProgram.isPresent() ? draftProgram.get() : activeProgram.get();
+    return program.lastModifiedTime().orElse(Instant.EPOCH);
   }
 
   private String extractProgramStatusText(

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -9,7 +9,11 @@ public final class ReferenceClasses {
   public static final String ADMIN_APPLICATION_BLOCK_CARD = "cf-admin-application-block-card";
   public static final String ADMIN_APPLICATION_CARD = "cf-admin-application-card";
   public static final String ADMIN_LANGUAGE_LINK = "cf-admin-language-link";
+  public static final String ADMIN_PROGRAM_CARD_LIST = "cf-admin-program-card-list";
+  public static final String ADMIN_PROGRAM_CARD_LIST_PLACEHOLDER =
+      "cf-admin-program-card-list-placeholder";
   public static final String ADMIN_PROGRAM_CARD = "cf-admin-program-card";
+  public static final String ADMIN_PROGRAM_CARD_TITLE = "cf-program-title";
   public static final String ADMIN_QUESTION_TABLE_ROW = "cf-admin-question-table-row";
   public static final String ADMIN_TI_GROUP_ROW = "cf-ti-row";
   public static final String ADMIN_VERSION_CARD = "cf-admin-version-card";


### PR DESCRIPTION
This is a reland of #2499, which was rolled back due to CI failures stemming from fast updates and EBean's rounding of timestamps to millisecond precision ([details](https://github.com/seattle-uat/civiform/pull/2499#issuecomment-1133325484)).

We fixed the ordering issue in #2524 by ensuring that "publish all drafts" doesn't update Program timestamps. As such, this is purely a reland without the changes `VersionRepository` / `VersionRepositoryTest`. Copying the original description for posterity.

Previously, the program list had no explicit ordering. In practice, this meant that programs were ordered based on their database ID. This meant that the most recently created programs appeared at the end of the list.

As part of #1238, we'll be updating the program list UI and potentially adding sorting options to it. This starts by applying a default sort order of last modified, hopefully helping to ensure that the most recently edited programs are at the top of the list.

Note: This sorting is done client-side per the rationale in https://github.com/seattle-uat/civiform/issues/1238#issuecomment-1127884289. The newly added admin_programs.ts file can grow to include additional sorting options as part of the work in #1238.

### Checklist
- [X] Created tests which fail without the change (if possible)

### Issue(s)
#1238; Fixes #2513