### PR TITLE
Use a singleton instance of Slugify

### DIFF
--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import annotations.BindingAnnotations.EnUsLang;
 import annotations.BindingAnnotations.Now;
+import com.github.slugify.Slugify;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -30,6 +31,8 @@ import services.question.QuestionServiceImpl;
  * `application.conf` configuration file.
  */
 public class MainModule extends AbstractModule {
+
+  public static final Slugify SLUGIFIER = Slugify.builder().build();
 
   @Override
   public void configure() {

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -2,7 +2,6 @@ package services.program;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
-import com.github.slugify.Slugify;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -23,6 +22,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import models.DisplayMode;
 import models.Program;
+import modules.MainModule;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
@@ -426,7 +426,7 @@ public abstract class ProgramDefinition {
   }
 
   public String slug() {
-    return Slugify.builder().build().slugify(this.adminName());
+    return MainModule.SLUGIFIER.slugify(this.adminName());
   }
 
   public int getQuestionCount() {

--- a/server/app/services/program/ProgramServiceImpl.java
+++ b/server/app/services/program/ProgramServiceImpl.java
@@ -21,6 +21,7 @@ import models.Application;
 import models.DisplayMode;
 import models.Program;
 import models.Version;
+import modules.MainModule;
 import play.db.ebean.Transactional;
 import play.libs.F;
 import play.libs.concurrent.HttpExecutionContext;
@@ -41,7 +42,6 @@ import services.question.types.QuestionDefinition;
 /** Implementation class for {@link ProgramService} interface. */
 public class ProgramServiceImpl implements ProgramService {
 
-  private final Slugify slugifier = Slugify.builder().build();
   private final ProgramRepository programRepository;
   private final QuestionService questionService;
   private final HttpExecutionContext httpExecutionContext;
@@ -129,7 +129,7 @@ public class ProgramServiceImpl implements ProgramService {
   @Override
   public ImmutableSet<String> getAllProgramSlugs() {
     return getAllProgramNames().stream()
-        .map(slugifier::slugify)
+        .map(MainModule.SLUGIFIER::slugify)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/server/app/views/admin/apikeys/ApiKeyIndexView.java
+++ b/server/app/views/admin/apikeys/ApiKeyIndexView.java
@@ -13,13 +13,13 @@ import static j2html.TagCreator.th;
 import static j2html.TagCreator.tr;
 
 import auth.ApiKeyGrants;
-import com.github.slugify.Slugify;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import j2html.tags.ContainerTag;
 import java.util.function.Function;
 import models.ApiKey;
+import modules.MainModule;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import services.DateConverter;
@@ -37,7 +37,6 @@ import views.style.Styles;
 public final class ApiKeyIndexView extends BaseHtmlView {
   private final AdminLayout layout;
   private final DateConverter dateConverter;
-  private final Slugify slugifier = Slugify.builder().build();
 
   @Inject
   public ApiKeyIndexView(AdminLayoutFactory layoutFactory, DateConverter dateConverter) {
@@ -101,7 +100,7 @@ public final class ApiKeyIndexView extends BaseHtmlView {
                       + apiKey.getName()
                       + "?')")
               .setText("Retire key")
-              .setId(String.format("retire-%s", slugifier.slugify(apiKey.getName())))
+              .setId(String.format("retire-%s", MainModule.SLUGIFIER.slugify(apiKey.getName())))
               .asHiddenForm(request));
     }
 
@@ -160,6 +159,6 @@ public final class ApiKeyIndexView extends BaseHtmlView {
 
   private ImmutableMap<String, String> buildProgramSlugToName(ImmutableSet<String> programNames) {
     return programNames.stream()
-        .collect(ImmutableMap.toImmutableMap(slugifier::slugify, Function.identity()));
+        .collect(ImmutableMap.toImmutableMap(MainModule.SLUGIFIER::slugify, Function.identity()));
   }
 }

--- a/server/app/views/admin/apikeys/ApiKeyNewOneView.java
+++ b/server/app/views/admin/apikeys/ApiKeyNewOneView.java
@@ -9,7 +9,6 @@ import static j2html.TagCreator.p;
 import static j2html.TagCreator.text;
 
 import annotations.BindingAnnotations.EnUsLang;
-import com.github.slugify.Slugify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -17,6 +16,7 @@ import controllers.admin.routes;
 import j2html.tags.ContainerTag;
 import j2html.tags.DomContent;
 import java.util.Optional;
+import modules.MainModule;
 import play.data.DynamicForm;
 import play.i18n.Messages;
 import play.mvc.Http.Request;
@@ -35,7 +35,6 @@ import views.style.Styles;
 public final class ApiKeyNewOneView extends BaseHtmlView {
   private final AdminLayout layout;
   private final Messages enUsMessages;
-  private final Slugify slugifier = Slugify.builder().build();
 
   private static final String EXPIRATION_DESCRIPTION =
       "Specify a date when this API key will no longer be valid. The expiration date"
@@ -119,7 +118,7 @@ public final class ApiKeyNewOneView extends BaseHtmlView {
           FieldWithLabel.checkbox()
               .setFieldName(programReadGrantFieldName(name))
               .setLabelText(name)
-              .setId(slugifier.slugify(name))
+              .setId(MainModule.SLUGIFIER.slugify(name))
               .setValue("true")
               .getContainer());
     }
@@ -139,7 +138,7 @@ public final class ApiKeyNewOneView extends BaseHtmlView {
   }
 
   private String programReadGrantFieldName(String name) {
-    return "grant-program-read[" + slugifier.slugify(name) + "]";
+    return "grant-program-read[" + MainModule.SLUGIFIER.slugify(name) + "]";
   }
 
   private FieldWithLabel setStateIfPresent(


### PR DESCRIPTION
We instantiate `Slugify` in several places around the code base. This is a little cumbersome since it no longer allows constructing with `new`. Sharing an instance reduces code complexity slightly and also suggests to the reader that slugify logic must be consistent across the application.