### PR TITLE
Allow recording browser videos when the RECORD_VIDEO environment variable is set

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -10,6 +10,7 @@ docker run --ipc=host --rm -it \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
   -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
   -v "$(pwd)/browser-test/tmp:/usr/src/civiform-browser-tests/tmp" \
+  -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform/civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -10,6 +10,7 @@ docker::set_project_name_browser_tests
 docker run \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
   -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
+  -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform-browser-test:latest \
   /usr/src/civiform-browser-tests/bin/wait_for_server_start_and_run_tests.sh \

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -17,13 +17,29 @@ export const isLocalDevEnvironment = () => {
   )
 }
 
+function makeBrowserContext(browser: Browser) {
+  if (process.env.RECORD_VIDEO) {
+    return browser.newContext({
+      acceptDownloads: true,
+      recordVideo: {
+        dir: 'tmp/videos/',
+      },
+    })
+  } else {
+    return browser.newContext({
+      acceptDownloads: true,
+    })
+  }
+}
+
 export const startSession = async () => {
   const browser = await chromium.launch()
-  const page = await browser.newPage({ acceptDownloads: true })
+  const context = await makeBrowserContext(browser)
+  const page = await context.newPage()
 
   await page.goto(BASE_URL)
 
-  return { browser, page }
+  return { browser, context, page }
 }
 
 export const endSession = async (browser: Browser) => {

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -19,6 +19,14 @@ export const isLocalDevEnvironment = () => {
 
 function makeBrowserContext(browser: Browser) {
   if (process.env.RECORD_VIDEO) {
+    // https://playwright.dev/docs/videos
+    // Docs state that videos are only saved upon
+    // closing the returned context. In practice,
+    // this doesn't appear to be true. Restructuring
+    // to ensure that we always close the returned
+    // context is possible, but likely not necessary
+    // until it causes a problem. In practice, this
+    // will only be used when debugging failures.
     return browser.newContext({
       acceptDownloads: true,
       recordVideo: {


### PR DESCRIPTION
### Description

TL;DR - `RECORD_VIDEO=1 bin/run-browser-tests` will now record videos in the `tmp/videos/` folder for easier debugging.

This allows recording browser videos following the instructions at https://playwright.dev/docs/videos, enabling easier debugging of browser test failures. Once merged, I'll also update our [testing docs](https://docs.civiform.us/contributor-guide/developer-guide/testing#screenshots) with a similar section for this.

Presently this names each video with a random ID, so it doesn't make it easy to tie a specific video to a specific browser test case. I imagine a solution might involve restructuring how we write tests to specify a prefix for each test. Right now, I think having anything is an improvement. This is something we can iterate on if we find a solution.

Additionally, the [Playwright docs](https://playwright.dev/docs/videos) claim that the created `BrowserContext` needs to be explicitly closed. I'm not observing that in practice. Again, I imagine that this would involve a restructuring that we can iterate on should it become necessary.

Finally, I imagine we'll need to use a different directory if we want to temporarily enable this for any GitHub actions. I intend to tackle that after this CL.

Known limitations:
  * Presently, there

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Fixes #<issue_number>; Fixes #<issue_number>; Fixes #<issue_number>...
