### PR TITLE
Add a suffix for video name based on current test. Enable video recording for CI tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -72,8 +72,16 @@ jobs:
       - name: Run prober test
         run: bin/run-prober
         env:
+          RECORD_VIDEO: 1
           TEST_USER_LOGIN: ${{ secrets.TEST_USER_LOGIN }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+
+      - name: Save recorded video
+        uses: actions/upload-artifact@v3
+        with:
+          name: browser-test-videos
+          path: browser-test/tmp/videos/
+          retention-days: 1
 
   run_all_tests:
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,15 @@ jobs:
     - name: Bring up test env with Localstack
       run: bin/run-browser-test-env --aws --ci
     - name: Run browser tests with Localstack
+      env:
+          RECORD_VIDEO: 1
       run: bin/run-browser-tests-ci
+    - name: Save recorded video
+      uses: actions/upload-artifact@v3
+      with:
+        name: browser-test-videos
+        path: browser-test/tmp/videos/
+        retention-days: 5
     - name: Print logs on failure
       if: failure()
       run: cat .dockerlogs
@@ -74,6 +82,8 @@ jobs:
     - name: Bring up test env with Azurite
       run: bin/run-browser-test-env --azure --ci
     - name: Run browser tests with Azurite
+      env:
+        RECORD_VIDEO: 1
       run: bin/run-browser-tests-ci
     - name: Print logs on failure
       if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,15 +49,7 @@ jobs:
     - name: Bring up test env with Localstack
       run: bin/run-browser-test-env --aws --ci
     - name: Run browser tests with Localstack
-      env:
-          RECORD_VIDEO: 1
       run: bin/run-browser-tests-ci
-    - name: Save recorded video
-      uses: actions/upload-artifact@v3
-      with:
-        name: browser-test-videos
-        path: browser-test/tmp/videos/
-        retention-days: 5
     - name: Print logs on failure
       if: failure()
       run: cat .dockerlogs
@@ -82,8 +74,6 @@ jobs:
     - name: Bring up test env with Azurite
       run: bin/run-browser-test-env --azure --ci
     - name: Run browser tests with Azurite
-      env:
-        RECORD_VIDEO: 1
       run: bin/run-browser-tests-ci
     - name: Print logs on failure
       if: failure()

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -10,6 +10,7 @@ docker::set_project_name_browser_tests
 docker run \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
   -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
+  -v "$(pwd)/browser-test/tmp:/usr/src/civiform-browser-tests/tmp" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform-browser-test:latest \

--- a/bin/run-prober
+++ b/bin/run-prober
@@ -8,6 +8,8 @@ bin/pull-image
 docker run \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
   -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
+  -v "$(pwd)/browser-test/tmp:/usr/src/civiform-browser-tests/tmp" \
+  -e RECORD_VIDEO="${RECORD_VIDEO}" \
   -e BASE_URL="https://staging.seattle.civiform.com" \
   -e TEST_USER_LOGIN="${TEST_USER_LOGIN}" \
   -e TEST_USER_PASSWORD="${TEST_USER_PASSWORD}" \

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -27,10 +27,12 @@ function makeBrowserContext(browser: Browser) {
     // context is possible, but likely not necessary
     // until it causes a problem. In practice, this
     // will only be used when debugging failures.
+    const suffix = (global as any)['expect'] === undefined
+      ? '' : expect.getState().currentTestName
     return browser.newContext({
       acceptDownloads: true,
       recordVideo: {
-        dir: 'tmp/videos/',
+        dir: `tmp/videos/${suffix}/`,
       },
     })
   } else {


### PR DESCRIPTION
### Description
**Test names**
The current suffix is the name from the `describe` clause. In an ideal world, we'd use something like the test file name (e.g. `admin_program_list.test.ts`), but I haven't figured that out yet. We use a distinct suffix since Playwright gives each video a random UUID name by default. This helps to disambiguate which test corresponds to which video.

**Scripts / GitHub actions**
The necessary plumbing to make the browser video directory available from the container was also added to each script. While debugging our current CI failures, I temporarily enabled video recording so that we can see what's going wrong. We may want to consider enabling this by default and saving on test failure, but I'd like to get a bit more experience with this mechanism prior to doing that.

### Checklist
- [X] Temporarily enabled video recording for browser tests in PR requests (38e7da3718354541cae1d7508fa030726f12b131). Confirmed that video artifacts are produced ([actions link](https://github.com/seattle-uat/civiform/actions/runs/2387082933#artifacts):
<img width="569" alt="Screen Shot 2022-05-25 at 2 21 53 PM" src="https://user-images.githubusercontent.com/1870301/170369592-6d3ebde4-aff3-489e-90af-8656fd83599a.png">

