### PR TITLE
Using the correct feature flag name for status tracking in server code.

### DIFF
--- a/server/app/modules/FeatureFlagsModule.java
+++ b/server/app/modules/FeatureFlagsModule.java
@@ -16,6 +16,6 @@ public class FeatureFlagsModule extends AbstractModule {
   @Provides
   @ApplicationStatusTrackingEnabled
   public boolean provideStatusTrackingEnabled(Config config) {
-    return checkNotNull(config).getBoolean("status_tracking_enabled");
+    return checkNotNull(config).getBoolean("application_status_tracking_enabled");
   }
 }

--- a/server/test/modules/FeatureFlagsModuleTest.java
+++ b/server/test/modules/FeatureFlagsModuleTest.java
@@ -22,7 +22,7 @@ public class FeatureFlagsModuleTest {
     Application app =
         new GuiceApplicationBuilder()
             .configure(
-                ConfigFactory.parseMap(ImmutableMap.of("status_tracking_enabled", isEnabled)))
+                ConfigFactory.parseMap(ImmutableMap.of("application_status_tracking_enabled", isEnabled)))
             .build();
     BindingKey<Boolean> key =
         new BindingKey<Boolean>(Boolean.class)


### PR DESCRIPTION
### Description

This changes the configuration value that is consulted to match that in `application.conf`.

### Issue(s)

#2752
