### PR TITLE
Fixing pagination rendering when there are no pages (previously was "Page 1 of 0")

### DIFF
--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -99,8 +99,10 @@ public abstract class BaseHtmlView {
       div.with(
           new LinkElement().setText("←").setHref(linkForPage.apply(page - 1).url()).asButton());
     }
+    String paginationText =
+        pageCount > 0 ? String.format("Page %d of %d", page, pageCount) : "No results";
     div.with(
-        div("Page " + page + " of " + pageCount)
+        div(paginationText)
             .withClasses(
                 Styles.LEADING_3, Styles.FLOAT_LEFT, Styles.INLINE_BLOCK, Styles.P_2, Styles.M_4));
     if (pageCount > page) {


### PR DESCRIPTION
### Description
Noticed this while investigating adding date filtering to the existing Program Admin applications view. I could also see a case for rendering "Page 0 of 0" and rendering "No results" further down. If there's a strong preference, I can convert to that.

Also, I looked into making the buttons show as disabled when there were no results since they currently give the illusion that clicking them will do something. I didn't pursue that since the styles being used are "private" to LinkElement and I didn't have a good sense of how / where we'd want to break those out. As it stands, this currently seems like a small usability improvement.

Before:
![Screen Shot 2022-06-16 at 4 11 27 PM](https://user-images.githubusercontent.com/1870301/174193378-ecee98cc-a134-4705-9eb2-cf7723d6634a.png)

After: 
![Screen Shot 2022-06-16 at 4 11 11 PM](https://user-images.githubusercontent.com/1870301/174193355-89fd115c-a16c-4631-9cec-1011df2f000b.png)

### Issue(s)
#1743