### PR TITLE
Manually running CI workflow failed

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4
+        if: ${{ github.event_name == 'push' }}
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Attempted to run ci workflow manually. The trilom/file-changes-action failed because the payload was empty since it didn't come from a push action. This should now only run that step if the event is from a push.


```Run trilom/file-changes-action@v1.2.4
Error: There was an issue inferring inputs to the action.
Exception: {
  "error": "500/inferInput Error",
  "from": "inferInput",
  "message": "Received event from workflow_dispatch, but received no inputs. {event_name:workflow_dispatch, pr: NaN, before:false, after:false}",
  "payload": ""
}
(node:1516) UnhandledPromiseRejectionWarning: Error: {"error":"500/inferInput Error","from":"inferInput","message":"Received event from workflow_dispatch, but received no inputs. {event_name:workflow_dispatch, pr: NaN, before:false, after:false}","payload":""}
    at run (/home/runner/work/_actions/trilom/file-changes-action/v1.2.4/dist/index.js:1:19989)
    at Object.198 (/home/runner/work/_actions/trilom/file-changes-action/v1.2.4/dist/index.js:1:20067)
    at __webpack_require__ (/home/runner/work/_actions/trilom/file-changes-action/v1.2.4/dist/index.js:1:154)
    at startup (/home/runner/work/_actions/trilom/file-changes-action/v1.2.4/dist/index.js:1:291)
    at module.exports.0 (/home/runner/work/_actions/trilom/file-changes-action/v1.2.4/dist/index.js:1:323)
    at Object.<anonymous> (/home/runner/work/_actions/trilom/file-changes-action/v1.2.4/dist/index.js:1:333)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
(node:1516) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:1516) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.```