### PR TITLE
Add debug button to login as TI

### DIFF
--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -91,6 +91,11 @@ export const loginAsProgramAdmin = async (page: Page) => {
   await waitForPageJsLoad(page)
 }
 
+export const loginAsTrustedIntermediary = async (page: Page) => {
+  await page.click('#trusted-intermediary')
+  await waitForPageJsLoad(page)
+}
+
 export const loginAsGuest = async (page: Page) => {
   await page.click('#guest')
   await waitForPageJsLoad(page)

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -2,11 +2,12 @@ import { Browser, Page } from 'playwright'
 import {
   startSession,
   loginAsAdmin,
+  loginAsTrustedIntermediary,
   endSession,
   AdminTIGroups,
 } from './support'
 
-describe('normal application flow', () => {
+describe('Trusted intermediaries', () => {
   let browser: Browser
   let page: Page
 
@@ -21,7 +22,7 @@ describe('normal application flow', () => {
     await endSession(browser)
   })
 
-  it('all major steps', async () => {
+  it('managing trusted intermediary groups', async () => {
     await loginAsAdmin(page)
     const adminGroups = new AdminTIGroups(page)
     await adminGroups.gotoAdminTIPage()
@@ -31,5 +32,12 @@ describe('normal application flow', () => {
     await adminGroups.editGroup('group name')
     await adminGroups.addGroupMember('foo@bar.com')
     await adminGroups.expectGroupMemberExist('<Unnamed User>', 'foo@bar.com')
+  })
+
+  it('logging in as a trusted intermediary', async () => {
+    await loginAsTrustedIntermediary(page)
+    expect(await page.innerText('#ti-dashboard-link')).toContain(
+      'Trusted intermediary dashboard'
+    )
   })
 })

--- a/server/app/auth/FakeAdminClient.java
+++ b/server/app/auth/FakeAdminClient.java
@@ -21,6 +21,7 @@ public class FakeAdminClient extends IndirectClient {
   public static final String GLOBAL_ADMIN = "GLOBAL";
   public static final String PROGRAM_ADMIN = "PROGRAM";
   public static final String DUAL_ADMIN = "DUAL";
+  public static final String TRUSTED_INTERMEDIARY = "TRUSTED_INTERMEDIARY";
 
   private ImmutableSet<String> acceptedHosts;
   private ProfileFactory profileFactory;
@@ -66,6 +67,8 @@ public class FakeAdminClient extends IndirectClient {
             cred.setUserProfile(profileFactory.createFakeProgramAdmin());
           } else if (adminType.get().equals(DUAL_ADMIN)) {
             cred.setUserProfile(profileFactory.createFakeDualAdmin());
+          } else if (adminType.get().equals(TRUSTED_INTERMEDIARY)) {
+            cred.setUserProfile(profileFactory.createFakeTrustedIntermediary());
           } else {
             throw new IllegalArgumentException(
                 String.format("admin type %s not recognized", adminType.get()));

--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -153,16 +153,16 @@ public class LoginForm extends BaseHtmlView {
     return div()
         .withClasses(Styles.ABSOLUTE)
         .with(
-            h1("DEBUG MODE: BECOME ADMIN"),
+            h1("DEBUG MODE. LOGIN AS:"),
             redirectButton(
                 "admin",
-                "Global",
+                "CiviForm Admin",
                 routes.CallbackController.fakeAdmin(
                         FakeAdminClient.CLIENT_NAME, FakeAdminClient.GLOBAL_ADMIN)
                     .url()),
             redirectButton(
                 "program-admin",
-                "Of All Active Programs",
+                "Program Admin",
                 routes.CallbackController.fakeAdmin(
                         FakeAdminClient.CLIENT_NAME, FakeAdminClient.PROGRAM_ADMIN)
                     .url()),
@@ -171,6 +171,12 @@ public class LoginForm extends BaseHtmlView {
                 "Program and Civiform Admin",
                 routes.CallbackController.fakeAdmin(
                         FakeAdminClient.CLIENT_NAME, FakeAdminClient.DUAL_ADMIN)
+                    .url()),
+            redirectButton(
+                "trusted-intermediary",
+                "Trusted Intermediary",
+                routes.CallbackController.fakeAdmin(
+                        FakeAdminClient.CLIENT_NAME, FakeAdminClient.TRUSTED_INTERMEDIARY)
                     .url()));
   }
 

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -183,6 +183,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
               .url();
       return div(
           a(tiDashboardText)
+              .withId("ti-dashboard-link")
               .withHref(tiDashboardLink)
               .withClasses(
                   Styles.PX_3,


### PR DESCRIPTION
Adds a button to the demo mode login page for logging in as a trusted intermediary. Also renames the other buttons to be more clear.

![image](https://user-images.githubusercontent.com/473671/173703447-ddcc75cf-5e6e-44a3-99d4-3b6c3e728067.png)

Should help with investigation into https://github.com/seattle-uat/civiform/pull/2722