### PR TITLE
Attempt to use local images within CI so that pull-images doesn't overwrite them

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -81,11 +81,11 @@ jobs:
             civiform/formatter:latest
       - name: Run Browsertest formatter
         if: contains(toJSON(steps.file_changes.outputs.files), 'browser-test/') || contains(toJSON(steps.file_changes.outputs.files), '.github/workflows/format.yaml')
-        run: USE_LOCAL_CIVIFORM=true browser-test/bin/fmt
+        run: browser-test/bin/fmt
       - name: show Browsertest diff
         run: git add .; git diff --exit-code HEAD
       - name: run bin/fmt
-        run: USE_LOCAL_CIVIFORM=true bin/fmt
+        run: bin/fmt
       - name: show bin/fmt diff
         run: git add .; git diff --exit-code HEAD
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,11 +50,11 @@ jobs:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: bin/build-browser-tests
+        run: USE_LOCAL_CIVIFORM=1 bin/build-browser-tests
       - name: Bring up test env with Localstack
-        run: bin/run-browser-test-env --aws --ci
+        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-test-env --aws --ci
       - name: Run browser tests with Localstack
-        run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
+        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs
@@ -79,11 +79,11 @@ jobs:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: bin/build-browser-tests
+        run: USE_LOCAL_CIVIFORM=1 bin/build-browser-tests
       - name: Bring up test env with Azurite
-        run: bin/run-browser-test-env --azure --ci
+        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-test-env --azure --ci
       - name: Run browser tests with Azurite
-        run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
+        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
       - name: Run tests
-        run: USE_LOCAL_CIVIFORM=true bin/run-test-ci
+        run: bin/run-test-ci
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -50,11 +50,11 @@ jobs:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: USE_LOCAL_CIVIFORM=1 bin/build-browser-tests
+        run: bin/build-browser-tests
       - name: Bring up test env with Localstack
-        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-test-env --aws --ci
+        run: bin/run-browser-test-env --aws --ci
       - name: Run browser tests with Localstack
-        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
+        run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs
@@ -79,11 +79,11 @@ jobs:
           DOCKER_BUILDKIT: 1
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: USE_LOCAL_CIVIFORM=1 bin/build-browser-tests
+        run: bin/build-browser-tests
       - name: Bring up test env with Azurite
-        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-test-env --azure --ci
+        run: bin/run-browser-test-env --azure --ci
       - name: Run browser tests with Azurite
-        run: USE_LOCAL_CIVIFORM=1 bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
+        run: bin/run-browser-tests-ci-batch ${{ matrix.batch_number }}
       - name: Print logs on failure
         if: failure()
         run: cat .dockerlogs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Build test app container
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t civiform --cache-from docker.io/civiform/civiform:latest ./
+        run: docker build -t civiform-dev --cache-from docker.io/civiform/civiform-dev:latest ./
       - name: Build browser testing container
         env:
           DOCKER_BUILDKIT: 1

--- a/bin/fmt-sbt
+++ b/bin/fmt-sbt
@@ -11,6 +11,8 @@ bin/pull-image --dev
 interactive_flag="-T"
 if [[ -n "${CI}" ]]; then
   interactive_flag=""
+  docker pull -q docker.io/civiform/civiform-dev:latest
+  docker tag civiform/civiform-dev:latest civiform-dev
 fi
 
 docker::run_shell_container

--- a/bin/fmt-sbt
+++ b/bin/fmt-sbt
@@ -11,6 +11,9 @@ bin/pull-image --dev
 interactive_flag="-T"
 if [[ -n "${CI}" ]]; then
   interactive_flag=""
+  # We manually pull the dev image here since bin/pull-image
+  # is disabled in CI mode. We need the dev image in order
+  # to run the SBT shell.
   docker pull -q docker.io/civiform/civiform-dev:latest
   docker tag civiform/civiform-dev:latest civiform-dev
 fi

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -1,7 +1,8 @@
 #! /usr/bin/env bash
 
 # DOC: Pull the latest development environment docker image from Docker Hub
-# DOC: unless USE_LOCAL_CIVIFORM is set. May specify what to pull with a flag
+# DOC: unless USE_LOCAL_CIVIFORM or CI (set in GitHub actions) is set. May
+# DOC: specify what to pull with a flag
 # DOC: e.g. "--formatter", "--localstack", or "--all" (the default).
 # DOC: If multiple flags are passed, all but the first will be ignored.
 
@@ -12,8 +13,13 @@ if [[ -n "${USE_LOCAL_CIVIFORM}" ]]; then
   exit 0
 fi
 
+if [[ -n "${CI}" ]]; then
+  echo "Using local civiform and dependency docker images"
+  exit 0
+fi
+
 echo "Making sure we're up to date with the latest dev... " \
-  "set environment variable USE_LOCAL_CIVIFORM=1 to skip"
+  "set environment variable USE_LOCAL_CIVIFORM=1 / CI=true to skip"
 
 function pull_all() {
   echo "Pull all docker images"

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -106,7 +106,7 @@ if truth::is_disabled continuous_integration; then
   truth::enable use_dev
 fi
 
-echo "Running docker compose to remove existing contianers."
+echo "Running docker compose to remove existing containers."
 compose_browser_test "${use_dev}" --profile ${cloud_provider} down
 
 # Start emulator.
@@ -117,14 +117,19 @@ compose_browser_test "${use_dev}" --profile ${cloud_provider} up -d ${emulator}
 echo "Waiting for the cloud emulator"
 "bin/${emulator}/wait" "${emulator_url}"
 
+# The --no-recreate option is particularly important for CI scenarios
+# where localstack may be recreated due to the additional time involved
+# in pulling images.
+# See https://github.com/seattle-uat/civiform/issues/2810#issuecomment-1168993637
+
 # localstack emulator is also required for Azurite. This should only run for
 # Azure browser tests.
 if truth::is_enabled both_emulators; then
   echo "Starting localstack emulator as well"
   if truth::is_enabled continuous_integration; then
-    compose_browser_test "${use_dev}" --profile aws up -d localstack >.dockerlogs 2>&1 &
+    compose_browser_test "${use_dev}" --profile aws up --no-recreate -d localstack >.dockerlogs 2>&1 &
   else
-    compose_browser_test "${use_dev}" --profile aws up -d localstack
+    compose_browser_test "${use_dev}" --profile aws up --no-recreate -d localstack
   fi
 fi
 

--- a/bin/run-browser-test-env
+++ b/bin/run-browser-test-env
@@ -106,6 +106,9 @@ if truth::is_disabled continuous_integration; then
   truth::enable use_dev
 fi
 
+echo "Running docker compose to remove existing contianers."
+compose_browser_test "${use_dev}" --profile ${cloud_provider} down
+
 # Start emulator.
 echo "Running docker compose to start the cloud emulator"
 compose_browser_test "${use_dev}" --profile ${cloud_provider} up -d ${emulator}
@@ -117,7 +120,7 @@ echo "Waiting for the cloud emulator"
 # localstack emulator is also required for Azurite. This should only run for
 # Azure browser tests.
 if truth::is_enabled both_emulators; then
-  echo "Staring localstack emulator as well"
+  echo "Starting localstack emulator as well"
   if truth::is_enabled continuous_integration; then
     compose_browser_test "${use_dev}" --profile aws up -d localstack >.dockerlogs 2>&1 &
   else
@@ -128,7 +131,7 @@ fi
 # Start everything else.
 echo "Running docker compose to start the CiviForm environment:"
 if truth::is_enabled continuous_integration; then
-  compose_browser_test "${use_dev}" --profile ${cloud_provider} up >.dockerlogs 2>&1 &
+  compose_browser_test "${use_dev}" --profile ${cloud_provider} up --no-recreate >.dockerlogs 2>&1 &
 else
-  compose_browser_test "${use_dev}" --profile ${cloud_provider} up
+  compose_browser_test "${use_dev}" --profile ${cloud_provider} up --no-recreate
 fi


### PR DESCRIPTION
### Description
See #2810 for detailed description / motivation behind --force-recreate.

At a high-level, this:
  * Skips calling `bin/pull-image` in CI mode since that script unsafely overwrites locally built tags (such as the `civiform-dev` image)
  * Removes setting the `USE_LOCAL_CIVIFORM` env variable in GitHub actions since the `bin/pull-image` change will cause that behavior to occur automatically
  * Fixes long-standing issue where the timing change associated with pulling images on demand when running docker compose caused `localstack` to be restarted, losing the associated bucket state ([detailed description](https://github.com/seattle-uat/civiform/issues/2810#issuecomment-1168993637)).

### Issue(s)

Fixes #2810