### PR TITLE
Seed canonical questions before prober runs

### DIFF
--- a/browser-test/src/delete_database.ts
+++ b/browser-test/src/delete_database.ts
@@ -1,7 +1,15 @@
-import { startSession, dropTables, endSession } from './support'
+import { startSession, dropTables, endSession, seedCanonicalQuestions } from './support'
 
 module.exports = async () => {
   const { browser, page } = await startSession()
   await dropTables(page)
+
+  // If the base URL is not localhost, then this is a prober run and the
+  // canonical questions need to be seeded manually since the tests are
+  // not running immediately after a server start.
+  if (!process.env.BASE_URL.includes('localhost')) {
+    await seedCanonicalQuestions(page)
+  }
+
   await endSession(browser)
 }

--- a/browser-test/src/delete_database.ts
+++ b/browser-test/src/delete_database.ts
@@ -1,4 +1,9 @@
-import { startSession, dropTables, endSession, seedCanonicalQuestions } from './support'
+import {
+  startSession,
+  dropTables,
+  endSession,
+  seedCanonicalQuestions,
+} from './support'
 
 module.exports = async () => {
   const { browser, page } = await startSession()

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -157,6 +157,11 @@ export const dropTables = async (page: Page) => {
   await page.click('#clear')
 }
 
+export const seedCanonicalQuestions = async (page: Page) => {
+  await page.goto(BASE_URL + '/dev/seed')
+  await page.click('#canonical-questions')
+}
+
 export const closeWarningMessage = async (page: Page) => {
   // The warning message may be in the way of this link
   var element = await page.$('#warning-message-dismiss')

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -98,6 +98,7 @@ public class DatabaseSeedController extends DevController {
     if (!isDevOrStagingEnvironment()) {
       return notFound();
     }
+    databaseSeedTask.run();
     insertProgramWithBlocks("Mock program");
     return redirect(routes.DatabaseSeedController.index().url())
         .flashing("success", "The database has been seeded");

--- a/server/app/controllers/dev/DevController.java
+++ b/server/app/controllers/dev/DevController.java
@@ -21,7 +21,7 @@ public class DevController extends Controller {
     this.hostName = URI.create(baseUrl).getHost();
   }
 
-  public boolean isDevEnvironment() {
+  public boolean isDevOrStagingEnvironment() {
     if (environment.isDev()) {
       return true;
     }

--- a/server/app/views/dev/DatabaseSeedView.java
+++ b/server/app/views/dev/DatabaseSeedView.java
@@ -70,6 +70,13 @@ public class DatabaseSeedView extends BaseHtmlView {
                     .with(
                         form()
                             .with(makeCsrfTokenInputTag(request))
+                            .with(submitButton("canonical-questions", "Seed canonical questions"))
+                            .withMethod("post")
+                            .withAction(
+                                routes.DatabaseSeedController.seedCanonicalQuestions().url()))
+                    .with(
+                        form()
+                            .with(makeCsrfTokenInputTag(request))
                             .with(submitButton("clear", "Clear entire database (irreversible!)"))
                             .withMethod("post")
                             .withAction(routes.DatabaseSeedController.clear().url())))

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -164,7 +164,8 @@ GET     /loginRadiusLogin            controllers.LegacyRoutesController.loginRad
 GET     /logout                      @org.pac4j.play.LogoutController.logout(request: Request)
 
 # Methods for development: seed the database with test content to develop against, and clear the database
-GET     /dev/seed                    controllers.dev.DatabaseSeedController.index(request: Request)
-POST    /dev/seed                    controllers.dev.DatabaseSeedController.seed()
-POST    /dev/seed/clear              controllers.dev.DatabaseSeedController.clear()
+GET     /dev/seed                        controllers.dev.DatabaseSeedController.index(request: Request)
+POST    /dev/seed/canonicalQuestions     controllers.dev.DatabaseSeedController.seedCanonicalQuestions()
+POST    /dev/seed                        controllers.dev.DatabaseSeedController.seed()
+POST    /dev/seed/clear                  controllers.dev.DatabaseSeedController.clear()
 


### PR DESCRIPTION
Running probers does not cause an app restart, but it does wipe the database. As a result the canonical questions are missing since they are automatically created when missing only on server start. This change adds a controller action that runs the database seed task and updates the browser tests to do so after wiping the database.