### PR TITLE
Fixing ci action

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -72,5 +72,5 @@ jobs:
         run: bin/build-and-push
 
   run_all_tests:
-    uses: ./.github/workflows/tests.yml
+    uses: ./.github/workflows/tests.yaml
     secrets: inherit


### PR DESCRIPTION
File name extension for tests action was recently renamed from tests.yml to tests.yaml. Updating the ci workflow to use that updated file name.