### PR TITLE
Fix form field ordering issue that breaks AWS S3 uploads.

### DIFF
--- a/server/app/views/AwsFileUploadViewStrategy.java
+++ b/server/app/views/AwsFileUploadViewStrategy.java
@@ -3,16 +3,21 @@ package views;
 import static j2html.TagCreator.input;
 
 import com.google.common.collect.ImmutableList;
+import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
+import java.util.Optional;
 import services.cloud.StorageUploadRequest;
 import services.cloud.aws.SignedS3UploadRequest;
 
 public final class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
 
   @Override
-  protected ImmutableList<Tag> extraFileUploadFields(StorageUploadRequest request) {
-    SignedS3UploadRequest signedRequest = castStorageRequest(request);
+  protected ImmutableList<Tag> fileUploadFields(Optional<StorageUploadRequest> request) {
+    if (request.isEmpty()) {
+      return ImmutableList.of();
+    }
+    SignedS3UploadRequest signedRequest = castStorageRequest(request.get());
     ImmutableList.Builder<Tag> builder = ImmutableList.builder();
     builder.add(
         input().withType("hidden").withName("key").withValue(signedRequest.key()),
@@ -39,6 +44,14 @@ public final class AwsFileUploadViewStrategy extends FileUploadViewStrategy {
               .withName("X-Amz-Security-Token")
               .withValue(signedRequest.securityToken()));
     }
+
+    // It's critical that the "file" field be the last input
+    // element for the form since S3 will ignore any fields
+    // after that. See #2653 /
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html
+    // for more context.
+    builder.add(
+        input().withType("file").withName("file").attr(Attr.ACCEPT, MIME_TYPES_IMAGES_AND_PDF));
     return builder.build();
   }
 

--- a/server/app/views/AzureFileUploadViewStrategy.java
+++ b/server/app/views/AzureFileUploadViewStrategy.java
@@ -4,7 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.input;
 
 import com.google.common.collect.ImmutableList;
+import j2html.attributes.Attr;
 import j2html.tags.Tag;
+import java.util.Optional;
 import javax.inject.Inject;
 import services.cloud.StorageUploadRequest;
 import services.cloud.azure.BlobStorageUploadRequest;
@@ -19,8 +21,11 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
   }
 
   @Override
-  protected ImmutableList<Tag> extraFileUploadFields(StorageUploadRequest request) {
-    BlobStorageUploadRequest signedRequest = castStorageRequest(request);
+  protected ImmutableList<Tag> fileUploadFields(Optional<StorageUploadRequest> request) {
+    if (request.isEmpty()) {
+      return ImmutableList.of();
+    }
+    BlobStorageUploadRequest signedRequest = castStorageRequest(request.get());
     ImmutableList.Builder<Tag> builder = ImmutableList.builder();
     builder.add(
         input().withType("hidden").withName("fileName").withValue(signedRequest.fileName()),
@@ -34,7 +39,8 @@ public final class AzureFileUploadViewStrategy extends FileUploadViewStrategy {
         input()
             .withType("hidden")
             .withName("successActionRedirect")
-            .withValue(signedRequest.successActionRedirect()));
+            .withValue(signedRequest.successActionRedirect()),
+        input().withType("file").withName("file").attr(Attr.ACCEPT, MIME_TYPES_IMAGES_AND_PDF));
     return builder.build();
   }
 

--- a/server/app/views/FileUploadViewStrategy.java
+++ b/server/app/views/FileUploadViewStrategy.java
@@ -4,7 +4,6 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.footer;
 import static j2html.TagCreator.form;
-import static j2html.TagCreator.input;
 import static j2html.attributes.Attr.ENCTYPE;
 import static j2html.attributes.Attr.FORM;
 
@@ -12,7 +11,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.routes;
 import j2html.TagCreator;
-import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
 import j2html.tags.Tag;
 import java.util.Optional;
@@ -36,7 +34,7 @@ import views.style.Styles;
  */
 public abstract class FileUploadViewStrategy extends ApplicationBaseView {
 
-  private static final String MIME_TYPES_IMAGES_AND_PDF = "image/*,.pdf";
+  protected static final String MIME_TYPES_IMAGES_AND_PDF = "image/*,.pdf";
   private static final String BLOCK_FORM_ID = "cf-block-form";
   private static final String FILEUPLOAD_CONTINUE_FORM_ID = "cf-fileupload-continue-form";
   private static final String FILEUPLOAD_DELETE_FORM_ID = "cf-fileupload-delete-form";
@@ -59,26 +57,16 @@ public abstract class FileUploadViewStrategy extends ApplicationBaseView {
             .getFilename()
             .map(f -> params.messages().at(MessageKey.INPUT_FILE_ALREADY_UPLOADED.getKeyName(), f));
 
-    ContainerTag result =
-        div()
-            .with(
-                div().withText(uploaded.orElse("")),
-                input()
-                    .withType("file")
-                    .withName("file")
-                    .attr(Attr.ACCEPT, MIME_TYPES_IMAGES_AND_PDF),
-                div(fileUploadQuestion.fileRequiredMessage().getMessage(params.messages()))
-                    .withClasses(
-                        ReferenceClasses.FILEUPLOAD_ERROR,
-                        BaseStyles.FORM_ERROR_TEXT_BASE,
-                        Styles.HIDDEN));
-    if (params.signedFileUploadRequest().isPresent()) {
-      result.with(extraFileUploadFields(params.signedFileUploadRequest().get()));
-    }
+    ContainerTag result = div().with(div().withText(uploaded.orElse("")));
+    result.with(fileUploadFields(params.signedFileUploadRequest()));
+    result.with(
+        div(fileUploadQuestion.fileRequiredMessage().getMessage(params.messages()))
+            .withClasses(
+                ReferenceClasses.FILEUPLOAD_ERROR, BaseStyles.FORM_ERROR_TEXT_BASE, Styles.HIDDEN));
     return result;
   }
 
-  protected abstract ImmutableList<Tag> extraFileUploadFields(StorageUploadRequest request);
+  protected abstract ImmutableList<Tag> fileUploadFields(Optional<StorageUploadRequest> request);
 
   /**
    * Method to render the UI for uploading a file.


### PR DESCRIPTION
### Description
We now move the input field generation into each specific provider and document that order is input for S3 (as well as the field name of "file").

### Issue(s)
Fixes #2653; #2589
