### PR TITLE
Downloading an uploaded file (for Azure) now downloads as an attachment rather than opening the content

### DIFF
--- a/browser-test/src/file.test.ts
+++ b/browser-test/src/file.test.ts
@@ -66,9 +66,12 @@ describe('file upload applicant flow', () => {
       await selectApplicantLanguage(pageObject, 'English')
 
       await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerFileUploadQuestion('file key')
+      const fileContent = 'some sample text'
+      await applicantQuestions.answerFileUploadQuestion(fileContent)
       await applicantQuestions.clickUpload()
 
+      const downloadedFileContent = await applicantQuestions.downloadSingleQuestionFromReviewPage()
+      expect(downloadpedFileContent).toEqual(fileContent)
       await applicantQuestions.submitFromReviewPage(programName)
     })
 

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright'
+import { readFileSync } from 'fs'
 import { waitForPageJsLoad } from './wait'
 
 export class ApplicantQuestions {
@@ -230,6 +231,23 @@ export class ApplicantQuestions {
       await dialog.accept()
     })
     await this.page.click(`:nth-match(:text("Remove Entity"), ${entityIndex})`)
+  }
+
+  async downloadSingleQuestionFromReviewPage() {
+    // Assert that we're on the review page.
+    expect(await this.page.innerText('h1')).toContain(
+      'Program application review'
+    )
+
+    const [downloadEvent] = await Promise.all([
+      this.page.waitForEvent('download'),
+      this.page.click('a:has-text("click to download")')
+    ])
+    const path = await downloadEvent.path()
+    if (path === null) {
+      throw new Error('download failed')
+    }
+    return readFileSync(path, 'utf8')
   }
 
   async submitFromReviewPage(programName: string) {

--- a/server/app/assets/javascripts/azure_upload.ts
+++ b/server/app/assets/javascripts/azure_upload.ts
@@ -35,6 +35,7 @@ class AzureUploadController {
     const options = {
       blobHTTPHeaders: {
         blobContentType: azureUploadProps.file.type,
+        blobContentDisposition: `attachment; filename=${azureUploadProps.file.name}`,
       },
     }
 

--- a/server/app/services/cloud/azure/BlobStorage.java
+++ b/server/app/services/cloud/azure/BlobStorage.java
@@ -135,7 +135,7 @@ public class BlobStorage implements StorageClient {
                           // and passed along, more info on the headers:
                           // https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
                           .setAllowedHeaders(
-                              "content-type,x-ms-blob-type,x-ms-client-request-id,x-ms-version,x-ms-blob-content-type")
+                              "content-type,x-ms-blob-type,x-ms-client-request-id,x-ms-version,x-ms-blob-content-type,x-ms-blob-content-disposition")
                           .setAllowedMethods("GET,PUT,OPTIONS")
                           .setMaxAgeInSeconds(500)));
       blobServiceClient.setProperties(properties);


### PR DESCRIPTION
### Description
Setting content-disposition header for Azure file uploads. This cause…s clicking 'download' to actually download the file as an attachment rather than opening the content in the browser tab.

For more context, see https://github.com/seattle-uat/civiform/issues/2656#issue-1261985761

### Checklist
- [X] Created tests which fail without the change (if possible)

### Issue(s)
Fixes #2656; #2589
