### PR TITLE
Fix browser test code for clicking download CSV, broken (intentionally) by #2749

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -480,10 +480,14 @@ export class AdminPrograms {
   }
 
   async getDemographicsCsv() {
+    await clickAndWaitForModal(this.page, 'download-demographics-csv-modal')
     const [downloadEvent] = await Promise.all([
       this.page.waitForEvent('download'),
-      this.page.click('text="Download Exported Data (CSV)"'),
+      this.page.click(
+        '#download-demographics-csv-modal button:has-text("Download Exported Data (CSV)")',
+      ),
     ])
+    await this.page.click('#download-demographics-csv-modal-close')
     const path = await downloadEvent.path()
     if (path === null) {
       throw new Error('download failed')


### PR DESCRIPTION
### Description

We have a bug where GitHub action test runs don't use the locally built server image. That fix is in progress. #2749 was submitted and needed browser test changes, but we couldn't submit them in the same PR since updating the test code would have failed due to using an old server image. While we fix the root issue, we decided to submit the server-side code and browser test code separately.
 
### Issue(s)

#1743 