### PR TITLE
Only run python formatter on cloud/ and bin/ dirs

### DIFF
--- a/formatter/fmt
+++ b/formatter/fmt
@@ -47,5 +47,8 @@ shfmt -bn -ci -i 2 -w -l \
 echo 'Done formatting shell'
 
 echo 'Start format python'
-yapf -i -r --no-local-style -p -vv --style='{based_on_style: google, SPLIT_BEFORE_FIRST_ARGUMENT:true}' .
+yapf -i -r -p -vv \
+  --no-local-style \
+  --style='{based_on_style: google, SPLIT_BEFORE_FIRST_ARGUMENT:true}' \
+  {cloud,bin}
 echo 'Done formatting python'


### PR DESCRIPTION
The python formatter is finding python files in dependencies, which clutters the output and takes extra time. This change restricts it to only formatting files in the `cloud/` and `bin/` directories.

```
Start format python
Reformatting ./bin/run-browser-tests-ci-batch
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/gyptest.py
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/gyp_main.py
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/PRESUBMIT.py
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/setup.py
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/samples/samples
Reformatting ./server/project/target/node-modules/webjars/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
```