### PR TITLE
Styling updates for V2 index.

### DIFF
--- a/server/app/views/BaseHtmlView.java
+++ b/server/app/views/BaseHtmlView.java
@@ -74,8 +74,9 @@ public abstract class BaseHtmlView {
   protected static ContainerTag makeSvgTextButton(String buttonText, String svgPath) {
     return TagCreator.button()
         .with(
-            Icons.svg(svgPath, 18).withClasses(Styles.ML_1, Styles.MR_2, Styles.INLINE_BLOCK),
-            span(buttonText));
+            Icons.svg(svgPath, 18)
+                .withClasses(Styles.ML_1, Styles.INLINE_BLOCK, Styles.FLEX_SHRINK_0),
+            span(buttonText).withClass(Styles.TEXT_LEFT));
   }
 
   /**

--- a/server/app/views/admin/programs/ProgramIndexViewV2.java
+++ b/server/app/views/admin/programs/ProgramIndexViewV2.java
@@ -249,10 +249,14 @@ public final class ProgramIndexViewV2 extends BaseHtmlView {
                                 .withId(extraActionsButtonId + "-dropdown")
                                 .withClasses(
                                     Styles.HIDDEN,
+                                    Styles.FLEX,
+                                    Styles.FLEX_COL,
                                     Styles.BORDER,
                                     Styles.BG_WHITE,
                                     Styles.ABSOLUTE,
-                                    Styles.RIGHT_0)
+                                    Styles.RIGHT_0,
+                                    Styles.W_56,
+                                    Styles.Z_50)
                                 .with(extraActions))));
   }
 

--- a/server/app/views/components/Modal.java
+++ b/server/app/views/components/Modal.java
@@ -42,7 +42,7 @@ public class Modal {
   public Tag getButton() {
     String triggerButtonId = modalId + "-button";
     if (triggerButtonContent.isPresent()) {
-      return triggerButtonContent.get().withClasses(buttonStyles).withId(triggerButtonId);
+      return triggerButtonContent.get().withId(triggerButtonId);
     } else {
       return button(triggerButtonId, triggerButtonText).withClasses(buttonStyles);
     }

--- a/server/app/views/style/AdminStyles.java
+++ b/server/app/views/style/AdminStyles.java
@@ -104,12 +104,17 @@ public class AdminStyles {
 
   public static final String PRIMARY_BUTTON_STYLES =
       StyleUtils.joinStyles(
-          BASE_BUTTON_STYLES, Styles.ROUNDED_FULL, BaseStyles.BG_SEATTLE_BLUE, Styles.TEXT_WHITE);
+          BASE_BUTTON_STYLES,
+          Styles.ROUNDED_FULL,
+          Styles.SPACE_X_2,
+          BaseStyles.BG_SEATTLE_BLUE,
+          Styles.TEXT_WHITE);
 
   public static final String SECONDARY_BUTTON_STYLES =
       StyleUtils.joinStyles(
           BASE_BUTTON_STYLES,
           Styles.ROUNDED_FULL,
+          Styles.SPACE_X_2,
           Styles.BORDER,
           BaseStyles.BORDER_SEATTLE_BLUE,
           Styles.BG_WHITE,
@@ -119,6 +124,17 @@ public class AdminStyles {
   public static final String TERTIARY_BUTTON_STYLES =
       StyleUtils.joinStyles(
           BASE_BUTTON_STYLES,
+          Styles.SPACE_X_2,
+          Styles.BORDER_NONE,
+          Styles.ROUNDED,
+          Styles.BG_TRANSPARENT,
+          Styles.TEXT_BLACK,
+          StyleUtils.hover(Styles.BG_GRAY_200));
+
+  public static final String DROPDOWN_BUTTON_STYLES =
+      StyleUtils.joinStyles(
+          BASE_BUTTON_STYLES,
+          Styles.SPACE_X_4,
           Styles.BORDER_NONE,
           Styles.ROUNDED,
           Styles.BG_TRANSPARENT,


### PR DESCRIPTION
### Description

Noticed these when adding a new dropdown option for status tracking (#2752).

Changes include:
  * Z-index is set appropriately so that the dropdown appears above other content
  * Spacing between icons and text varies based on whether it's a primary/secondary button or tertiary/dropdown.
  * SVGs no longer shrink based on content, leading to a more consistent layout
  * Making the dropdown wider to actually fit the content included

Before:
![Screen Shot 2022-06-27 at 8 47 31 AM](https://user-images.githubusercontent.com/1870301/175981217-7b67b384-5c8b-41cb-8e3a-68430367d0ba.png)

After:
![Screen Shot 2022-06-27 at 8 45 57 AM](https://user-images.githubusercontent.com/1870301/175981230-2a4e506e-4568-4890-8f41-d1755ca4f0b4.png)

### Issue(s)

#2752, #1238