### PR TITLE
Adding Comment on Browser Test IDCS Login

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -98,9 +98,10 @@ export const loginAsTestUser = async (page: Page) => {
   if (isTestUser()) {
     await page.click('#idcs')
     // Wait for the IDCS login page to make sure we've followed all redirects.
-    // If running this against a site with a real idcs (i.e. staging) and this 
+    // If running this against a site with a real IDCS (i.e. staging) and this 
     // test fails with a timeout try re-running the tests. Sometimes there are 
     // just transient network hiccups that will pass on a second run.
+    // In short: If using a real IDCS retry test if this has a timeout failures
     await page.waitForURL('**/#/login*')
     await page.fill('input[name=userName]', TEST_USER_LOGIN)
     await page.fill('input[name=password]', TEST_USER_PASSWORD)

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -101,7 +101,7 @@ export const loginAsTestUser = async (page: Page) => {
     // If running this against a site with a real IDCS (i.e. staging) and this 
     // test fails with a timeout try re-running the tests. Sometimes there are 
     // just transient network hiccups that will pass on a second run.
-    // In short: If using a real IDCS retry test if this has a timeout failures
+    // In short: If using a real IDCS retry test if this has a timeout failure.
     await page.waitForURL('**/#/login*')
     await page.fill('input[name=userName]', TEST_USER_LOGIN)
     await page.fill('input[name=password]', TEST_USER_PASSWORD)

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -98,6 +98,9 @@ export const loginAsTestUser = async (page: Page) => {
   if (isTestUser()) {
     await page.click('#idcs')
     // Wait for the IDCS login page to make sure we've followed all redirects.
+    // If running this against a site with a real idcs (i.e. staging) and this 
+    // test fails with a timeout try re-running the tests. Sometimes there are 
+    // just transient network hiccups that will pass on a second run.
     await page.waitForURL('**/#/login*')
     await page.fill('input[name=userName]', TEST_USER_LOGIN)
     await page.fill('input[name=password]', TEST_USER_PASSWORD)


### PR DESCRIPTION
I had a test failure in the probers during a staging deploy likely due to a network hiccup. The IDCS login timed out waiting for the IDCS. Re-running the tests all passed. This just adds some comments to give tips if this fails.



The error:
```
Summary of all failing tests
FAIL src/application_download.test.ts (24.632 s)
  ● normal application flow › all major steps

    page.waitForURL: Timeout 4000ms exceeded.
    =========================== logs ===========================
    waiting for navigation to "**/#/login*" until "load"
    ============================================================

       99 |     await page.click('#idcs')
      100 |     // Wait for the IDCS login page to make sure we've followed all redirects.
    > 101 |     await page.waitForURL('**/#/login*')
          |                ^
      102 |     await page.fill('input[name=userName]', TEST_USER_LOGIN)
      103 |     await page.fill('input[name=password]', TEST_USER_PASSWORD)
      104 |     await page.click('button:has-text("Login"):not([disabled])')

      at src/support/index.ts:101:16
      at fulfilled (src/support/index.ts:5:58)
```