### PR TITLE
Modifying getApplications explicitly order results by ID

### DIFF
--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -152,9 +152,18 @@ public class ApplicationRepository {
             });
   }
 
+  /**
+   * Returns all applications submitted within the provided time range. Results are returned in the
+   * order that the applications were created.
+   */
   public ImmutableList<Application> getApplications(TimeFilter submitTimeFilter) {
     ExpressionList<Application> query =
-        database.find(Application.class).fetch("program").fetch("applicant.account").where();
+        database
+            .find(Application.class)
+            .fetch("program")
+            .fetch("applicant.account")
+            .orderBy("id")
+            .where();
     if (submitTimeFilter.fromTime().isPresent()) {
       query = query.where().ge("submit_time", submitTimeFilter.fromTime().get());
     }

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -100,7 +100,8 @@ public interface ApplicantService {
 
   /**
    * Return a filtered set of applications, including applications from previous versions, with
-   * program, applicant, and account associations eager loaded.
+   * program, applicant, and account associations eager loaded. Results are ordered by application
+   * ID in ascending order.
    */
   ImmutableList<Application> getApplications(TimeFilter submitTimeFilter);
 }


### PR DESCRIPTION
### Description

This is causing flakes of the ApplicationRepositoryTest, which assumes that applications have an explicit order. Since this is consumed for export purposes, it'd be nice to have a stable order. I had thought that the query planner would choose the "natural" order ascending by ID, but it appears to be choosing a different order for unit tests in GitHub actions.

I considered sorting the results in-memory at the server, but discarded that since ordering by ID should already be fast (due to the implicit index in the DB) and is likely what callers would expect.

### Issue(s)

#1743 