### PR TITLE
Render application submission date format consistent with other dates rendered in Admin UI

### DIFF
--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -13,7 +13,6 @@ import com.google.inject.Inject;
 import controllers.admin.routes;
 import j2html.tags.Tag;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import models.Application;
 import org.slf4j.Logger;
@@ -34,12 +33,14 @@ import views.style.Styles;
 public final class ProgramApplicationListView extends BaseHtmlView {
   private final AdminLayout layout;
   private final ApplicantUtils applicantUtils;
+  private final ZoneId zoneId;
   private final Logger log = LoggerFactory.getLogger(ProgramApplicationListView.class);
 
   @Inject
-  public ProgramApplicationListView(AdminLayout layout, ApplicantUtils applicantUtils) {
+  public ProgramApplicationListView(AdminLayout layout, ApplicantUtils applicantUtils, ZoneId zoneId) {
     this.layout = checkNotNull(layout).setOnlyProgramAdminType();
     this.applicantUtils = checkNotNull(applicantUtils);
+    this.zoneId = checkNotNull(zoneId);
   }
 
   public Content render(
@@ -133,7 +134,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
 
     Tag bottomContent =
         div(
-                p(getSubmitTime(application)).withClasses(Styles.TEXT_GRAY_700, Styles.ITALIC),
+                p(renderSubmitTime(application)).withClasses(Styles.TEXT_GRAY_700, Styles.ITALIC),
                 p().withClasses(Styles.FLEX_GROW),
                 renderViewLink(viewLinkText, application))
             .withClasses(Styles.FLEX, Styles.TEXT_SM, Styles.W_FULL);
@@ -148,13 +149,11 @@ public final class ProgramApplicationListView extends BaseHtmlView {
             ReferenceClasses.ADMIN_APPLICATION_CARD, Styles.W_FULL, Styles.SHADOW_LG, Styles.MB_4);
   }
 
-  private Tag getSubmitTime(Application application) {
+  private Tag renderSubmitTime(Application application) {
     try {
       return span()
           .withText(
-              DateTimeFormatter.RFC_1123_DATE_TIME
-                  .withZone(ZoneId.systemDefault())
-                  .format(application.getSubmitTime()));
+              renderDateTime(application.getSubmitTime(), zoneId));
     } catch (NullPointerException e) {
       log.error("Application {} submitted without submission time marked.", application.id);
       return span();

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -37,7 +37,8 @@ public final class ProgramApplicationListView extends BaseHtmlView {
   private final Logger log = LoggerFactory.getLogger(ProgramApplicationListView.class);
 
   @Inject
-  public ProgramApplicationListView(AdminLayout layout, ApplicantUtils applicantUtils, ZoneId zoneId) {
+  public ProgramApplicationListView(
+      AdminLayout layout, ApplicantUtils applicantUtils, ZoneId zoneId) {
     this.layout = checkNotNull(layout).setOnlyProgramAdminType();
     this.applicantUtils = checkNotNull(applicantUtils);
     this.zoneId = checkNotNull(zoneId);
@@ -151,9 +152,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
 
   private Tag renderSubmitTime(Application application) {
     try {
-      return span()
-          .withText(
-              renderDateTime(application.getSubmitTime(), zoneId));
+      return span().withText(renderDateTime(application.getSubmitTime(), zoneId));
     } catch (NullPointerException e) {
       log.error("Application {} submitted without submission time marked.", application.id);
       return span();


### PR DESCRIPTION
### Description
This also has the effect of rendering submission dates in the CiviForm time zone rather than UTC.

Before:
<img width="454" alt="Screen Shot 2022-05-24 at 10 48 46 AM" src="https://user-images.githubusercontent.com/1870301/170100427-c33da279-57ad-4a41-ac40-e7fd897b6aa1.png">

After:
<img width="437" alt="Screen Shot 2022-05-24 at 10 48 54 AM" src="https://user-images.githubusercontent.com/1870301/170100396-e1e71013-2f46-4cd8-a488-2197fefc945b.png">

### Issue(s)
Fixes #1905 
