### PR TITLE
move custom domain into a module. don't do it by default

### DIFF
--- a/cloud/aws/modules/custom_domain/main.tf
+++ b/cloud/aws/modules/custom_domain/main.tf
@@ -1,10 +1,10 @@
 data "aws_route53_zone" "civiform" {
-  name         = "civiform.dev"
+  name         = var.custom_route_zone
   private_zone = false
 }
 
 resource "aws_route53_record" "civiform_domain_record" {
-  name    = "staging-aws"
+  name    = var.custom_subdomain
   zone_id = data.aws_route53_zone.civiform.zone_id
   type    = "CNAME"
   records = [aws_apprunner_custom_domain_association.civiform_domain.dns_target]
@@ -33,5 +33,5 @@ resource "aws_route53_record" "civiform_domain_validation" {
 
 resource "aws_apprunner_custom_domain_association" "civiform_domain" {
   domain_name = "staging-aws.civiform.dev"
-  service_arn = aws_apprunner_service.civiform_dev.arn
+  service_arn = var.apprunner_arn
 }

--- a/cloud/aws/modules/custom_domain/variables.tf
+++ b/cloud/aws/modules/custom_domain/variables.tf
@@ -1,13 +1,13 @@
 variable "custom_route_zone" {
-    type = string
-    description = "Route zone for Civiform (e.g. civiform.dev)"
-  
+  type        = string
+  description = "Route zone for Civiform (e.g. civiform.dev)"
+
 }
 variable "custom_subdomain" {
-    type = string
-    description = "Custom domain for Civiform (e.g. staging-aws)."
+  type        = string
+  description = "Custom domain for Civiform (e.g. staging-aws)."
 }
 variable "apprunner_arn" {
-    type = string
-    description = "ARN for apprunner instance"
+  type        = string
+  description = "ARN for apprunner instance"
 }

--- a/cloud/aws/modules/custom_domain/variables.tf
+++ b/cloud/aws/modules/custom_domain/variables.tf
@@ -1,0 +1,13 @@
+variable "custom_route_zone" {
+    type = string
+    description = "Route zone for Civiform (e.g. civiform.dev)"
+  
+}
+variable "custom_subdomain" {
+    type = string
+    description = "Custom domain for Civiform (e.g. staging-aws)."
+}
+variable "apprunner_arn" {
+    type = string
+    description = "ARN for apprunner instance"
+}


### PR DESCRIPTION
This should probably be in post_terraform step in our deploy scripts. Also depends on how the dns records are managed (current setup assumes route53 zone, which may not always be the case). 