### PR TITLE
Make SVG icons into an enum rather than const. Also add /dev/icons view to determine the size of each icon.

### DIFF
--- a/server/app/assets/javascripts/dev_icons.ts
+++ b/server/app/assets/javascripts/dev_icons.ts
@@ -1,3 +1,5 @@
+/** This handler is responsible for annotating each rendered SVG icon
+ * with its size as calculated by the browser.  */
 window.addEventListener('load', () => {
   Array.from(document.querySelectorAll('tr')).forEach((rowEl) => {
     const svgEl = rowEl.querySelector('svg')

--- a/server/app/assets/javascripts/dev_icons.ts
+++ b/server/app/assets/javascripts/dev_icons.ts
@@ -1,0 +1,11 @@
+window.addEventListener('load', () => {
+  Array.from(document.querySelectorAll('tr')).forEach((rowEl) => {
+    const svgEl = rowEl.querySelector('svg')
+    if (!svgEl) {
+      return
+    }
+    const bbox = svgEl.getBBox()
+    rowEl.querySelectorAll('p')[0].textContent = `${bbox.x + bbox.width}`
+    rowEl.querySelectorAll('p')[1].textContent = `${bbox.y + bbox.height}`
+  })
+})

--- a/server/app/assets/javascripts/dev_icons.ts
+++ b/server/app/assets/javascripts/dev_icons.ts
@@ -5,7 +5,7 @@ window.addEventListener('load', () => {
       return
     }
     const bbox = svgEl.getBBox()
-    rowEl.querySelectorAll('p')[0].textContent = `${bbox.x + bbox.width}`
-    rowEl.querySelectorAll('p')[1].textContent = `${bbox.y + bbox.height}`
+    rowEl.querySelector('.icon-width')!.textContent = `${bbox.x + bbox.width}`
+    rowEl.querySelector('.icon-height')!.textContent = `${bbox.y + bbox.height}`
   })
 })

--- a/server/app/controllers/dev/IconsController.java
+++ b/server/app/controllers/dev/IconsController.java
@@ -1,0 +1,27 @@
+package controllers.dev;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.inject.Inject;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.mvc.Result;
+import views.dev.IconsView;
+
+public final class IconsController extends DevController {
+
+  private final IconsView iconsView;
+
+  @Inject
+  public IconsController(IconsView iconsView, Environment environment, Config configuration) {
+    super(environment, configuration);
+    this.iconsView = checkNotNull(iconsView);
+  }
+
+  public Result index() {
+    if (!isDevOrStagingEnvironment()) {
+      return notFound();
+    }
+    return ok(iconsView.render());
+  }
+}

--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -74,8 +74,7 @@ public abstract class BaseHtmlView {
   protected static ContainerTag makeSvgTextButton(String buttonText, Icons icon) {
     return TagCreator.button()
         .with(
-            Icons.svg(icon, 18)
-                .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0),
+            Icons.svg(icon, 18).withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0),
             span(buttonText).withClass(Styles.TEXT_LEFT));
   }
 

--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -71,10 +71,10 @@ public abstract class BaseHtmlView {
     return buttonEl.attr("onclick", String.format("window.location = '%s';", redirectUrl));
   }
 
-  protected static ContainerTag makeSvgTextButton(String buttonText, String svgPath) {
+  protected static ContainerTag makeSvgTextButton(String buttonText, Icons icon) {
     return TagCreator.button()
         .with(
-            Icons.svg(svgPath, 18).withClasses(Styles.ML_1, Styles.MR_2, Styles.INLINE_BLOCK),
+            Icons.svg(icon, 18).withClasses(Styles.ML_1, Styles.MR_2, Styles.INLINE_BLOCK),
             span(buttonText));
   }
 

--- a/server/app/views/admin/programs/ProgramIndexViewV2.java
+++ b/server/app/views/admin/programs/ProgramIndexViewV2.java
@@ -104,14 +104,14 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
   private Tag renderDownloadExportCsvButton() {
     String link = routes.AdminApplicationController.downloadDemographics().url();
     ContainerTag button =
-        makeSvgTextButton("Download Exported Data (CSV)", Icons.DOWNLOAD_SVG_PATH)
+        makeSvgTextButton("Download Exported Data (CSV)", Icons.DOWNLOAD)
             .withId("download-export-csv-button")
             .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, Styles.MY_2);
     return asRedirectButton(button, link);
   }
 
   private ContainerTag makePublishButton() {
-    return makeSvgTextButton("Publish all drafts", Icons.PUBLISH_SVG_PATH)
+    return makeSvgTextButton("Publish all drafts", Icons.PUBLISH)
         .withId("publish-programs-button")
         .withClasses(AdminStyles.PRIMARY_BUTTON_STYLES, Styles.MY_2);
   }
@@ -141,7 +141,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
   private Tag renderNewProgramButton() {
     String link = controllers.admin.routes.AdminProgramController.newOne().url();
     ContainerTag button =
-        makeSvgTextButton("Create new program", Icons.ADD_SVG_PATH)
+        makeSvgTextButton("Create new program", Icons.ADD)
             .withId("new-program-button")
             .withClasses(AdminStyles.SECONDARY_BUTTON_STYLES, Styles.MY_2);
     return asRedirectButton(button, link);
@@ -183,7 +183,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
 
     String extraActionsButtonId = "extra-actions-" + program.id();
     ContainerTag extraActionsButton =
-        makeSvgTextButton("", Icons.MORE_VERT_PATH)
+        makeSvgTextButton("", Icons.MORE_VERT)
             .withId(extraActionsButtonId)
             .withClasses(
                 AdminStyles.TERTIARY_BUTTON_STYLES,
@@ -213,7 +213,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
                     Styles.JUSTIFY_CENTER)
                 .withStyle("min-width:90px")
                 .with(
-                    Icons.svg(Icons.NOISE_CONTROL_OFF_SVG_PATH, 20)
+                    Icons.svg(Icons.NOISE_CONTROL_OFF, 20)
                         .withClasses(Styles.INLINE_BLOCK, Styles.ML_3_5),
                     span(badgeText).withClass(Styles.MR_4)),
             div()
@@ -362,7 +362,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
     String programLink =
         baseUrl
             + controllers.applicant.routes.RedirectController.programByName(program.slug()).url();
-    return makeSvgTextButton("Share link", Icons.CONTENT_COPY_SVG_PATH)
+    return makeSvgTextButton("Share link", Icons.CONTENT_COPY)
         .withClass(AdminStyles.TERTIARY_BUTTON_STYLES)
         .withData("copyable-program-link", programLink);
   }
@@ -376,7 +376,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
     }
 
     ContainerTag button =
-        makeSvgTextButton("Edit", Icons.EDIT_SVG_PATH)
+        makeSvgTextButton("Edit", Icons.EDIT)
             .withId(editLinkId)
             .withClasses(AdminStyles.TERTIARY_BUTTON_STYLES);
     return isActive
@@ -390,7 +390,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
                 program.id(), LocalizedStrings.DEFAULT_LOCALE.toLanguageTag())
             .url();
     ContainerTag button =
-        makeSvgTextButton("Manage translations", Icons.LANGUAGE_SVG_PATH)
+        makeSvgTextButton("Manage translations", Icons.LANGUAGE)
             .withId("program-translations-link-" + program.id())
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
     return asRedirectButton(button, linkDestination);
@@ -414,7 +414,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
               .url();
 
       ContainerTag button =
-          makeSvgTextButton("Applications", Icons.TEXT_SNIPPET_SVG_PATH)
+          makeSvgTextButton("Applications", Icons.TEXT_SNIPPET)
               .withId("program-view-apps-link-" + activeProgram.id())
               .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
       return Optional.of(asRedirectButton(button, editLink));
@@ -425,7 +425,7 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
   private Tag renderManageProgramAdminsLink(ProgramDefinition program) {
     String adminLink = routes.ProgramAdminManagementController.edit(program.id()).url();
     ContainerTag button =
-        makeSvgTextButton("Manage admins", Icons.GROUP_SVG_PATH)
+        makeSvgTextButton("Manage admins", Icons.GROUP)
             .withId("manage-program-admin-link-" + program.id())
             .withClass(AdminStyles.TERTIARY_BUTTON_STYLES);
     return asRedirectButton(button, adminLink);

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -289,7 +289,7 @@ public class ProgramIndexView extends BaseHtmlView {
               .asAnchorText()
               .withTarget("_blank")
               .with(
-                  Icons.svg(Icons.OPEN_IN_NEW_PATH, 24, 24)
+                  Icons.svg(Icons.OPEN_IN_NEW, 24, 24)
                       .withClasses(
                           Styles.FLEX_SHRINK_0,
                           Styles.H_5,

--- a/server/app/views/components/Accordion.java
+++ b/server/app/views/components/Accordion.java
@@ -46,7 +46,7 @@ public class Accordion {
     ContainerTag titleDiv = div(this.title).withClasses(Styles.TEXT_XL, Styles.FONT_LIGHT);
 
     ContainerTag accordionSvg =
-        Icons.svg(Icons.ACCORDION_BUTTON_PATH, 24)
+        Icons.svg(Icons.ACCORDION_BUTTON, 24)
             .withClasses(Styles.H_6, Styles.W_6)
             .attr("fill", "none")
             .attr("stroke-width", "2")

--- a/server/app/views/components/Icons.java
+++ b/server/app/views/components/Icons.java
@@ -7,21 +7,20 @@ import services.question.types.QuestionType;
  * Class to hold constants for icons and provide methods for rendering SVG components. Most of these
  * icons are from https://fonts.google.com/icons, each one is commented with its icon name.
  */
-public class Icons {
-
-  public static final String ADD_SVG_PATH =
-      "M9.125 15.833V10.875H4.167V9.125H9.125V4.167H10.875V9.125H15.833V10.875H10.875V15.833Z";
+public enum Icons {
+  ADD("M9.125 15.833V10.875H4.167V9.125H9.125V4.167H10.875V9.125H15.833V10.875H10.875V15.833Z"),
   // Place
-  public static final String ADDRESS_SVG_PATH =
+  ADDRESS(
       "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38"
-          + " 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z";
-  public static final String ANNOTATION_SVG_PATH =
-      "M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z";
+          + " 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"),
+  ANNOTATION(
+      "M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4"
+          + " 4z"),
   // Check Box
-  public static final String CHECKBOX_SVG_PATH =
+  CHECKBOX(
       "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0"
-          + " 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z";
-  public static final String CONTENT_COPY_SVG_PATH =
+          + " 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z"),
+  CONTENT_COPY(
       "M7.75 14.833Q7.021 14.833 6.51 14.323Q6 13.812 6 13.083V3.417Q6 2.688 6.51 2.177Q7.021"
           + " 1.667 7.75 1.667H14.917Q15.646 1.667 16.156 2.177Q16.667 2.688 16.667"
           + " 3.417V13.083Q16.667 13.812 16.156 14.323Q15.646 14.833 14.917 14.833ZM7.75"
@@ -32,48 +31,48 @@ public class Icons {
           + " 16.583Q4.25 16.583 4.25 16.583H13.271V18.333ZM7.75 3.417Q7.75 3.417 7.75 3.417Q7.75"
           + " 3.417 7.75 3.417V13.083Q7.75 13.083 7.75 13.083Q7.75 13.083 7.75 13.083Q7.75 13.083"
           + " 7.75 13.083Q7.75 13.083 7.75 13.083V3.417Q7.75 3.417 7.75 3.417Q7.75 3.417 7.75"
-          + " 3.417Z";
+          + " 3.417Z"),
   // Payments
-  public static final String CURRENCY_SVG_PATH =
+  CURRENCY(
       "M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3"
           + " 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11"
-          + " 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z";
-  public static final String DATE_SVG_PATH =
+          + " 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"),
+  DATE(
       "M19 4h-1V3c0-.55-.45-1-1-1s-1 .45-1 1v1H8V3c0-.55-.45-1-1-1s-1 .45-1 1v1H5c-1.11"
           + " 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 15c0"
-          + " .55-.45 1-1 1H6c-.55 0-1-.45-1-1V9h14v10zM7 11h2v2H7zm4 0h2v2h-2zm4 0h2v2h-2z";
-  public static final String DOWNLOAD_SVG_PATH =
+          + " .55-.45 1-1 1H6c-.55 0-1-.45-1-1V9h14v10zM7 11h2v2H7zm4 0h2v2h-2zm4 0h2v2h-2z"),
+  DOWNLOAD(
       "M10 13.271 5.708 8.979 6.958 7.729 9.125 9.896V3.333H10.875V9.896L13.042 7.729L14.292"
           + " 8.979ZM5.083 16.667Q4.354 16.667 3.844 16.156Q3.333 15.646 3.333"
           + " 14.917V12.5H5.083V14.917Q5.083 14.917 5.083 14.917Q5.083 14.917 5.083"
           + " 14.917H14.917Q14.917 14.917 14.917 14.917Q14.917 14.917 14.917"
-          + " 14.917V12.5H16.667V14.917Q16.667 15.646 16.156 16.156Q15.646 16.667 14.917 16.667Z";
+          + " 14.917V12.5H16.667V14.917Q16.667 15.646 16.156 16.156Q15.646 16.667 14.917 16.667Z"),
   // Arrow Drop Down Circle
-  public static final String DROPDOWN_SVG_PATH =
+  DROPDOWN(
       "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.48 2 2 6.48 2 12s4.48 10 10"
-          + " 10 10-4.48 10-10S17.52 2 12 2zm0 13l-4-4h8z";
-  public static final String EDIT_SVG_PATH =
+          + " 10 10-4.48 10-10S17.52 2 12 2zm0 13l-4-4h8z"),
+  EDIT(
       "M4.25 15.75H5.479L13.5 7.729L12.896 7.104L12.271 6.5L4.25 14.521ZM2.5 17.5V13.771L13.479"
           + " 2.792Q14 2.271 14.719 2.271Q15.438 2.271 15.958 2.792L17.208 4.042Q17.708 4.542"
           + " 17.708 5.281Q17.708 6.021 17.208 6.521L6.229 17.5ZM15.958 5.271 14.729 4.042ZM13.5"
-          + " 7.729 12.896 7.104 12.271 6.5V6.479L13.5 7.729Z";
+          + " 7.729 12.896 7.104 12.271 6.5V6.479L13.5 7.729Z"),
   // Email
-  public static final String EMAIL_SVG_PATH =
+  EMAIL(
       "M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8"
-          + " 5-8-5h16zm0 12H4V8l8 5 8-5v10z";
+          + " 5-8-5h16zm0 12H4V8l8 5 8-5v10z"),
   // Forms Add On
-  public static final String ENUMERATOR_SVG_PATH =
+  ENUMERATOR(
       "M19 6H7V4H19ZM7 10V8H19V10ZM7 14V12H13.65Q13.075 12.4 12.613 12.9Q12.15 13.4 11.8 14ZM7"
           + " 16H11.075Q11.025 16.25 11.012 16.488Q11 16.725 11 16.975Q11 17.25 11.025 17.5Q11.05"
           + " 17.75 11.1 18H7ZM16"
           + " 20.975V17.975H13V15.975H16V12.975H18V15.975H21V17.975H18V20.975ZM5 6H3V4H5ZM3"
-          + " 10V8H5V10ZM3 14V12H5V14ZM3 16H5V18H3Z";
+          + " 10V8H5V10ZM3 14V12H5V14ZM3 16H5V18H3Z"),
   // Upload
-  public static final String FILEUPLOAD_SVG_PATH =
+  FILEUPLOAD(
       "M11 16V7.85L8.4 10.45L7 9L12 4L17 9L15.6 10.45L13 7.85V16ZM6 20Q5.175 20 4.588 19.413Q4"
           + " 18.825 4 18V15H6V18Q6 18 6 18Q6 18 6 18H18Q18 18 18 18Q18 18 18 18V15H20V18Q20"
-          + " 18.825 19.413 19.413Q18.825 20 18 20Z";
-  public static final String GROUP_SVG_PATH =
+          + " 18.825 19.413 19.413Q18.825 20 18 20Z"),
+  GROUP(
       "M0.833 16.667V14.271Q0.833 13.542 1.208 12.958Q1.583 12.375 2.188 12.083Q3.438 11.458 4.812"
           + " 11.146Q6.188 10.833 7.562 10.833Q8.938 10.833 10.312 11.156Q11.688 11.479 12.938"
           + " 12.083Q13.542 12.375 13.917 12.958Q14.292 13.542 14.292 14.271V16.667ZM14.042"
@@ -96,9 +95,9 @@ public class Icons {
           + " 6.646Q7.562 6.646 7.562 6.646Q7.562 6.646 7.562 6.646Q7.562 6.646 7.562 6.646ZM7.562"
           + " 12.583Q7.562 12.583 7.562 12.583Q7.562 12.583 7.562 12.583Q7.562 12.583 7.562"
           + " 12.583Q7.562 12.583 7.562 12.583Q7.562 12.583 7.562 12.583Q7.562 12.583 7.562"
-          + " 12.583Q7.562 12.583 7.562 12.583Q7.562 12.583 7.562 12.583Z";
+          + " 12.583Q7.562 12.583 7.562 12.583Q7.562 12.583 7.562 12.583Z"),
   // Badge
-  public static final String ID_SVG_PATH =
+  ID(
       "M14 13.5H18V12H14ZM14 16.5H18V15H14ZM15 7H20Q20.825 7 21.413 7.587Q22 8.175 22 9V20Q22"
           + " 20.825 21.413 21.413Q20.825 22 20 22H4Q3.175 22 2.588 21.413Q2 20.825 2 20V9Q2 8.175"
           + " 2.588 7.587Q3.175 7 4 7H9V4Q9 3.175 9.588 2.587Q10.175 2 11 2H13Q13.825 2 14.413"
@@ -111,8 +110,8 @@ public class Icons {
           + " 15.863Q9.575 15.75 9 15.75Q8.425 15.75 7.913 15.863Q7.4 15.975 6.9 16.2Q6.475 16.4"
           + " 6.238 16.762Q6 17.125 6 17.55ZM9 9H4Q4 9 4 9Q4 9 4 9V20Q4 20 4 20Q4 20 4 20H20Q20 20"
           + " 20 20Q20 20 20 20V9Q20 9 20 9Q20 9 20 9H15Q15 9.825 14.413 10.412Q13.825 11 13"
-          + " 11H11Q10.175 11 9.588 10.412Q9 9.825 9 9Z";
-  public static final String LANGUAGE_SVG_PATH =
+          + " 11H11Q10.175 11 9.588 10.412Q9 9.825 9 9Z"),
+  LANGUAGE(
       "M10 18.333Q8.292 18.333 6.771 17.677Q5.25 17.021 4.115 15.885Q2.979 14.75 2.323"
           + " 13.229Q1.667 11.708 1.667 10Q1.667 8.271 2.323 6.76Q2.979 5.25 4.115 4.115Q5.25"
           + " 2.979 6.771 2.323Q8.292 1.667 10 1.667Q11.729 1.667 13.24 2.323Q14.75 2.979 15.885"
@@ -135,8 +134,8 @@ public class Icons {
           + " 12.875 14.812Q12.604 15.542 12.25 16.188ZM13.646 11.583H16.396Q16.5 11.208 16.542"
           + " 10.812Q16.583 10.417 16.583 9.979Q16.583 9.562 16.542 9.167Q16.5 8.771 16.396"
           + " 8.396H13.646Q13.708 8.938 13.74 9.302Q13.771 9.667 13.771 9.979Q13.771 10.312 13.74"
-          + " 10.677Q13.708 11.042 13.646 11.583Z";
-  public static final String MORE_VERT_PATH =
+          + " 10.677Q13.708 11.042 13.646 11.583Z"),
+  MORE_VERT(
       "M10.021 16.667Q9.354 16.667 8.875 16.188Q8.396 15.708 8.396 15.042Q8.396 14.375 8.875"
           + " 13.896Q9.354 13.417 10.021 13.417Q10.688 13.417 11.167 13.896Q11.646 14.375 11.646"
           + " 15.042Q11.646 15.708 11.167 16.188Q10.688 16.667 10.021 16.667ZM10.021 11.625Q9.354"
@@ -144,9 +143,10 @@ public class Icons {
           + " 8.375Q10.688 8.375 11.167 8.854Q11.646 9.333 11.646 10Q11.646 10.667 11.167"
           + " 11.146Q10.688 11.625 10.021 11.625ZM10.021 6.583Q9.354 6.583 8.875 6.104Q8.396 5.625"
           + " 8.396 4.958Q8.396 4.292 8.875 3.813Q9.354 3.333 10.021 3.333Q10.688 3.333 11.167"
-          + " 3.813Q11.646 4.292 11.646 4.958Q11.646 5.625 11.167 6.104Q10.688 6.583 10.021 6.583Z";
+          + " 3.813Q11.646 4.292 11.646 4.958Q11.646 5.625 11.167 6.104Q10.688 6.583 10.021"
+          + " 6.583Z"),
   // Person
-  public static final String NAME_SVG_PATH =
+  NAME(
       "M12 12Q10.35 12 9.175 10.825Q8 9.65 8 8Q8 6.35 9.175 5.175Q10.35 4 12 4Q13.65 4 14.825"
           + " 5.175Q16 6.35 16 8Q16 9.65 14.825 10.825Q13.65 12 12 12ZM4 20V17.2Q4 16.35 4.438"
           + " 15.637Q4.875 14.925 5.6 14.55Q7.15 13.775 8.75 13.387Q10.35 13 12 13Q13.65 13 15.25"
@@ -157,36 +157,36 @@ public class Icons {
           + " 6.588Q12.825 6 12 6Q11.175 6 10.588 6.588Q10 7.175 10 8Q10 8.825 10.588 9.412Q11.175"
           + " 10 12 10ZM12 8Q12 8 12 8Q12 8 12 8Q12 8 12 8Q12 8 12 8Q12 8 12 8Q12 8 12 8Q12 8 12"
           + " 8Q12 8 12 8ZM12 18Q12 18 12 18Q12 18 12 18Q12 18 12 18Q12 18 12 18Q12 18 12 18Q12 18"
-          + " 12 18Q12 18 12 18Q12 18 12 18Z";
-  public static final String NOISE_CONTROL_OFF_SVG_PATH =
+          + " 12 18Q12 18 12 18Q12 18 12 18Z"),
+  NOISE_CONTROL_OFF(
       "M10 14.208Q8.25 14.208 7.021 12.979Q5.792 11.75 5.792 10Q5.792 8.25 7.021 7.021Q8.25 5.792"
           + " 10 5.792Q11.75 5.792 12.979 7.021Q14.208 8.25 14.208 10Q14.208 11.75 12.979"
-          + " 12.979Q11.75 14.208 10 14.208Z";
+          + " 12.979Q11.75 14.208 10 14.208Z"),
   // Numbers
-  public static final String NUMBER_SVG_PATH =
+  NUMBER(
       "M20.5,10L21,8h-4l1-4h-2l-1,4h-4l1-4h-2L9,8H5l-0.5,2h4l-1,4h-4L3,16h4l-1,4h2l1-4h4l-1,4h2l1-4h4l0.5-2h-4l1-4H20.5z"
-          + " M13.5,14h-4l1-4h4L13.5,14z";
+          + " M13.5,14h-4l1-4h4L13.5,14z"),
 
   // External Links
-  public static final String OPEN_IN_NEW_PATH =
+  OPEN_IN_NEW(
       "M19 19H5V5H12V3H5C3.89 3 3 3.9 3 5V19C3 20.1 3.89 21 5 21H19C20.1"
-          + " 21 21 20.1 21 19V12H19V19ZM14 3V5H17.59L7.76 14.83L9.17 16.24L19 6.41V10H21V3H14Z";
+          + " 21 21 20.1 21 19V12H19V19ZM14 3V5H17.59L7.76 14.83L9.17 16.24L19 6.41V10H21V3H14Z"),
 
-  public static final String PLUS_SVG_PATH =
-      "M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z";
-  public static final String PUBLISH_SVG_PATH =
+  PLUS("M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"),
+  PUBLISH(
       "M9.125 16.667V10.104L6.958 12.271L5.708 11.021L10 6.729L14.292 11.021L13.042 12.271L10.875"
           + " 10.104V16.667ZM3.333 7.5V5.083Q3.333 4.354 3.844 3.844Q4.354 3.333 5.083"
           + " 3.333H14.917Q15.646 3.333 16.156 3.844Q16.667 4.354 16.667"
           + " 5.083V7.5H14.917V5.083Q14.917 5.083 14.917 5.083Q14.917 5.083 14.917"
-          + " 5.083H5.083Q5.083 5.083 5.083 5.083Q5.083 5.083 5.083 5.083V7.5Z";
-  public static final String SEARCH_SVG_PATH =
+          + " 5.083H5.083Q5.083 5.083 5.083 5.083Q5.083 5.083 5.083 5.083V7.5Z"),
+  SEARCH(
       "M55.146,51.887L41.588,37.786c3.486-4.144,5.396-9.358,5.396-14.786c0-12.682-10.318-23-23-23s-23,10.318-23,23"
           + "  s10.318,23,23,23c4.761,0,9.298-1.436,13.177-4.162l13.661,14.208c0.571,0.593,1.339,0.92,2.162,0.92"
           + "  c0.779,0,1.518-0.297,2.079-0.837C56.255,54.982,56.293,53.08,55.146,51.887z"
-          + " M23.984,6c9.374,0,17,7.626,17,17s-7.626,17-17,17 s-17-7.626-17-17S14.61,6,23.984,6z";
+          + " M23.984,6c9.374,0,17,7.626,17,17s-7.626,17-17,17"
+          + " s-17-7.626-17-17S14.61,6,23.984,6z"),
   // Radio Button Checked
-  public static final String RADIO_BUTTON_PATH =
+  RADIO_BUTTON(
       "M12 17Q14.075 17 15.538 15.537Q17 14.075 17 12Q17 9.925 15.538 8.462Q14.075 7 12 7Q9.925 7"
           + " 8.463 8.462Q7 9.925 7 12Q7 14.075 8.463 15.537Q9.925 17 12 17ZM12 22Q9.925 22 8.1"
           + " 21.212Q6.275 20.425 4.925 19.075Q3.575 17.725 2.788 15.9Q2 14.075 2 12Q2 9.925 2.788"
@@ -196,10 +196,10 @@ public class Icons {
           + " 22ZM12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12"
           + " 12 12 12Q12 12 12 12ZM12 20Q15.325 20 17.663 17.663Q20 15.325 20 12Q20 8.675 17.663"
           + " 6.337Q15.325 4 12 4Q8.675 4 6.338 6.337Q4 8.675 4 12Q4 15.325 6.338 17.663Q8.675 20"
-          + " 12 20Z";
+          + " 12 20Z"),
   // Notes
-  public static final String TEXT_SVG_PATH = "M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z";
-  public static final String TEXT_SNIPPET_SVG_PATH =
+  TEXT("M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z"),
+  TEXT_SNIPPET(
       "M4.25 15.75H15.75Q15.75 15.75 15.75 15.75Q15.75 15.75 15.75 15.75V8.188L11.812"
           + " 4.25H4.25Q4.25 4.25 4.25 4.25Q4.25 4.25 4.25 4.25V15.75Q4.25 15.75 4.25 15.75Q4.25"
           + " 15.75 4.25 15.75ZM4.25 17.5Q3.521 17.5 3.01 16.99Q2.5 16.479 2.5 15.75V4.25Q2.5"
@@ -207,85 +207,99 @@ public class Icons {
           + " 16.99Q16.479 17.5 15.75 17.5ZM5.833 14.208H14.167V12.458H5.833ZM5.833"
           + " 10.875H14.167V9.125H5.833ZM5.833 7.521H11.625V5.771H5.833ZM4.25 15.75Q4.25 15.75"
           + " 4.25 15.75Q4.25 15.75 4.25 15.75V4.25Q4.25 4.25 4.25 4.25Q4.25 4.25 4.25"
-          + " 4.25V8.188V15.75Q4.25 15.75 4.25 15.75Q4.25 15.75 4.25 15.75Z";
-  public static final String UNKNOWN_SVG_PATH =
+          + " 4.25V8.188V15.75Q4.25 15.75 4.25 15.75Q4.25 15.75 4.25 15.75Z"),
+  UNKNOWN(
       "M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0"
           + " 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4"
           + " 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5"
-          + " 0-2.21-1.79-4-4-4z";
-  public static final String TRASH_CAN_SVG_PATH =
+          + " 0-2.21-1.79-4-4-4z"),
+  TRASH_CAN(
       "M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1"
-          + " 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16";
-  public static final String WARNING_SVG_PATH =
+          + " 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"),
+  WARNING(
       "M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742"
           + " 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012"
-          + " 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z";
+          + " 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"),
 
-  public static final String ACCORDION_BUTTON_PATH = "M19 9l-7 7-7-7";
+  ACCORDION_BUTTON("M19 9l-7 7-7-7");
+
+  public final String path;
+
+  private Icons(String path) {
+    this.path = path;
+  }
 
   public static ContainerTag questionTypeSvg(QuestionType type, int size) {
     return questionTypeSvg(type, size, size);
   }
 
   public static ContainerTag questionTypeSvg(QuestionType type, int width, int height) {
-    String iconPath = "";
+    Icons icon;
     switch (type) {
       case ADDRESS:
-        iconPath = Icons.ADDRESS_SVG_PATH;
+        icon = Icons.ADDRESS;
         break;
       case CHECKBOX:
-        iconPath = Icons.CHECKBOX_SVG_PATH;
+        icon = Icons.CHECKBOX;
         break;
       case CURRENCY:
-        return svg(Icons.CURRENCY_SVG_PATH, width, height)
+        return svg(Icons.CURRENCY, width, height)
             .attr("fill", "none")
             .attr("stroke-linecap", "round")
             .attr("stroke-linejoin", "round")
             .attr("stroke-width", "2");
       case DATE:
-        iconPath = Icons.DATE_SVG_PATH;
+        icon = Icons.DATE;
         break;
       case DROPDOWN:
-        iconPath = Icons.DROPDOWN_SVG_PATH;
+        icon = Icons.DROPDOWN;
         break;
       case EMAIL:
-        iconPath = Icons.EMAIL_SVG_PATH;
+        icon = Icons.EMAIL;
         break;
       case FILEUPLOAD:
-        iconPath = Icons.FILEUPLOAD_SVG_PATH;
+        icon = Icons.FILEUPLOAD;
         break;
       case ID:
-        iconPath = Icons.ID_SVG_PATH;
+        icon = Icons.ID;
         break;
       case NAME:
-        iconPath = Icons.NAME_SVG_PATH;
+        icon = Icons.NAME;
         break;
       case NUMBER:
-        iconPath = Icons.NUMBER_SVG_PATH;
+        icon = Icons.NUMBER;
         break;
       case RADIO_BUTTON:
-        iconPath = Icons.RADIO_BUTTON_PATH;
+        icon = Icons.RADIO_BUTTON;
         break;
       case ENUMERATOR:
-        iconPath = Icons.ENUMERATOR_SVG_PATH;
+        icon = Icons.ENUMERATOR;
         break;
       case STATIC:
-        return svg(Icons.ANNOTATION_SVG_PATH, width, height)
+        return svg(Icons.ANNOTATION, width, height)
             .attr("fill", "none")
             .attr("stroke-linecap", "round")
             .attr("stroke-linejoin", "round")
             .attr("stroke-width", "2");
       case TEXT:
-        iconPath = Icons.TEXT_SVG_PATH;
+        icon = Icons.TEXT;
         break;
       default:
-        iconPath = Icons.UNKNOWN_SVG_PATH;
+        icon = Icons.UNKNOWN;
     }
-    return svg(iconPath, width, height);
+    return svg(icon, width, height);
+  }
+
+  public static ContainerTag svg(Icons icon, int pixelSize) {
+    return svg(icon.path, pixelSize);
   }
 
   public static ContainerTag svg(String pathString, int pixelSize) {
     return svg(pathString, pixelSize, pixelSize);
+  }
+
+  public static ContainerTag svg(Icons icon, int width, int height) {
+    return svg(icon.path, width, height);
   }
 
   public static ContainerTag svg(String pathString, int width, int height) {

--- a/server/app/views/components/QuestionBank.java
+++ b/server/app/views/components/QuestionBank.java
@@ -29,7 +29,7 @@ import views.style.Styles;
 /** Contains methods for rendering question bank for an admin to add questions to a program. */
 public class QuestionBank {
   private static final ContainerTag PLUS_ICON =
-      Icons.svg(Icons.PLUS_SVG_PATH, 24)
+      Icons.svg(Icons.PLUS, 24)
           .withClasses(Styles.FLEX_SHRINK_0, Styles.H_12, Styles.W_6)
           .attr("fill", "currentColor")
           .attr("stroke-width", "2")
@@ -106,8 +106,7 @@ public class QuestionBank {
                 Styles.SHADOW,
                 StyleUtils.focus(Styles.OUTLINE_NONE));
 
-    ContainerTag filterIcon =
-        Icons.svg(Icons.SEARCH_SVG_PATH, 56).withClasses(Styles.H_4, Styles.W_4);
+    ContainerTag filterIcon = Icons.svg(Icons.SEARCH, 56).withClasses(Styles.H_4, Styles.W_4);
     ContainerTag filterIconDiv =
         div().withClasses(Styles.ABSOLUTE, Styles.ML_4, Styles.MT_3, Styles.MR_4).with(filterIcon);
     ContainerTag filterDiv =

--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -91,7 +91,7 @@ public class TextFormatter {
         urlTag
             .withTarget("_blank")
             .with(
-                Icons.svg(Icons.OPEN_IN_NEW_PATH, 24, 24)
+                Icons.svg(Icons.OPEN_IN_NEW, 24, 24)
                     .withClasses(
                         Styles.FLEX_SHRINK_0,
                         Styles.H_5,

--- a/server/app/views/dev/IconsView.java
+++ b/server/app/views/dev/IconsView.java
@@ -1,0 +1,59 @@
+package views.dev;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.each;
+import static j2html.TagCreator.p;
+import static j2html.TagCreator.script;
+import static j2html.TagCreator.table;
+import static j2html.TagCreator.td;
+import static j2html.TagCreator.th;
+import static j2html.TagCreator.tr;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import j2html.tags.ContainerTag;
+import j2html.tags.Tag;
+import play.twirl.api.Content;
+import views.BaseHtmlLayout;
+import views.BaseHtmlView;
+import views.HtmlBundle;
+import views.components.Icons;
+
+public final class IconsView extends BaseHtmlView {
+  private final BaseHtmlLayout layout;
+
+  @Inject
+  public IconsView(BaseHtmlLayout layout) {
+    this.layout = checkNotNull(layout);
+  }
+
+  public Content render() {
+    ContainerTag content =
+        div()
+            .with(
+                table()
+                    .with(
+                        tr().with(th("Icon name"), th("Icon"), th("Width"), th("Height")),
+                        each(ImmutableList.copyOf(Icons.values()), icon -> renderIconRow(icon))),
+                script(
+                    String.join(
+                        "\n",
+                        "document.querySelectorAll('svg').forEach(el => {",
+                        "  bbox = el.getBBox();",
+                        "  el.parentElement.querySelector('p').textContent = `Total width:"
+                            + " ${bbox.x + bbox.width} Total height: ${bbox.y + bbox.height}`;",
+                        "});")));
+    HtmlBundle bundle =
+        layout
+            .getBundle()
+            .setTitle("Icons")
+            .addMainContent(content)
+            .addFooterScripts(layout.viewUtils.makeLocalJsTag("dev_icons"));
+    return layout.render(bundle);
+  }
+
+  private Tag renderIconRow(Icons icon) {
+    return tr().with(td(icon.name()), td(Icons.svg(icon.path, 24)), td(p("")), td(p("")));
+  }
+}

--- a/server/app/views/dev/IconsView.java
+++ b/server/app/views/dev/IconsView.java
@@ -18,6 +18,10 @@ import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.components.Icons;
 
+/**
+ * Renders a listing of all SVG icons and metadata about the icon size. This is generally useful for
+ * seeing what icons are already available and debugging any SVG scaling / sizing issues.
+ */
 public final class IconsView extends BaseHtmlView {
   private final BaseHtmlLayout layout;
 

--- a/server/app/views/dev/IconsView.java
+++ b/server/app/views/dev/IconsView.java
@@ -1,10 +1,8 @@
 package views.dev;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.p;
-import static j2html.TagCreator.script;
 import static j2html.TagCreator.table;
 import static j2html.TagCreator.td;
 import static j2html.TagCreator.th;
@@ -30,20 +28,10 @@ public final class IconsView extends BaseHtmlView {
 
   public Content render() {
     ContainerTag content =
-        div()
+        table()
             .with(
-                table()
-                    .with(
-                        tr().with(th("Icon name"), th("Icon"), th("Width"), th("Height")),
-                        each(ImmutableList.copyOf(Icons.values()), icon -> renderIconRow(icon))),
-                script(
-                    String.join(
-                        "\n",
-                        "document.querySelectorAll('svg').forEach(el => {",
-                        "  bbox = el.getBBox();",
-                        "  el.parentElement.querySelector('p').textContent = `Total width:"
-                            + " ${bbox.x + bbox.width} Total height: ${bbox.y + bbox.height}`;",
-                        "});")));
+                tr().with(th("Icon name"), th("Icon"), th("Width"), th("Height")),
+                each(ImmutableList.copyOf(Icons.values()), icon -> renderIconRow(icon)));
     HtmlBundle bundle =
         layout
             .getBundle()
@@ -54,6 +42,10 @@ public final class IconsView extends BaseHtmlView {
   }
 
   private Tag renderIconRow(Icons icon) {
-    return tr().with(td(icon.name()), td(Icons.svg(icon.path, 24)), td(p("")), td(p("")));
+    return tr().with(
+            td(icon.name()),
+            td(Icons.svg(icon.path, 24)),
+            td(p("").withClass("icon-width")),
+            td(p("").withClass("icon-height")));
   }
 }

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -170,6 +170,7 @@ GET     /logout                      @org.pac4j.play.LogoutController.logout(req
 # Methods for development: seed the database with test content to develop against, and clear the database
 GET     /dev/seed                        controllers.dev.DatabaseSeedController.index(request: Request)
 POST    /dev/seed/canonicalQuestions     controllers.dev.DatabaseSeedController.seedCanonicalQuestions()
+GET     /dev/icons                       controllers.dev.IconsController.index()
 POST    /dev/seed                        controllers.dev.DatabaseSeedController.seed()
 POST    /dev/seed/clear                  controllers.dev.DatabaseSeedController.clear()
 


### PR DESCRIPTION
### Description

Moving this to an enum makes it easier to categorize what icons we actually have. Additionally, I've been dealing with issues where I try and scale an existing SVG path up and down and running into issues where the content gets clipped. This is due to the fact that the SVG paths we have have inherent sizes. We'll need to set the viewBox property to this inherent size in order to properly scale the icon up/down using the width/height properties. Having the `/dev/icons` view is a first step to determining which icons need to be updated (and is also generally useful for seeing what icons are available).

See https://css-tricks.com/scale-svg/.