### PR TITLE
No longer record videos for prober runs.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -72,16 +72,8 @@ jobs:
       - name: Run prober test
         run: bin/run-prober
         env:
-          RECORD_VIDEO: 1
           TEST_USER_LOGIN: ${{ secrets.TEST_USER_LOGIN }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-
-      - name: Save recorded video
-        uses: actions/upload-artifact@v3
-        with:
-          name: browser-test-videos
-          path: browser-test/tmp/videos/
-          retention-days: 1
 
   run_all_tests:
     uses: ./.github/workflows/tests.yml


### PR DESCRIPTION
### Description
Disabling this so we don't use too much storage for our GitHub actions. We only really need one CI run in order to determine what the source of prober failures is.