### PR TITLE
Enable the sbt remote cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH "${PATH}:${SBT_HOME}/bin"
 ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz"
-ENV SBT_OPTS="${SBT_OPTS} -Dsbt.io.jdktimestamps=true"
 
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME server

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,23 +14,30 @@ ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH "${PATH}:${SBT_HOME}/bin"
 ENV SBT_URL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz"
-
-RUN set -o pipefail && \
-    apk update && \
-    apk add --upgrade apk-tools && \
-    apk upgrade --available && \
-    apk add --no-cache --update bash wget npm git openssh && \
-    npm install -g npm@8.5.1 && \
-    mkdir -p "${SBT_HOME}" && \
-    wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
-    echo -ne "- with sbt ${SBT_VERSION}\n" >> /root/.built
+ENV SBT_OPTS="${SBT_OPTS} -Dsbt.io.jdktimestamps=true"
 
 ENV PROJECT_HOME /usr/src
 ENV PROJECT_NAME server
+ENV PROJECT_LOC "${PROJECT_HOME}/${PROJECT_NAME}"
 
-COPY "${PROJECT_NAME}" "${PROJECT_HOME}/${PROJECT_NAME}"
+RUN set -o pipefail && \
+  apk update && \
+  apk add --upgrade apk-tools && \
+  apk upgrade --available && \
+  apk add --no-cache --update bash wget npm git openssh && \
+  npm install -g npm@8.5.1 && \
+  mkdir -p "${SBT_HOME}" && \
+  wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
+  echo -ne "- with sbt ${SBT_VERSION}\n" >> /root/.built
 
+COPY "${PROJECT_NAME}" "${PROJECT_LOC}"
 COPY entrypoint.sh /entrypoint.sh
+
+# We need to save the build assets to a seperate directory (pushRemoteCache)
+RUN cd "${PROJECT_LOC}" && \
+  npm install && \
+  sbt update && \
+  sbt compile pushRemoteCache -Dconfig.file=conf/application.dev.conf
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -7,7 +7,7 @@ source bin/lib.sh
 # Build the new development image.
 docker build \
   -t civiform-dev \
-  --cache-from civiform/civiform-browser-test:latest \
+  --cache-from civiform/civiform-dev:latest \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   .
 

--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -11,10 +11,6 @@ services:
       - node_modules-data:/usr/src/server/node_modules
       - project-data:/usr/src/server/project/project
       - project-target-data:/usr/src/server/project/target
-      - coursier-data:/root/.cache/coursier
-      - sbt-data:/root/.sbt
-      - ivy2-data:/root/.ivy2
-      - m2-data:/root/.m2
     stdin_open: true # docker run -i
     tty: true # docker run -t
     ports:
@@ -28,14 +24,6 @@ volumes:
   project-data:
     driver: local
   project-target-data:
-    driver: local
-  coursier-data:
-    driver: local
-  sbt-data:
-    driver: local
-  ivy2-data:
-    driver: local
-  m2-data:
     driver: local
   target:
     driver: local

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,7 @@ version: '3.4'
 x-sbt-volumes:
   volumes: &sbt-volumes
     - ./server:/usr/src/server
+    # Un-shadow the build directories under server.
     - target:/usr/src/server/target
     - node_modules-data:/usr/src/server/node_modules
     - project-data:/usr/src/server/project/project
@@ -81,14 +82,6 @@ volumes:
   project-data:
     driver: local
   project-target-data:
-    driver: local
-  coursier-data:
-    driver: local
-  sbt-data:
-    driver: local
-  ivy2-data:
-    driver: local
-  m2-data:
     driver: local
   target:
     driver: local

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,10 +11,6 @@ x-sbt-volumes:
     - node_modules-data:/usr/src/server/node_modules
     - project-data:/usr/src/server/project/project
     - project-target-data:/usr/src/server/project/target
-    - coursier-data:/root/.cache/coursier
-    - sbt-data:/root/.sbt
-    - ivy2-data:/root/.ivy2
-    - m2-data:/root/.m2
 
 services:
   dev-oidc:

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -125,6 +125,10 @@ lazy val root = (project in file("."))
 
     // Save build artifacts to a cache that isn't shadowed by docker.
     // https://www.scala-sbt.org/1.x/docs/Remote-Caching.html
+    // During the build step, we push build artifacts to the "build-cache" dir,
+    // which is saved in the image file by the deploy process.
+    // On later loads, we pull assets from that cache and incrementally compile,
+    // any changes, plus the dynamically generated code (autovalue and routes).
     publish / skip := true,
     Global / pushRemoteCacheTo := Some(MavenCache("local-cache", file(baseDirectory.value+"/../build-cache"))),
 

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -78,7 +78,7 @@ lazy val root = (project in file("."))
 
       // Apache libraries for export
       "org.apache.commons" % "commons-csv" % "1.9.0",
-      
+
       //pdf library for export
        "com.itextpdf" % "itextpdf" % "5.5.13.3",
 
@@ -105,7 +105,9 @@ lazy val root = (project in file("."))
       "-Werror"
     ),
     // Documented at https://github.com/sbt/zinc/blob/c18637c1b30f8ab7d1f702bb98301689ec75854b/internal/compiler-interface/src/main/contraband/incremental.contra
-    // Recompile everything if >10% files have changed
+    // Recompile everything if >30% files have changed, to help avoid infinate
+    // incremental compilation.
+    // (but still allow some incremental building for speed.)
     incOptions := incOptions.value.withRecompileAllFraction(.3),
     // After 2 transitive steps, do more aggressive invalidation
     // https://github.com/sbt/zinc/issues/911
@@ -122,6 +124,7 @@ lazy val root = (project in file("."))
     Compile / doc / sources := Seq.empty,
 
     // Save build artifacts to a cache that isn't shadowed by docker.
+    // https://www.scala-sbt.org/1.x/docs/Remote-Caching.html
     publish / skip := true,
     Global / pushRemoteCacheTo := Some(MavenCache("local-cache", file(baseDirectory.value+"/../build-cache"))),
 

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -178,6 +178,3 @@ resolveFromWebjarsNodeModulesDir := true
 playRunHooks += TailwindBuilder(baseDirectory.value)
 // Reload when the build.sbt file changes.
 Global / onChangedBuildSource := ReloadOnSourceChanges
-// uncomment to show debug logging.
-logLevel := Level.Debug
-Compile / compile / logLevel := Level.Debug

--- a/test-support/unit-test-docker-compose.dev.yml
+++ b/test-support/unit-test-docker-compose.dev.yml
@@ -8,10 +8,6 @@ services:
       - node_modules-data:/usr/src/server/node_modules
       - project-data:/usr/src/server/project/project
       - project-target-data:/usr/src/server/project/target
-      - coursier-data:/root/.cache/coursier
-      - sbt-data:/root/.sbt
-      - ivy2-data:/root/.ivy2
-      - m2-data:/root/.m2
 
 volumes:
   node_modules-data:
@@ -19,14 +15,6 @@ volumes:
   project-data:
     driver: local
   project-target-data:
-    driver: local
-  coursier-data:
-    driver: local
-  sbt-data:
-    driver: local
-  ivy2-data:
-    driver: local
-  m2-data:
     driver: local
   target:
     driver: local


### PR DESCRIPTION
### Description
Runs a full sbt compile on the docker image build, and saves the assets locally (outside of the server directory, so docker volumes don't shadow/override it).  Then on sbt load, pulls from the "remote" (really local) cache into our build directory. 

Seems to reuse ~80% of assets, and speeds up the build more than 50%

### Checklist
- [ ] Ran it locally

