### PR TITLE
Small fixes for AWS deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tailwind.css
 *.terraform
 *.terraform.lock.hcl
 *.tfvars
+cloud/**/backend_vars
 /cloud/deploys/dev_azure/civiform_config.sh
 /cloud/deploys/dev_aws/civiform_config.sh
 *_override.tf
@@ -27,6 +28,7 @@ tailwind.css
 terraform.tfstate**
 .terraform.tfstate**
 *.pyc
+terraform_plan
 
 sbt_cache/*
 !sbt_cache/.keep

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ target
 public
 code-coverage
 logs
+.terraform
 
 .classpath
 .project

--- a/cloud/aws/modules/custom_domain/main.tf
+++ b/cloud/aws/modules/custom_domain/main.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "civiform_domain_record" {
   ttl     = 60
 }
 
-# this updates CNAME records with certificates. 
+# this updates CNAME records with certificates.
 # The records are only known after AppRunner is up and associated with custom domain.
 # to make this work we need to run terraform apply -target aws_apprunner_custom_domain_association.civiform_domain first
 resource "aws_route53_record" "civiform_domain_validation" {

--- a/cloud/aws/modules/setup/backend_storage.tf
+++ b/cloud/aws/modules/setup/backend_storage.tf
@@ -1,5 +1,8 @@
 resource "aws_s3_bucket" "backend_state_bucket" {
   bucket = "${var.app_prefix}-backendstate"
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_s3_bucket_versioning" "backend_state_versioning" {

--- a/cloud/aws/modules/setup/secrets.tf
+++ b/cloud/aws/modules/setup/secrets.tf
@@ -8,8 +8,11 @@ resource "aws_kms_key" "civiform_kms_key" {
 
 # Create a random generated password to use for postgres_password.
 resource "random_password" "postgres_username" {
-  length  = 16
+  length  = 7
   special = false
+  keepers = {
+    version = 1
+  }
 }
 
 # Creating a AWS secret for postgres_username
@@ -21,13 +24,18 @@ resource "aws_secretsmanager_secret" "postgres_username_secret" {
 # Creating a AWS secret versions for postgres_username
 resource "aws_secretsmanager_secret_version" "postgres_username_secret_version" {
   secret_id     = aws_secretsmanager_secret.postgres_username_secret.id
-  secret_string = random_password.postgres_username.result
+  secret_string = "db_admin_${random_password.postgres_username.result}"
 }
 
 # Create a random generated password to use for postgres_password.
 resource "random_password" "postgres_password" {
-  length  = 16
-  special = false
+  length           = 40
+  special          = false
+  min_special      = 5
+  override_special = "!#$%^&*()-_=+[]{}<>:?"
+  keepers = {
+    version = 1
+  }
 }
 
 # Creating a AWS secret for postgres_password

--- a/cloud/aws/modules/setup/secrets.tf
+++ b/cloud/aws/modules/setup/secrets.tf
@@ -30,7 +30,7 @@ resource "aws_secretsmanager_secret_version" "postgres_username_secret_version" 
 # Create a random generated password to use for postgres_password.
 resource "random_password" "postgres_password" {
   length           = 40
-  special          = false
+  special          = true
   min_special      = 5
   override_special = "!#$%^&*()-_=+[]{}<>:?"
   keepers = {

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -71,7 +71,7 @@ resource "aws_apprunner_service" "civiform_dev" {
 # List of params that we could configure:
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Parameters.html#Appendix.PostgreSQL.CommonDBATasks.Parameters.parameters-list
 resource "aws_db_parameter_group" "civiform" {
-  name   = "${var.app_prefix}-civiform"
+  name   = "${var.app_prefix}-civiform-db-params"
   family = "postgres12"
 
   parameter {
@@ -81,7 +81,7 @@ resource "aws_db_parameter_group" "civiform" {
 }
 
 resource "aws_db_instance" "civiform" {
-  identifier              = "${var.app_prefix}-${var.postgress_name}"
+  identifier              = "${var.app_prefix}-${var.postgress_name}-db"
   instance_class          = var.postgres_instance_class
   allocated_storage       = var.postgres_storage_gb
   engine                  = "postgres"

--- a/cloud/aws/templates/aws_oidc/variable_definitions.json
+++ b/cloud/aws/templates/aws_oidc/variable_definitions.json
@@ -22,5 +22,11 @@
     "secret": false,
     "tfvar": true,
     "type": "string"
+  },
+  "SES_SENDER_EMAIL": {
+    "required": false,
+    "secret": false,
+    "tfvar": true,
+    "type": "string"
   }
 }

--- a/cloud/deploys/dev_aws/bin/terraform
+++ b/cloud/deploys/dev_aws/bin/terraform
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+source cloud/deploys/dev_aws/bin/lib.sh
+
+cloud/shared/bin/terraform "$@"

--- a/cloud/deploys/dev_aws/bin/terraform-setup
+++ b/cloud/deploys/dev_aws/bin/terraform-setup
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+source cloud/deploys/dev_aws/bin/lib.sh
+
+export TERRAFORM_TEMPLATE_DIR="${TERRAFORM_TEMPLATE_DIR}/setup"
+cloud/shared/bin/terraform "$@"

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -65,12 +65,8 @@ try:
     # Note that the -chdir means we use the relative paths for
     # both the backend config and the var file
     terraform_init_args = [
-        "terraform",
-        f"-chdir={template_dir}",
-        "init",
-        "-input=false",
-        "-upgrade",
-        "-migrate-state"
+        "terraform", f"-chdir={template_dir}", "init", "-input=false",
+        "-upgrade", "-migrate-state"
     ]
     if config_loader.use_backend_config():
         terraform_init_args.append(

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -70,6 +70,7 @@ try:
         "init",
         "-input=false",
         "-upgrade",
+        "-migrate-state"
     ]
     if config_loader.use_backend_config():
         terraform_init_args.append(


### PR DESCRIPTION
### Description

 - Make deploys more reliable by adjusting the auto-generated passwords/user names to work regardless of the prefix and special characters chosen at random.
 - Adds terraform files to the gitignore
 - Don't try to delete the terraform state bucket (It causes unrecoverable errors) when changing prefix
   - Instead, run `cloud/deploys/dev_aws/bin/terraform-setup state rm module.setup.aws_s3_bucket.backend_state_bucket` to remove it from the state
 - Add scripts to run terraform directly, when needed. 
 - Pipe SES_SENDER_EMAIL into terraform.
 