### PR TITLE
Program admin applicant search improvements to allow full name search

### DIFF
--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -323,8 +323,8 @@ public interface ProgramService {
 
   /**
    * Get all submitted applications for this program and all other previous and future versions of
-   * it where the applicant's first name, last name, email, or application ID contains the search
-   * query. Does not include drafts or deleted applications.
+   * it where the applicant's name, email, or application ID contains the search query. Does not
+   * include drafts or deleted applications.
    *
    * <p>If searchNameFragment is not an unsigned integer, the query will filter to applications with
    * email, first name, or last name that contain it.

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -74,7 +74,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                         routes.AdminApplicationController.index(
                             program.id(), Optional.empty(), Optional.empty()),
                         Optional.of(Styles.W_FULL),
-                        Optional.of("Search first name, last name, or application ID"))
+                        Optional.of("Search by name, email, or application ID"))
                     .withClasses(Styles.MT_6),
                 each(paginatedApplications.getPageContents(), this::renderApplicationListItem),
                 br(),

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -8,6 +8,8 @@ import io.ebean.DB;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import models.Account;
 import models.Applicant;
 import models.Application;
@@ -15,21 +17,26 @@ import models.DisplayMode;
 import models.Program;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import play.libs.F;
 import services.IdentifierBasedPaginationSpec;
 import services.LocalizedStrings;
 import services.PageNumberBasedPaginationSpec;
 import services.PaginationResult;
+import services.WellKnownPaths;
+import services.applicant.ApplicantData;
 import services.program.ProgramNotFoundException;
 import support.CfTestHelpers;
+import support.QuestionAnswerer;
 
+@RunWith(JUnitParamsRunner.class)
 public class ProgramRepositoryTest extends ResetPostgres {
 
   private ProgramRepository repo;
   private VersionRepository versionRepo;
 
   @Before
-  public void setupProgramRepository() {
+  public void setup() {
     repo = instanceOf(ProgramRepository.class);
     versionRepo = instanceOf(VersionRepository.class);
   }
@@ -168,6 +175,104 @@ public class ProgramRepositoryTest extends ResetPostgres {
     // still have the same admin associated.
     Program newDraft = repo.createOrUpdateDraft(withAdmins);
     assertThat(repo.getProgramAdministrators(newDraft.id)).containsExactly(admin);
+  }
+
+  @Test
+  public void getApplicationsForAllProgramVersions_searchById() {
+    Program program = resourceCreator.insertActiveProgram("test program");
+
+    Applicant bob = resourceCreator.insertApplicantWithAccount(Optional.of("bob@example.com"));
+    Application bobApp = makeApplicationWithName(bob, program, "Bob", "MiddleName", "Doe");
+    Applicant jane = resourceCreator.insertApplicantWithAccount(Optional.of("jane@example.com"));
+    makeApplicationWithName(jane, program, "Jane", "MiddleName", "Doe");
+
+    PaginationResult<Application> paginationResult =
+        repo.getApplicationsForAllProgramVersions(
+            program.id,
+            F.Either.Left(IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG),
+            Optional.of(bobApp.id.toString()),
+            TimeFilter.EMPTY);
+
+    assertThat(
+            paginationResult.getPageContents().stream()
+                .map(a -> a.getSubmitterEmail().orElse(""))
+                .collect(ImmutableSet.toImmutableSet()))
+        .containsExactly("bob@example.com");
+    assertThat(paginationResult.getNumPages()).isEqualTo(1);
+  }
+
+  private static ImmutableList<Object[]> getSearchByNameOrEmailData() {
+    // Assumes that the test has been seeded with three applications:
+    // 1. bob@example.com - Bob Doe
+    // 2. jane@example.com - Jane Doe
+    // 3. chris@exAMPLE.com - Chris Person
+    return ImmutableList.<Object[]>of(
+        new Object[] {"Bob Doe", ImmutableSet.of("bob@example.com")},
+        new Object[] {"Doe Bob", ImmutableSet.of("bob@example.com")},
+        new Object[] {"Doe, Bob", ImmutableSet.of("bob@example.com")},
+        new Object[] {"Doe", ImmutableSet.of("bob@example.com", "jane@example.com")},
+        new Object[] {"Bob", ImmutableSet.of("bob@example.com")},
+        new Object[] {"Person", ImmutableSet.of("chris@exAMPLE.com")},
+        new Object[] {"bob@example.com", ImmutableSet.of("bob@example.com")},
+        new Object[] {"Other Person", ImmutableSet.of()},
+
+        // Case insensitive search.
+        new Object[] {"bOb dOe", ImmutableSet.of("bob@example.com")},
+        new Object[] {"CHRIS@example.com", ImmutableSet.of("chris@exAMPLE.com")},
+
+        // Leading and trailing whitespace is ignored.
+        new Object[] {"    Bob Doe    ", ImmutableSet.of("bob@example.com")},
+
+        // Degenerate cases.
+        // Email must be an exact match.
+        new Object[] {"example.com", ImmutableSet.of()},
+        // Only match a single space between first and last name.
+        new Object[] {"Bob  Doe", ImmutableSet.of()});
+  }
+
+  @Test
+  @Parameters(method = "getSearchByNameOrEmailData")
+  public void getApplicationsForAllProgramVersions_searchByNameOrEmail(
+      String searchFragment, ImmutableSet<String> wantEmails) {
+    Program program = resourceCreator.insertActiveProgram("test program");
+
+    Applicant bob = resourceCreator.insertApplicantWithAccount(Optional.of("bob@example.com"));
+    makeApplicationWithName(bob, program, "Bob", "MiddleName", "Doe");
+    Applicant jane = resourceCreator.insertApplicantWithAccount(Optional.of("jane@example.com"));
+    makeApplicationWithName(jane, program, "Jane", "MiddleName", "Doe");
+    // Note: The mixed casing on the email is intentional for tests of case insensitivity.
+    Applicant chris = resourceCreator.insertApplicantWithAccount(Optional.of("chris@exAMPLE.com"));
+    makeApplicationWithName(chris, program, "Chris", "MiddleName", "Person");
+
+    Applicant otherApplicant =
+        resourceCreator.insertApplicantWithAccount(Optional.of("other@example.com"));
+    resourceCreator.insertDraftApplication(otherApplicant, program);
+
+    PaginationResult<Application> paginationResult =
+        repo.getApplicationsForAllProgramVersions(
+            program.id,
+            F.Either.Left(IdentifierBasedPaginationSpec.MAX_PAGE_SIZE_SPEC_LONG),
+            Optional.of(searchFragment),
+            TimeFilter.EMPTY);
+
+    assertThat(
+            paginationResult.getPageContents().stream()
+                .map(a -> a.getSubmitterEmail().orElse(""))
+                .collect(ImmutableSet.toImmutableSet()))
+        .isEqualTo(wantEmails);
+    assertThat(paginationResult.getNumPages()).isEqualTo(wantEmails.isEmpty() ? 0 : 1);
+  }
+
+  private Application makeApplicationWithName(
+      Applicant applicant, Program program, String firstName, String middleName, String lastName) {
+    Application application = resourceCreator.insertActiveApplication(applicant, program);
+    ApplicantData applicantData = application.getApplicantData();
+    QuestionAnswerer.answerNameQuestion(
+        applicantData, WellKnownPaths.APPLICANT_NAME, firstName, middleName, lastName);
+    application.setApplicantData(applicantData);
+    application.setSubmitterEmail(applicant.getAccount().getEmailAddress());
+    application.save();
+    return application;
   }
 
   @Test

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -94,6 +94,10 @@ public class ResourceCreator {
     return Application.create(applicant, program, LifecycleStage.ACTIVE);
   }
 
+  public Application insertDraftApplication(Applicant applicant, Program program) {
+    return Application.create(applicant, program, LifecycleStage.DRAFT);
+  }
+
   public Application insertApplication(
       Applicant applicant, Program program, LifecycleStage lifecycleStage) {
     return Application.create(applicant, program, lifecycleStage);
@@ -120,6 +124,7 @@ public class ResourceCreator {
     Account account = insertAccount();
 
     accountEmail.ifPresent(account::setEmailAddress);
+    account.save();
     applicant.setAccount(account);
     applicant.save();
 


### PR DESCRIPTION
### Description
Noticed this as part of pending PR #2826.

Previously, program admins could search by the applicant's first name, last name, email, or application ID. This augments the functionality to allow additionally searching using the following forms:
* First Last
* Last First
* Last, First

A couple of additional improvements were also added, including:
* Searching by email is case insensitive (even if the stored email has mixed casing)
* Updated the search field label to indicate that email is a valid search option
* Adding unit test coverage that wasn't previously present

### Checklist

- [X] Created tests which fail without the change (if possible)

### Issue(s)

#1743