### PR TITLE
Formatter skips deleted files.

### DIFF
--- a/formatter/fmt
+++ b/formatter/fmt
@@ -9,7 +9,9 @@ cd /code
 # Gets the list of file paths for files that are tracked by git and have
 # changes relative to the main branch.
 function get_tracked_modified_files() {
-  git diff --name-only origin/main
+  # Exclude deleted files:
+  # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203
+  git diff --diff-filter=d --name-only origin/main
 }
 
 # Gets the list of file paths for files that are not tracked by git and are


### PR DESCRIPTION
### Description
Fix a bug where deleting a file caused the formatter to run on the deleted file and get a path not exists. This was discovered when running `bin/fmt` on the deleted file from #2734.

Tested locally by building a new formatter image and confirming that the deleted file from #2734 didn't cause an error.

### Issue(s)
#1743