### PR TITLE
Make filtering errors in logs slightly easier

### DIFF
--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -77,7 +77,7 @@ public class ApplicantData extends CfJsonDocumentContext {
       }
       return Optional.of(firstName);
     } catch (NoSuchElementException e) {
-      logger.error("Application {} does not include an applicant name.");
+      logger.warn("Application {} does not include an applicant name. This is expected for guest users.");
       return Optional.empty();
     }
   }

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -77,7 +77,8 @@ public class ApplicantData extends CfJsonDocumentContext {
       }
       return Optional.of(firstName);
     } catch (NoSuchElementException e) {
-      logger.warn("Application {} does not include an applicant name. This is expected for guest users.");
+      logger.warn(
+          "Application {} does not include an applicant name. This is expected for guest users.");
       return Optional.empty();
     }
   }


### PR DESCRIPTION
Guest users always get this logged as an error. Lowering to warning to make it easier to filter logs and adding a note in the logged message.
