### PR TITLE
Fixing test failing due to casing differences in the rendered output

### DIFF
--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -37,7 +37,7 @@ describe('Trusted intermediaries', () => {
   it('logging in as a trusted intermediary', async () => {
     await loginAsTrustedIntermediary(page)
     expect(await page.innerText('#ti-dashboard-link')).toContain(
-      'Trusted intermediary dashboard'
+      'TRUSTED INTERMEDIARY DASHBOARD'
     )
   })
 })


### PR DESCRIPTION
Fixing test failing due to casing differences in the rendered output