### PR TITLE
Update canonical question identifier from "Applicant Name" to "Name"

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -23,7 +23,7 @@ describe('normal question lifecycle', () => {
     const adminQuestions = new AdminQuestions(page)
 
     await adminQuestions.gotoAdminQuestionsPage()
-    await adminQuestions.expectDraftQuestionExist('Applicant Name')
+    await adminQuestions.expectDraftQuestionExist('Name')
     await adminQuestions.expectDraftQuestionExist('Applicant Date of Birth')
 
     await endSession(browser)

--- a/server/app/controllers/dev/DatabaseSeedController.java
+++ b/server/app/controllers/dev/DatabaseSeedController.java
@@ -115,6 +115,11 @@ public class DatabaseSeedController extends DevController {
   }
 
   private QuestionDefinition insertNameQuestionDefinition() {
+    // TODO(#2843): Remove this in favor of the question definition
+    // created by the seed canonical questions task. This doesn't currently
+    // conflict with the canonical question since it has a different
+    // character casing. When constructing the mock program above, the
+    // canonical name question will need to be retrieved.
     return questionService
         .create(
             new NameQuestionDefinition(

--- a/server/app/services/WellKnownPaths.java
+++ b/server/app/services/WellKnownPaths.java
@@ -3,8 +3,7 @@ package services;
 /** WellKnownPaths are paths commonly referenced, e.g. the applicant's name. */
 public class WellKnownPaths {
   // These need to stay in sync with the correct paths for a top-level question
-  // asking the applicant their name.  We currently assume that question is called
-  // `name`, and use the path suffixes from `NameQuestionDefinition`.
+  // asking the applicant their name. This is seeded by the DatabaseSeedTask.
   public static Path APPLICANT_FIRST_NAME = Path.create("applicant.name.first_name");
   public static Path APPLICANT_MIDDLE_NAME = Path.create("applicant.name.middle_name");
   public static Path APPLICANT_LAST_NAME = Path.create("applicant.name.last_name");

--- a/server/app/tasks/DatabaseSeedTask.java
+++ b/server/app/tasks/DatabaseSeedTask.java
@@ -48,7 +48,7 @@ public final class DatabaseSeedTask {
       ImmutableList.of(
           new QuestionDefinitionBuilder()
               .setQuestionType(QuestionType.NAME)
-              .setName("Applicant Name")
+              .setName("Name")
               .setDescription("The applicant's name")
               .setQuestionText(
                   LocalizedStrings.of(

--- a/server/app/views/applicant/TrustedIntermediaryDashboardView.java
+++ b/server/app/views/applicant/TrustedIntermediaryDashboardView.java
@@ -159,7 +159,8 @@ public class TrustedIntermediaryDashboardView extends BaseHtmlView {
             .setLabelText("Last Name")
             .setValue(request.flash().get("providedLastName").orElse(""))
             .setPlaceholderText("Applicant last name (Required)");
-    // TODO: do something with this field.  currently doesn't do anything.
+    // TODO: do something with this field.  currently doesn't do anything. Add a Path
+    // to WellKnownPaths referencing the canonical date of birth question.
     FieldWithLabel dateOfBirthField =
         FieldWithLabel.date()
             .setId("date-of-birth-input")

--- a/server/test/tasks/DatabaseSeedTaskTest.java
+++ b/server/test/tasks/DatabaseSeedTaskTest.java
@@ -38,7 +38,7 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
             getAllQuestions().stream()
                 .map(Question::getQuestionDefinition)
                 .map(QuestionDefinition::getName))
-        .containsOnly("Applicant Name", "Applicant Date of Birth");
+        .containsOnly("Name", "Applicant Date of Birth");
   }
 
   @Test
@@ -62,7 +62,7 @@ public class DatabaseSeedTaskTest extends ResetPostgres {
             getAllQuestions().stream()
                 .map(Question::getQuestionDefinition)
                 .map(QuestionDefinition::getName))
-        .containsOnly("Applicant Name", "Applicant Date of Birth");
+        .containsOnly("Name", "Applicant Date of Birth");
   }
 
   private Set<Question> getAllQuestions() {


### PR DESCRIPTION
### Description

Switching the canonical seed task from 'Applicant Name' to 'Name' since our internal code expects the well-known name question to be called 'Name' rather than 'Applicant Name'.

Left a TODO to remove a duplicative 'name' question from the `/dev/seed` endpoint since the QuestionService doesn't presently expose sufficient plumbing to retrieve the canonical `QuestionDefinition`.

### Issue(s)

#2843