### PR TITLE
Don't create duplicate stored files

### DIFF
--- a/server/app/repository/StoredFileRepository.java
+++ b/server/app/repository/StoredFileRepository.java
@@ -62,11 +62,11 @@ public class StoredFileRepository {
         executionContext);
   }
 
-  public CompletionStage<Long> insert(StoredFile file) {
+  public CompletionStage<StoredFile> insert(StoredFile file) {
     return supplyAsync(
         () -> {
           database.insert(file);
-          return file.id;
+          return file;
         },
         executionContext);
   }

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -497,6 +497,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
   }
 
+  /**
+   * This test guards regression for the bugfix to
+   * https://github.com/seattle-uat/civiform/issues/2818
+   */
   @Test
   public void updateFile_storedFileAlreadyExists_doesNotCreateDuplicateStoredFile() {
     var storedFileRepo = instanceOf(StoredFileRepository.class);

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -498,7 +498,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void updateFile_storedFileAlreadyExists_doesNotCrateDuplicate() {
+  public void updateFile_storedFileAlreadyExists_doesNotCreateDuplicateStoredFile() {
     var storedFileRepo = instanceOf(StoredFileRepository.class);
 
     program =

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -11,17 +11,20 @@ import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.stubMessagesApi;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.WithMockedProfiles;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import models.Applicant;
 import models.Program;
+import models.StoredFile;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
 import play.mvc.Result;
+import repository.StoredFileRepository;
 import services.Path;
 import services.applicant.question.Scalar;
 import support.ProgramBuilder;
@@ -492,6 +495,44 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         routes.ApplicantProgramReviewController.review(applicant.id, program.id).url();
 
     assertThat(result.redirectLocation()).hasValue(reviewRoute);
+  }
+
+  @Test
+  public void updateFile_storedFileAlreadyExists_doesNotCrateDuplicate() {
+    var storedFileRepo = instanceOf(StoredFileRepository.class);
+
+    program =
+        ProgramBuilder.newDraftProgram()
+            .withBlock("block 1")
+            .withRequiredQuestion(testQuestionBank().applicantFile())
+            .build();
+
+    var fileKey = "fake-key";
+    var storedFile = new StoredFile();
+    storedFile.setName(fileKey);
+    storedFile.save();
+
+    RequestBuilder request =
+        fakeRequest(
+            routes.ApplicantProgramBlocksController.updateFile(
+                applicant.id, program.id, /* blockId = */ "1", /* inReview = */ false));
+    addQueryString(request, ImmutableMap.of("key", fileKey, "bucket", "fake-bucket"));
+
+    Result result =
+        subject
+            .updateFile(
+                request.build(),
+                applicant.id,
+                program.id,
+                /* blockId = */ "1",
+                /* inReview = */ false)
+            .toCompletableFuture()
+            .join();
+
+    int storedFileCount =
+        storedFileRepo.lookupFiles(ImmutableList.of(fileKey)).toCompletableFuture().join().size();
+    assertThat(storedFileCount).isEqualTo(1);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   private RequestBuilder addQueryString(


### PR DESCRIPTION
When an applicant uploads a file for a given program-block, the file is stored in cloud storage keyed by the applicant-program-block-originalFileName -- a four-part composite key. If they upload another file (or the same file) with the same filename for the same program-block, the bytes in cloud storage are overwritten, but CiviForm creates a duplicate `StoredFile` entry with a colliding `name` value, resulting in two (or more) database entries for a single file in cloud storage.

This change prevents CiviForm from creating a duplicate as a result of this applicant behavior.

Fixes https://github.com/seattle-uat/civiform/issues/2818