### PR TITLE
browser tests should use the civiform-dev tag

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: Build test app container
       env:
         DOCKER_BUILDKIT: 1
-      run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+      run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
     - name: Build browser testing container
       env:
         DOCKER_BUILDKIT: 1

--- a/browser-test/browser-test-compose.dev.yml
+++ b/browser-test/browser-test-compose.dev.yml
@@ -3,8 +3,6 @@
 version: '3.4'
 services:
   civiform:
-    image: civiform-dev
-    build: .. # build the civiform-dev image.
     volumes:
       - ./server:/usr/src/server
       - target:/usr/src/server/target

--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -17,7 +17,7 @@ services:
       - 8033:3380
 
   civiform:
-    image: civiform
+    image: civiform-dev
     restart: always
     links:
       - 'db:database'


### PR DESCRIPTION
### Description
They are using the civiform-dev dockerfile, so the tag should be consistant .

### Checklist
- [x] Ran browsertests
