### PR TITLE
Change gzip blacklist to whitelist using mime types

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -314,7 +314,7 @@ play.filters {
     compressionLevel = -1   # -1 is the default compression level (level 6)
     contentType {
       # If non empty, then a response will only be compressed if its content type is in this list.
-      blackList = [ "app/assets/Images/"] 
+      whiteList = [ "text/*", "application/javascript", "application/json" ]
     }
   }
 


### PR DESCRIPTION
### Description
Use mimetypes to decide which files can be gzipped, instead of blacklisting the image asset directory

Leftover change from #2612 (https://github.com/seattle-uat/civiform/pull/2612#discussion_r889610985).

