### PR TITLE
Fix local browser tests

### DIFF
--- a/browser-test/src/application_download.test.ts
+++ b/browser-test/src/application_download.test.ts
@@ -1,5 +1,7 @@
 import {
   startSession,
+  seedCanonicalQuestions,
+  dropTables,
   logout,
   loginAsTestUser,
   loginAsGuest,
@@ -14,6 +16,13 @@ import {
 } from './support'
 
 describe('normal application flow', () => {
+
+  beforeAll(async () => {
+    const { page } = await startSession()
+    await dropTables(page)
+    await seedCanonicalQuestions(page)
+  })
+
   it('all major steps', async () => {
     const { browser, page } = await startSession()
     // Timeout for clicks and element fills. If your selector fails to locate

--- a/browser-test/src/delete_database.ts
+++ b/browser-test/src/delete_database.ts
@@ -8,13 +8,7 @@ import {
 module.exports = async () => {
   const { browser, page } = await startSession()
   await dropTables(page)
-
-  // If the base URL is not localhost, then this is a prober run and the
-  // canonical questions need to be seeded manually since the tests are
-  // not running immediately after a server start.
-  if (!process.env.BASE_URL.includes('localhost')) {
-    await seedCanonicalQuestions(page)
-  }
+  await seedCanonicalQuestions(page)
 
   await endSession(browser)
 }

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -1,16 +1,25 @@
+import { Browser, Page } from 'playwright'
 import {
   startSession,
   loginAsAdmin,
   AdminQuestions,
   AdminPrograms,
   endSession,
+  dropTables,
+  seedCanonicalQuestions,
   waitForPageJsLoad,
 } from './support'
 
 describe('normal question lifecycle', () => {
+
+  beforeAll(async () => {
+    const { page } = await startSession()
+    await dropTables(page)
+    await seedCanonicalQuestions(page)
+  })
+
   it('has canonical questions available by default', async () => {
     const { browser, page } = await startSession()
-
     await loginAsAdmin(page)
     const adminQuestions = new AdminQuestions(page)
 


### PR DESCRIPTION
### Description
Apparently [dropTables](https://github.com/seattle-uat/civiform/blob/main/browser-test/jest.config.js#L7)  is only being run once at the beginning of the test suite, and it seems that messes up `question_lifecycle.test.ts` and `application_download.test.ts` when the whole test suite is run so I added dropTables before both and got a passing test run locally

### Checklist
- [x] Get a passing run of local browser tests
- [ ] Maybe dropTables before every test?