### PR TITLE
Expose dev-oidc port to unblock local testing of login.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,9 @@ services:
   azurite:
      ports:
       - 10000:10000
+  dev-oidc:
+     ports:
+      - 3390:3390
 
   db:
     image: postgres:12.5


### PR DESCRIPTION
### Description
We weren't exposing the dev-oidc container's port to the host machine. This meant that the steps described in https://docs.civiform.us/contributor-guide/developer-guide/authentication-providers#testing didn't work.

While here, I also did an audit of other exposed ports from docker-compose.yml and didn't find any others that were missing. Technically, the default Postgres port of 5432 isn't exposed, but there's likely no need to connect directly to the Postgres TCP port from the host machine.

Tested (`bin/run-dev`):
  * Before - "Login" returns an unresolved host error
  * After - "Login" succeeds