### PR TITLE
Find or create canonical questions on server start

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -8,6 +8,19 @@ import {
 } from './support'
 
 describe('normal question lifecycle', () => {
+  it('has canonical questions available by default', async () => {
+    const { browser, page } = await startSession()
+
+    await loginAsAdmin(page)
+    const adminQuestions = new AdminQuestions(page)
+
+    await adminQuestions.gotoAdminQuestionsPage()
+    await adminQuestions.expectDraftQuestionExist('Applicant Name')
+    await adminQuestions.expectDraftQuestionExist('Applicant Date of Birth')
+
+    await endSession(browser)
+  })
+
   it('create, update, publish, create a new version, and update all questions', async () => {
     const { browser, page } = await startSession()
     page.setDefaultTimeout(4000)

--- a/server/app/modules/DatabaseSeedModule.java
+++ b/server/app/modules/DatabaseSeedModule.java
@@ -1,0 +1,12 @@
+package modules;
+
+import com.google.inject.AbstractModule;
+import tasks.DatabaseSeedTask;
+
+public class DatabaseSeedModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(DatabaseSeedTask.class).asEagerSingleton();
+  }
+}

--- a/server/app/modules/DatabaseSeedModule.java
+++ b/server/app/modules/DatabaseSeedModule.java
@@ -3,6 +3,10 @@ package modules;
 import com.google.inject.AbstractModule;
 import tasks.DatabaseSeedTask;
 
+/**
+ * Binds the {@link DatabaseSeedTask} as an eager singleton, which causes it to run at server start
+ * time.
+ */
 public class DatabaseSeedModule extends AbstractModule {
 
   @Override

--- a/server/app/modules/DatabaseSeedModule.java
+++ b/server/app/modules/DatabaseSeedModule.java
@@ -1,16 +1,35 @@
 package modules;
 
+import akka.actor.ActorSystem;
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import java.time.Duration;
+import javax.inject.Provider;
+import scala.concurrent.ExecutionContext;
 import tasks.DatabaseSeedTask;
 
 /**
- * Binds the {@link DatabaseSeedTask} as an eager singleton, which causes it to run at server start
- * time.
+ * Binds the {@link DatabaseSeedScheduler} as an eager singleton, which causes it to run at server
+ * start time.
  */
 public class DatabaseSeedModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(DatabaseSeedTask.class).asEagerSingleton();
+    bind(DatabaseSeedScheduler.class).asEagerSingleton();
+  }
+
+  public static class DatabaseSeedScheduler {
+
+    @Inject
+    public DatabaseSeedScheduler(
+        ActorSystem actorSystem,
+        ExecutionContext executionContext,
+        Provider<DatabaseSeedTask> databaseSeedTaskProvider) {
+      actorSystem
+          .scheduler()
+          .scheduleOnce(
+              Duration.ofMillis(10), () -> databaseSeedTaskProvider.get().run(), executionContext);
+    }
   }
 }

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -7,9 +7,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
 import io.ebean.Database;
+import io.ebean.SqlRow;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
@@ -171,6 +173,17 @@ public class QuestionRepository {
         .sorted(Comparator.comparing(question -> question.getQuestionDefinition().getName()))
         .map(Question::getQuestionDefinition)
         .collect(ImmutableList.toImmutableList());
+  }
+
+  public ImmutableSet<String> getQuestionNames() {
+    ImmutableSet.Builder<String> names = ImmutableSet.builder();
+    List<SqlRow> rows = database.sqlQuery("SELECT DISTINCT name FROM questions").findList();
+
+    for (SqlRow row : rows) {
+      names.add(row.getString("name"));
+    }
+
+    return names.build();
   }
 
   private static class ConflictDetector {

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -7,11 +7,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.ebean.DB;
 import io.ebean.Database;
-import io.ebean.SqlRow;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
@@ -176,14 +174,13 @@ public class QuestionRepository {
   }
 
   public ImmutableSet<String> getQuestionNames() {
-    ImmutableSet.Builder<String> names = ImmutableSet.builder();
-    List<SqlRow> rows = database.sqlQuery("SELECT DISTINCT name FROM questions").findList();
+    return database.sqlQuery("SELECT DISTINCT name FROM questions").findList().stream()
+        .map((row) -> row.getString("name"))
+        .collect(ImmutableSet.toImmutableSet());
+  }
 
-    for (SqlRow row : rows) {
-      names.add(row.getString("name"));
-    }
-
-    return names.build();
+  public boolean questionExists(String questionName) {
+    return database.find(Question.class).where().eq("name", questionName).exists();
   }
 
   private static class ConflictDetector {

--- a/server/app/services/LocalizedStrings.java
+++ b/server/app/services/LocalizedStrings.java
@@ -111,6 +111,11 @@ public abstract class LocalizedStrings {
     return LocalizedStrings.create(ImmutableMap.of(k1, v1, k2, v2, k3, v3, k4, v4));
   }
 
+  /** Create localized strings with translation data from the provided map. */
+  public static LocalizedStrings of(ImmutableMap<Locale, String> translations) {
+    return LocalizedStrings.create(translations);
+  }
+
   /** Returns true if these localized strings have a translation for the locale. */
   public boolean hasTranslationFor(Locale locale) {
     return translations().containsKey(locale);

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -1,6 +1,7 @@
 package services.question;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import models.QuestionTag;
@@ -41,6 +42,9 @@ public interface QuestionService {
    * <p>NOTE: This does not update the version.
    */
   ErrorAnd<QuestionDefinition, CiviFormError> create(QuestionDefinition definition);
+
+  /** Gets all question admin names */
+  ImmutableSet<String> getQuestionNames();
 
   /**
    * Destructive overwrite of a question at a given path.

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -46,6 +46,8 @@ public interface QuestionService {
   /** Gets all question admin names */
   ImmutableSet<String> getQuestionNames();
 
+  boolean questionExists(String questionName);
+
   /**
    * Destructive overwrite of a question at a given path.
    *

--- a/server/app/services/question/QuestionServiceImpl.java
+++ b/server/app/services/question/QuestionServiceImpl.java
@@ -55,6 +55,11 @@ public final class QuestionServiceImpl implements QuestionService {
   }
 
   @Override
+  public ImmutableSet<String> getQuestionNames() {
+    return questionRepository.getQuestionNames();
+  }
+
+  @Override
   public CompletionStage<ReadOnlyQuestionService> getReadOnlyQuestionService() {
     return CompletableFuture.completedStage(
         new ReadOnlyCurrentQuestionServiceImpl(

--- a/server/app/services/question/QuestionServiceImpl.java
+++ b/server/app/services/question/QuestionServiceImpl.java
@@ -60,6 +60,11 @@ public final class QuestionServiceImpl implements QuestionService {
   }
 
   @Override
+  public boolean questionExists(String questionName) {
+    return questionRepository.questionExists(questionName);
+  }
+
+  @Override
   public CompletionStage<ReadOnlyQuestionService> getReadOnlyQuestionService() {
     return CompletableFuture.completedStage(
         new ReadOnlyCurrentQuestionServiceImpl(

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -157,6 +157,18 @@ public class QuestionDefinitionBuilder {
     return this;
   }
 
+  /**
+   * Calls {@code build} and throws a {@link RuntimeException} if the {@link QuestionType} is
+   * invalid.
+   */
+  public QuestionDefinition unsafeBuild() {
+    try {
+      return build();
+    } catch (UnsupportedQuestionTypeException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public QuestionDefinition build() throws UnsupportedQuestionTypeException {
     switch (this.questionType) {
       case ADDRESS:

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -100,7 +100,7 @@ public final class DatabaseSeedTask {
    * the database, inserting the definitions in {@code CANONICAL_QUESTIONS} if any aren't found.
    */
   private void seedCanonicalQuestions() {
-    if (!isMissingCanonicalQuestions()) {
+    if (canonicalQuestionsAlreadyPresent()) {
       return;
     }
 
@@ -165,8 +165,8 @@ public final class DatabaseSeedTask {
     }
   }
 
-  private boolean isMissingCanonicalQuestions() {
-    return !questionService
+  private boolean canonicalQuestionsAlreadyPresent() {
+    return questionService
         .getQuestionNames()
         .containsAll(
             CANONICAL_QUESTIONS.stream()

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -20,6 +20,12 @@ import services.question.types.DateQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
+/**
+ * Task for seeding the database. All of its work is done in the constructor, which is its only
+ * public method.
+ *
+ * <p>Logic for seeding different resources should be factored into separate methods for clarity.
+ */
 public final class DatabaseSeedTask {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseSeedTask.class);
@@ -64,6 +70,10 @@ public final class DatabaseSeedTask {
     seedCanonicalQuestions();
   }
 
+  /**
+   * Ensures that questions with names matching those in {@code CANONICAL_QUESTIONS} are present in
+   * the database, inserting the definitions in {@code CANONICAL_QUESTIONS} if any aren't found.
+   */
   private void seedCanonicalQuestions() {
     var questionService = questionServiceProvider.get();
 

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -10,7 +10,6 @@ import io.ebean.SerializableConflictException;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import io.ebean.annotation.TxIsolation;
-import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -24,9 +23,9 @@ import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
 import services.question.QuestionService;
-import services.question.types.DateQuestionDefinition;
-import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionType;
 
 /**
  * Task for seeding the database. All of its work is done in the constructor, which is its only
@@ -48,31 +47,39 @@ public final class DatabaseSeedTask {
   private static final int MAX_RETRIES = 10;
   private static final ImmutableList<QuestionDefinition> CANONICAL_QUESTIONS =
       ImmutableList.of(
-          new NameQuestionDefinition(
-              /* name= */ "Applicant Name",
-              /* enumeratorId= */ Optional.empty(),
-              /* description= */ "The applicant's name",
-              /* questionText= */ LocalizedStrings.of(
-                  ImmutableMap.of(
-                      Lang.forCode("am").toLocale(), "ስም (የመጀመሪያ ስም እና የመጨረሻ ስም አህጽሮት ይሆናል)",
-                      Lang.forCode("ko").toLocale(), "성함 (이름 및 성의 경우 이니셜도 괜찮음)",
-                      Lang.forCode("so").toLocale(), "Magaca (magaca koowaad iyo kan dambe okay)",
-                      Lang.forCode("tl").toLocale(),
+          new QuestionDefinitionBuilder()
+              .setQuestionType(QuestionType.NAME)
+              .setName("Applicant Name")
+              .setDescription("The applicant's name")
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("am").toLocale(),
+                          "ስም (የመጀመሪያ ስም እና የመጨረሻ ስም አህጽሮት ይሆናል)",
+                          Lang.forCode("ko").toLocale(),
+                          "성함 (이름 및 성의 경우 이니셜도 괜찮음)",
+                          Lang.forCode("so").toLocale(),
+                          "Magaca (magaca koowaad iyo kan dambe okay)",
+                          Lang.forCode("tl").toLocale(),
                           "Pangalan (unang pangalan at ang unang titik ng apilyedo ay okay)",
-                      Lang.forCode("vi").toLocale(), "Tên (tên và họ viết tắt đều được)",
-                      Lang.forCode("en-US").toLocale(), "Please enter your first and last name",
-                      Lang.forCode("es-US").toLocale(),
+                          Lang.forCode("vi").toLocale(),
+                          "Tên (tên và họ viết tắt đều được)",
+                          Lang.forCode("en-US").toLocale(),
+                          "Please enter your first and last name",
+                          Lang.forCode("es-US").toLocale(),
                           "Nombre (nombre y la inicial del apellido está bien)",
-                      Lang.forCode("zh-TW").toLocale(), "姓名（名字和姓氏第一個字母便可）")),
-              /* questionHelpText= */ LocalizedStrings.empty()),
-          new DateQuestionDefinition(
-              /* name= */ "Applicant Date of Birth",
-              /* enumeratorId= */ Optional.empty(),
-              /* description= */ "Applicant's date of birth",
-              /* questionText= */ LocalizedStrings.of(
-                  Lang.forCode("en-US").toLocale(),
-                  "Please enter your date of birth in the format mm/dd/yyyy"),
-              /* questionHelpText= */ LocalizedStrings.empty()));
+                          Lang.forCode("zh-TW").toLocale(),
+                          "姓名（名字和姓氏第一個字母便可）")))
+              .unsafeBuild(),
+          new QuestionDefinitionBuilder()
+              .setQuestionType(QuestionType.DATE)
+              .setName("Applicant Date of Birth")
+              .setDescription("Applicant's date of birth")
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Please enter your date of birth in the format mm/dd/yyyy"))
+              .unsafeBuild());
 
   private final QuestionService questionService;
   private final VersionRepository versionRepository;

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -49,13 +49,12 @@ public final class DatabaseSeedTask {
               /* questionText= */ LocalizedStrings.of(
                   Lang.forCode("en-US").toLocale(),
                   "Please enter your date of birth in the format mm/dd/yyyy"),
-              /* questionHelpText */ LocalizedStrings.empty()));
+              /* questionHelpText= */ LocalizedStrings.empty()));
 
   private final Provider<QuestionService> questionServiceProvider;
 
   @Inject
-  public DatabaseSeedTask(
-      Provider<QuestionService> questionService) {
+  public DatabaseSeedTask(Provider<QuestionService> questionService) {
     this.questionServiceProvider = checkNotNull(questionService);
 
     this.run();
@@ -72,7 +71,8 @@ public final class DatabaseSeedTask {
 
     for (QuestionDefinition questionDefinition : CANONICAL_QUESTIONS) {
       if (existingQuestionNames.contains(questionDefinition.getName())) {
-        LOGGER.info("Canonical question \"%s\" exists at server start", questionDefinition.getName());
+        LOGGER.info(
+            "Canonical question \"%s\" exists at server start", questionDefinition.getName());
         continue;
       }
 

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -28,8 +28,7 @@ import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 
 /**
- * Task for seeding the database. All of its work is done in the constructor, which is its only
- * public method.
+ * Task for seeding the database.
  *
  * <p>Logic for seeding different resources should be factored into separate methods for clarity.
  *

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -1,0 +1,109 @@
+package tasks;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import play.i18n.Lang;
+import services.CiviFormError;
+import services.ErrorAnd;
+import services.LocalizedStrings;
+import services.question.QuestionService;
+import services.question.types.DateQuestionDefinition;
+import services.question.types.NameQuestionDefinition;
+import services.question.types.QuestionDefinition;
+
+public final class DatabaseSeedTask {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseSeedTask.class);
+  private static final ImmutableList<QuestionDefinition> CANONICAL_QUESTIONS =
+      ImmutableList.of(
+          new NameQuestionDefinition(
+              /* name= */ "Applicant Name",
+              /* enumeratorId= */ Optional.empty(),
+              /* description= */ "The applicant's name",
+              /* questionText= */ LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("am").toLocale(), "ስም (የመጀመሪያ ስም እና የመጨረሻ ስም አህጽሮት ይሆናል)",
+                      Lang.forCode("ko").toLocale(), "성함 (이름 및 성의 경우 이니셜도 괜찮음)",
+                      Lang.forCode("so").toLocale(), "Magaca (magaca koowaad iyo kan dambe okay)",
+                      Lang.forCode("tl").toLocale(),
+                          "Pangalan (unang pangalan at ang unang titik ng apilyedo ay okay)",
+                      Lang.forCode("vi").toLocale(), "Tên (tên và họ viết tắt đều được)",
+                      Lang.forCode("en-US").toLocale(), "Please enter your first and last name",
+                      Lang.forCode("es-US").toLocale(),
+                          "Nombre (nombre y la inicial del apellido está bien)",
+                      Lang.forCode("zh-TW").toLocale(), "姓名（名字和姓氏第一個字母便可）")),
+              /* questionHelpText= */ LocalizedStrings.empty()),
+          new DateQuestionDefinition(
+              /* name= */ "Applicant Date of Birth",
+              /* enumeratorId= */ Optional.empty(),
+              /* description= */ "Applicant's date of birth",
+              /* questionText= */ LocalizedStrings.of(
+                  Lang.forCode("en-US").toLocale(),
+                  "Please enter your date of birth in the format mm/dd/yyyy"),
+              /* questionHelpText */ LocalizedStrings.empty()));
+
+  private final Provider<QuestionService> questionServiceProvider;
+
+  @Inject
+  public DatabaseSeedTask(
+      Provider<QuestionService> questionService) {
+    this.questionServiceProvider = checkNotNull(questionService);
+
+    this.run();
+  }
+
+  private void run() {
+    seedCanonicalQuestions();
+  }
+
+  private void seedCanonicalQuestions() {
+    var questionService = questionServiceProvider.get();
+
+    ImmutableSet<String> existingQuestionNames = getExistingQuestionNames();
+
+    for (QuestionDefinition questionDefinition : CANONICAL_QUESTIONS) {
+      if (existingQuestionNames.contains(questionDefinition.getName())) {
+        LOGGER.info("Canonical question \"%s\" exists at server start", questionDefinition.getName());
+        continue;
+      }
+
+      ErrorAnd<QuestionDefinition, CiviFormError> result =
+          questionService.create(questionDefinition);
+
+      if (result.isError()) {
+        String errorMessages =
+            result.getErrors().stream()
+                .map(CiviFormError::message)
+                .collect(Collectors.joining(", "));
+
+        LOGGER.error(
+            String.format(
+                "Unable to create canonical question \"%s\" due to %s",
+                questionDefinition.getName(), errorMessages));
+      } else {
+        LOGGER.info("Created canonical question \"%s\"", questionDefinition.getName());
+      }
+    }
+  }
+
+  private ImmutableSet<String> getExistingQuestionNames() {
+    return questionServiceProvider
+        .get()
+        .getReadOnlyQuestionService()
+        .toCompletableFuture()
+        .join()
+        .getAllQuestions()
+        .stream()
+        .map(QuestionDefinition::getName)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -144,6 +144,7 @@ play.modules {
   enabled += modules.CloudStorageModule
   enabled += modules.MainModule
   enabled += modules.FeatureFlagsModule
+  enabled += modules.DatabaseSeedModule
 
   # If there are any built-in modules that you want to disable, you can list them here.
   #disabled += ""

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -1,5 +1,9 @@
 include "application.dev.conf"
 
+play.modules {
+  disabled += modules.DatabaseSeedModule
+}
+
 db {
   default.driver = org.postgresql.Driver
   default.url = "jdbc:postgresql://db:5432/postgres"

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -1,6 +1,8 @@
 include "application.dev.conf"
 
 play.modules {
+  # Don't seed the database in test mode, many unit tests expect a completely
+  # empty empty database at setup time.
   disabled += modules.DatabaseSeedModule
 }
 

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -178,6 +178,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void questionExists_doesNotExist() {
+    assertThat(repo.questionExists("question-one")).isFalse();
+  }
+
+  @Test
   public void updateQuestion() throws UnsupportedQuestionTypeException {
     Question question = resourceCreator.insertQuestion();
     QuestionDefinition questionDefinition = question.getQuestionDefinition();

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -170,6 +170,14 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void getQuestionNames() {
+    resourceCreator.insertQuestion("question-one");
+    resourceCreator.insertQuestion("question-two");
+
+    assertThat(repo.getQuestionNames()).containsOnly("question-one", "question-two");
+  }
+
+  @Test
   public void updateQuestion() throws UnsupportedQuestionTypeException {
     Question question = resourceCreator.insertQuestion();
     QuestionDefinition questionDefinition = question.getQuestionDefinition();

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -1,0 +1,68 @@
+package tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.Set;
+import models.Question;
+import org.junit.Before;
+import org.junit.Test;
+import play.i18n.Lang;
+import repository.QuestionRepository;
+import repository.ResetPostgres;
+import services.LocalizedStrings;
+import services.question.QuestionService;
+import services.question.types.DateQuestionDefinition;
+import services.question.types.QuestionDefinition;
+
+public class DatabaseSeedTaskTest extends ResetPostgres {
+
+  private QuestionRepository questionRepository;
+
+  @Before
+  public void setUp() {
+    questionRepository = instanceOf(QuestionRepository.class);
+  }
+
+  @Test
+  public void seedCanonicalQuestions_whenQuestionsNotSeededYet_itSeedsTheCanonicalQuestions() {
+    assertThat(getAllQuestions().size()).isEqualTo(0);
+
+    instanceOf(DatabaseSeedTask.class);
+
+    assertThat(getAllQuestions().size()).isEqualTo(2);
+    assertThat(
+            getAllQuestions().stream()
+                .map(Question::getQuestionDefinition)
+                .map(QuestionDefinition::getName))
+        .containsOnly("Applicant Name", "Applicant Date of Birth");
+  }
+
+  @Test
+  public void seedCanonicalQuestions_whenSomeQuestionsAlreadySeeded_itSeedsTheMissingOnes() {
+    instanceOf(QuestionService.class)
+        .create(
+            new DateQuestionDefinition(
+                /* name= */ "Applicant Date of Birth",
+                /* enumeratorId= */ Optional.empty(),
+                /* description= */ "Applicant's date of birth",
+                /* questionText= */ LocalizedStrings.of(
+                    Lang.forCode("en-US").toLocale(),
+                    "Please enter your date of birth in the format mm/dd/yyyy"),
+                /* questionHelpText= */ LocalizedStrings.empty()));
+    assertThat(getAllQuestions().size()).isEqualTo(1);
+
+    instanceOf(DatabaseSeedTask.class);
+
+    assertThat(getAllQuestions().size()).isEqualTo(2);
+    assertThat(
+            getAllQuestions().stream()
+                .map(Question::getQuestionDefinition)
+                .map(QuestionDefinition::getName))
+        .containsOnly("Applicant Name", "Applicant Date of Birth");
+  }
+
+  private Set<Question> getAllQuestions() {
+    return questionRepository.listQuestions().toCompletableFuture().join();
+  }
+}

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -18,17 +18,20 @@ import services.question.types.QuestionDefinition;
 public class DatabaseSeedTaskTest extends ResetPostgres {
 
   private QuestionRepository questionRepository;
+  private DatabaseSeedTask databaseSeedTask;
 
   @Before
   public void setUp() {
     questionRepository = instanceOf(QuestionRepository.class);
+    databaseSeedTask = instanceOf(DatabaseSeedTask.class);
   }
 
   @Test
-  public void seedCanonicalQuestions_whenQuestionsNotSeededYet_itSeedsTheCanonicalQuestions() {
+  public void seedCanonicalQuestions_whenQuestionsNotSeededYet_itSeedsTheCanonicalQuestions()
+      throws Exception {
     assertThat(getAllQuestions().size()).isEqualTo(0);
 
-    instanceOf(DatabaseSeedTask.class);
+    databaseSeedTask.run();
 
     assertThat(getAllQuestions().size()).isEqualTo(2);
     assertThat(
@@ -52,7 +55,7 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
                 /* questionHelpText= */ LocalizedStrings.empty()));
     assertThat(getAllQuestions().size()).isEqualTo(1);
 
-    instanceOf(DatabaseSeedTask.class);
+    databaseSeedTask.run();
 
     assertThat(getAllQuestions().size()).isEqualTo(2);
     assertThat(


### PR DESCRIPTION
Binds a `DatabaseSeedTask` instance as an eager singleton, which has a constructor that implements seeding logic.

Runs the seeds in a serializable transaction and retries upon failure.

closes https://github.com/seattle-uat/civiform/issues/2484