### PR TITLE
Browser tests batch script doesn't fail if the subprocess fails

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,7 @@ jobs:
 
   run_browser_tests_aws:
     strategy:
+      fail-fast: false
       matrix:
         batch_number: [1, 2, 3, 4]
     runs-on: ubuntu-latest
@@ -64,6 +65,7 @@ jobs:
 
   run_browser_tests_azure:
     strategy:
+      fail-fast: false
       matrix:
         batch_number: [1, 2, 3, 4]
     runs-on: ubuntu-latest

--- a/bin/run-browser-tests-ci-batch
+++ b/bin/run-browser-tests-ci-batch
@@ -41,4 +41,4 @@ for item in batch_contents:
 
 shell_command = ["./bin/run-browser-tests-ci"] + batch_contents
 
-subprocess.run(shell_command)
+subprocess.run(shell_command, check=True)

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -27,4 +27,8 @@ describe('applicant security', () => {
 
     await endSession(browser)
   })
+  
+  it('test batch scripts fails', async () => {
+    expect("a").toBe("b")
+  })
 })

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -27,8 +27,4 @@ describe('applicant security', () => {
 
     await endSession(browser)
   })
-  
-  it('test batch scripts fails', async () => {
-    expect("a").toBe("b")
-  })
 })


### PR DESCRIPTION
The ci browser tests batch script is failing silently. The python script always returns 0 so it doesn't trigger the failure on the github action step.

[Example](https://github.com/seattle-uat/civiform/runs/6905881953) see "run_all_tests / run_browser_tests_aws (4)"

[Python docs](https://docs.python.org/3/library/subprocess.html) indicate that the check parameter will cause the subprocess to throw an exception if the exit code is not 0 which in turn has the main process fail with exit code 1.

