### PR TITLE
change .input to .email in EditTrustedIntermediaryGroupView file

### DIFF
--- a/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
+++ b/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
@@ -73,7 +73,7 @@ public class EditTrustedIntermediaryGroupView extends BaseHtmlView {
             .withAction(
                 routes.TrustedIntermediaryManagementController.addIntermediary(tiGroup.id).url());
     FieldWithLabel emailField =
-        FieldWithLabel.input()
+        FieldWithLabel.email()
             .setId("group-name-input")
             .setFieldName("emailAddress")
             .setLabelText("Member Email Address")


### PR DESCRIPTION
### Description

Changed `.input()` to `.email()` in EditTrustedIntermediaryGroupView.java file.

### Issue(s)

Fixes [#2762](https://github.com/seattle-uat/civiform/issues/2762) emailField should call .email() instead of .input() in EditTrustedIntermediaryGroupView.java
