### PR TITLE
Tag the AWS terraform resources for easier identification

### DIFF
--- a/cloud/aws/modules/custom_domain/main.tf
+++ b/cloud/aws/modules/custom_domain/main.tf
@@ -4,6 +4,11 @@ data "aws_route53_zone" "civiform" {
 }
 
 resource "aws_route53_record" "civiform_domain_record" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Domain Record"
+    Type = "Civiform Domain Record"
+  }
+
   name    = var.custom_subdomain
   zone_id = data.aws_route53_zone.civiform.zone_id
   type    = "CNAME"
@@ -15,6 +20,11 @@ resource "aws_route53_record" "civiform_domain_record" {
 # The records are only known after AppRunner is up and associated with custom domain.
 # to make this work we need to run terraform apply -target aws_apprunner_custom_domain_association.civiform_domain first
 resource "aws_route53_record" "civiform_domain_validation" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Domain Validation"
+    Type = "Civiform Domain Validation"
+  }
+
   for_each = {
     for dvo in aws_apprunner_custom_domain_association.civiform_domain.certificate_validation_records : dvo.name => {
       name   = dvo.name
@@ -32,6 +42,11 @@ resource "aws_route53_record" "civiform_domain_validation" {
 
 
 resource "aws_apprunner_custom_domain_association" "civiform_domain" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Domain"
+    Type = "Civiform Domain"
+  }
+
   domain_name = "staging-aws.civiform.dev"
   service_arn = var.apprunner_arn
 }

--- a/cloud/aws/modules/setup/backend_storage.tf
+++ b/cloud/aws/modules/setup/backend_storage.tf
@@ -1,4 +1,8 @@
 resource "aws_s3_bucket" "backend_state_bucket" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Backend State Bucket"
+    Type = "Civiform Backend State Bucket"
+  }
   bucket = "${var.app_prefix}-backendstate"
 }
 
@@ -10,6 +14,10 @@ resource "aws_s3_bucket_versioning" "backend_state_versioning" {
 }
 
 resource "aws_kms_key" "backend_storage_key" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Backend Storage Key"
+    Type = "Civiform Backend Storage Key"
+  }
   description             = "This key is used to encrypt backend state bucket objects"
   deletion_window_in_days = 10
 }
@@ -54,6 +62,10 @@ data "aws_iam_policy_document" "backend_state_files_policy" {
 }
 
 resource "aws_dynamodb_table" "state_locking" {
+  tags = {
+    Name = "${var.app_prefix} Civiform DynamoDB State Lock"
+    Type = "Civiform DynamoDB State Lock"
+  }
   hash_key = "LockID"
   name     = "${var.app_prefix}-locktable"
   attribute {

--- a/cloud/aws/modules/setup/logbucket.tf
+++ b/cloud/aws/modules/setup/logbucket.tf
@@ -1,6 +1,11 @@
 # TODO this is actually should be an input into filestorage
 # b/c it relies on this
 resource "aws_s3_bucket" "log_bucket" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Logs"
+    Type = "Civiform Logs"
+  }
+
   bucket = "${var.app_prefix}-logs"
 }
 

--- a/cloud/aws/modules/setup/main.tf
+++ b/cloud/aws/modules/setup/main.tf
@@ -9,4 +9,11 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+  default_tags {
+    tags = {
+      Group       = "setup-${var.app_prefix}"
+      Environment = "${var.civiform_mode}"
+      Service     = "Civiform Setup"
+    }
+  }
 }

--- a/cloud/aws/modules/setup/secrets.tf
+++ b/cloud/aws/modules/setup/secrets.tf
@@ -2,6 +2,10 @@
 # isn't totally necessary, but allows for custom IAM
 # policies on the key
 resource "aws_kms_key" "civiform_kms_key" {
+  tags = {
+    Name = "${var.app_prefix} Civiform KMS Key"
+    Type = "Civiform KMS Key"
+  }
   description             = "KMS key for civiform"
   deletion_window_in_days = 10
 }
@@ -14,6 +18,10 @@ resource "random_password" "postgres_username" {
 
 # Creating a AWS secret for postgres_username
 resource "aws_secretsmanager_secret" "postgres_username_secret" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Postgres Username Secret"
+    Type = "Civiform Postgres Username Secret"
+  }
   name       = "${var.app_prefix}-postgres_username"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
 }
@@ -32,6 +40,10 @@ resource "random_password" "postgres_password" {
 
 # Creating a AWS secret for postgres_password
 resource "aws_secretsmanager_secret" "postgres_password_secret" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Postgres Password Secret"
+    Type = "Civiform Postgres Password Secret"
+  }
   name       = "${var.app_prefix}-postgres_password"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
 }
@@ -51,6 +63,10 @@ resource "random_password" "app_secret_key" {
 
 # Creating a AWS secret for app_secret_key
 resource "aws_secretsmanager_secret" "app_secret_key_secret" {
+  tags = {
+    Name = "${var.app_prefix} Civiform App Secret Secret"
+    Type = "Civiform App Secret Secret"
+  }
   name = "${var.app_prefix}-app_secret_key"
 }
 
@@ -62,6 +78,10 @@ resource "aws_secretsmanager_secret_version" "app_secret_key_secret_version" {
 
 # Creating a AWS secret for adfs_secret
 resource "aws_secretsmanager_secret" "adfs_secret_secret" {
+  tags = {
+    Name = "${var.app_prefix} Civiform ADFS Secret Secret"
+    Type = "Civiform ADFS Secret Secret"
+  }
   name       = "${var.app_prefix}-adfs_secret"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
 }
@@ -74,6 +94,10 @@ resource "aws_secretsmanager_secret_version" "adfs_secret_secret_version" {
 
 # Creating a AWS secret for adfs_client_id
 resource "aws_secretsmanager_secret" "adfs_client_id_secret" {
+  tags = {
+    Name = "${var.app_prefix} Civiform ADFS Client ID Secret"
+    Type = "Civiform ADFS Client ID Secret"
+  }
   name       = "${var.app_prefix}-adfs_client_id"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
 }
@@ -86,6 +110,10 @@ resource "aws_secretsmanager_secret_version" "adfs_client_id_secret_version" {
 
 # Creating a AWS secret for adfs_discovery_uri
 resource "aws_secretsmanager_secret" "adfs_discovery_uri_secret" {
+  tags = {
+    Name = "${var.app_prefix} Civiform ADFS Discovery URI Secret"
+    Type = "Civiform ADFS Discovery URI Secret"
+  }
   name       = "${var.app_prefix}-adfs_discovery_uri"
   kms_key_id = aws_kms_key.civiform_kms_key.arn
 }

--- a/cloud/aws/modules/setup/variables.tf
+++ b/cloud/aws/modules/setup/variables.tf
@@ -3,9 +3,13 @@ variable "app_prefix" {
   description = "A prefix to add to values so we can have multiple deploys in the same aws account"
 }
 
+variable "civiform_mode" {
+  type        = string
+  description = "The civiform environment mode (test/dev/staging/prod)"
+}
+
 variable "aws_region" {
   type        = string
   description = "Region where the AWS servers will live"
   default     = "us-east-1"
 }
-

--- a/cloud/aws/templates/aws_oidc/aim.tf
+++ b/cloud/aws/templates/aws_oidc/aim.tf
@@ -1,4 +1,8 @@
 resource "aws_iam_role" "apprunner_instance_role" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Apprunner Role"
+    Type = "Civiform Apprunner Role"
+  }
   name               = "${var.app_prefix}-AppRunnerInstanceRole"
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.apprunner_instance_assume_policy.json
@@ -16,6 +20,10 @@ data "aws_iam_policy_document" "apprunner_instance_assume_policy" {
 }
 
 resource "aws_iam_policy" "apprunner_s3_policy" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Apprunner S3 Policy"
+    Type = "Civiform Apprunner S3 Policy"
+  }
   name   = "${var.app_prefix}-apprunner_s3_policy"
   policy = data.aws_iam_policy_document.apprunner_instance_s3_policy.json
 }

--- a/cloud/aws/templates/aws_oidc/autoscaling.tf
+++ b/cloud/aws/templates/aws_oidc/autoscaling.tf
@@ -1,5 +1,9 @@
 # TODO: determine reasonable max concurrency for a civiform server
 resource "aws_apprunner_auto_scaling_configuration_version" "auto_scaling_config" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Autoscaling"
+    Type = "Civiform Autoscaling"
+  }
   auto_scaling_configuration_name = "${var.app_prefix}-civiform_config"
   max_concurrency                 = var.auto_scaling_config["max_concurrency"]
   max_size                        = var.auto_scaling_config["max_size"]

--- a/cloud/aws/templates/aws_oidc/filestorage.tf
+++ b/cloud/aws/templates/aws_oidc/filestorage.tf
@@ -1,4 +1,9 @@
 resource "aws_s3_bucket" "civiform_files_s3" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Files"
+    Type = "Civiform Files"
+  }
+
   bucket = "${var.app_prefix}-${var.file_storage_bucket}"
 }
 

--- a/cloud/aws/templates/aws_oidc/main.tf
+++ b/cloud/aws/templates/aws_oidc/main.tf
@@ -5,6 +5,10 @@ module "secrets" {
 }
 
 resource "aws_apprunner_service" "civiform_dev" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Server"
+    Type = "Civiform Server"
+  }
   auto_scaling_configuration_arn = aws_apprunner_auto_scaling_configuration_version.auto_scaling_config.arn
   service_name                   = "${var.app_prefix}-civiform_dev"
 
@@ -72,6 +76,11 @@ resource "aws_apprunner_service" "civiform_dev" {
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Parameters.html#Appendix.PostgreSQL.CommonDBATasks.Parameters.parameters-list
 resource "aws_db_parameter_group" "civiform" {
   name   = "${var.app_prefix}-civiform"
+  tags = {
+    Name = "${var.app_prefix} Civiform DB Parameters"
+    Type = "Civiform DB Parameters"
+  }
+
   family = "postgres12"
 
   parameter {
@@ -82,6 +91,11 @@ resource "aws_db_parameter_group" "civiform" {
 
 resource "aws_db_instance" "civiform" {
   identifier              = "${var.app_prefix}-${var.postgress_name}"
+  tags = {
+    Name = "${var.app_prefix} Civiform Database"
+    Type = "Civiform Database"
+  }
+
   instance_class          = var.postgres_instance_class
   allocated_storage       = var.postgres_storage_gb
   engine                  = "postgres"

--- a/cloud/aws/templates/aws_oidc/providers.tf
+++ b/cloud/aws/templates/aws_oidc/providers.tf
@@ -10,4 +10,11 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+  default_tags {
+    tags = {
+      Group       = "${var.app_prefix}"
+      Environment = "${var.civiform_mode}"
+      Service     = "Civiform"
+    }
+  }
 }

--- a/cloud/aws/templates/aws_oidc/setup/main.tf
+++ b/cloud/aws/templates/aws_oidc/setup/main.tf
@@ -1,4 +1,5 @@
 module "setup" {
-  source     = "../../../modules/setup"
-  app_prefix = var.app_prefix
+  source        = "../../../modules/setup"
+  app_prefix    = var.app_prefix
+  civiform_mode = var.civiform_mode
 }

--- a/cloud/aws/templates/aws_oidc/setup/variables.tf
+++ b/cloud/aws/templates/aws_oidc/setup/variables.tf
@@ -2,3 +2,8 @@ variable "app_prefix" {
   type        = string
   description = "A prefix to add to values so we can have multiple deploys in the same aws account"
 }
+variable "civiform_mode" {
+  type        = string
+  description = "The civiform environment mode (test/dev/staging/prod)"
+}
+

--- a/cloud/aws/templates/aws_oidc/variables.tf
+++ b/cloud/aws/templates/aws_oidc/variables.tf
@@ -185,3 +185,8 @@ variable "applicant_oidc_additional_scopes" {
   description = "Additional scopes for Applicant oidc"
   default     = "allatclaims"
 }
+
+variable "civiform_mode" {
+  type        = string
+  description = "The civiform environment mode (test/dev/staging/prod)"
+}

--- a/cloud/aws/templates/aws_oidc/vpc.tf
+++ b/cloud/aws/templates/aws_oidc/vpc.tf
@@ -41,13 +41,6 @@ resource "aws_security_group" "rds" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
 }
 
 

--- a/cloud/aws/templates/aws_oidc/vpc.tf
+++ b/cloud/aws/templates/aws_oidc/vpc.tf
@@ -21,6 +21,10 @@ resource "aws_db_subnet_group" "civiform" {
 }
 
 resource "aws_security_group" "rds" {
+  tags = {
+    Name = "${var.app_prefix} Civiform DB Security Group"
+    Type = "Civiform DB Security Group"
+  }
   name   = "${var.app_prefix}-civiform_rds"
   vpc_id = module.vpc.vpc_id
 
@@ -37,9 +41,21 @@ resource "aws_security_group" "rds" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
 }
 
+
 resource "aws_apprunner_vpc_connector" "connector" {
+  tags = {
+    Name = "${var.app_prefix} Civiform Apprunner VPC Connector"
+    Type = "Civiform Apprunner VPC Connector"
+  }
   vpc_connector_name = "${var.app_prefix}-civiform_connector"
   subnets            = module.vpc.private_subnets
   security_groups    = [aws_security_group.rds.id]

--- a/cloud/shared/bin/lib/config_loader.py
+++ b/cloud/shared/bin/lib/config_loader.py
@@ -26,6 +26,10 @@ class ConfigLoader:
     def app_prefix(self):
         return os.environ['APP_PREFIX']
 
+    @property
+    def civiform_mode(self):
+        return os.environ['CIVIFORM_MODE']
+
     def load_config(self):
         self._load_config()
         return self.validate_config()
@@ -94,12 +98,10 @@ class ConfigLoader:
         return self.configs.get("TERRAFORM_TEMPLATE_DIR")
 
     def is_dev(self):
-        civiform_mode = self.configs.get("CIVIFORM_MODE")
-        return civiform_mode == "dev"
+        return self.civiform_mode == "dev"
 
     def is_test(self):
-        civiform_mode = self.configs.get("CIVIFORM_MODE")
-        return civiform_mode == "test"
+        return self.civiform_mode == "test"
 
     def use_backend_config(self):
         return not self.is_dev()

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -82,8 +82,8 @@ try:
 
     print(" - Run terraform apply")
     tf_apply_args = [
-        "terraform", f"-chdir={terraform_template_dir}", "apply", "-input=false",
-        f"-var-file={config_loader.tfvars_filename}"
+        "terraform", f"-chdir={terraform_template_dir}", "apply",
+        "-input=false", f"-var-file={config_loader.tfvars_filename}"
     ]
 
     if not config_loader.is_dev():
@@ -101,8 +101,8 @@ try:
 
         subprocess.check_call(
             [
-                "terraform", f"-chdir={terraform_template_dir}", "apply", "-input=false",
-                f"-var-file={config_loader.tfvars_filename}"
+                "terraform", f"-chdir={terraform_template_dir}", "apply",
+                "-input=false", f"-var-file={config_loader.tfvars_filename}"
             ])
 
     subprocess.run(

--- a/cloud/shared/bin/lib/setup.py
+++ b/cloud/shared/bin/lib/setup.py
@@ -35,8 +35,9 @@ if not is_valid:
 # Load Setup Class for the specific template directory
 ###############################################################################
 
-template_dir = config_loader.get_template_dir()
-Setup = load_setup_class(template_dir)
+terraform_template_dir = config_loader.get_template_dir()
+app_prefix = config_loader.app_prefix
+Setup = load_setup_class(terraform_template_dir)
 
 template_setup = Setup(config_loader)
 template_setup.setup_log_file()
@@ -47,7 +48,7 @@ log_args = f"\"{image_tag}\" {current_user}"
 
 print("Writing TF Vars file")
 terraform_tfvars_path = os.path.join(
-    template_dir, config_loader.tfvars_filename)
+    terraform_template_dir, config_loader.tfvars_filename)
 
 # Write the passthrough vars to a temporary file
 tf_var_writter = TfVarWriter(terraform_tfvars_path)
@@ -66,20 +67,22 @@ try:
     # both the backend config and the var file
     terraform_init_args = [
         "terraform",
-        f"-chdir={template_dir}",
+        f"-chdir={terraform_template_dir}",
         "init",
         "-input=false",
         "-upgrade",
     ]
     if config_loader.use_backend_config():
+        print(f"Using backend config {config_loader.backend_vars_filename}")
         terraform_init_args.append(
             f"-backend-config={config_loader.backend_vars_filename}")
 
     print(" - Run terraform init")
     subprocess.check_call(terraform_init_args)
 
+    print(" - Run terraform apply")
     tf_apply_args = [
-        "terraform", f"-chdir={template_dir}", "apply", "-input=false",
+        "terraform", f"-chdir={terraform_template_dir}", "apply", "-input=false",
         f"-var-file={config_loader.tfvars_filename}"
     ]
 
@@ -98,9 +101,10 @@ try:
 
         subprocess.check_call(
             [
-                "terraform", f"-chdir={template_dir}", "apply", "-input=false",
+                "terraform", f"-chdir={terraform_template_dir}", "apply", "-input=false",
                 f"-var-file={config_loader.tfvars_filename}"
             ])
+
     subprocess.run(
         [
             "/bin/bash", "-c",

--- a/cloud/shared/bin/lib/terraform.py
+++ b/cloud/shared/bin/lib/terraform.py
@@ -14,9 +14,11 @@ def perform_apply(config_loader, is_destroy=False, terraform_template_dir=None):
     terraform_cmd = f'terraform -chdir={terraform_template_dir}'
 
     if config_loader.is_dev():
+        print(" - Run terraform init -upgrade -reconfigure")
         subprocess.check_call(
             shlex.split(f'{terraform_cmd} init -upgrade -reconfigure'))
     else:
+        print(" - Run terraform init -upgrade -reconfigure")
         subprocess.check_call(
             shlex.split(
                 f'{terraform_cmd} init -input=false -upgrade -backend-config={os.getenv("BACKEND_VARS_FILENAME")}'
@@ -30,6 +32,7 @@ def perform_apply(config_loader, is_destroy=False, terraform_template_dir=None):
             f'Aborting the script. {tf_vars_filename} does not exist in {terraform_template_dir} directory'
         )
 
+    print(" - Run terraform plan")
     terraform_plan_out_file = 'terraform_plan'
     plan_arguments = f'{terraform_cmd} plan -input=false -out={terraform_plan_out_file} -var-file={tf_vars_filename}'
     if is_destroy:
@@ -39,6 +42,7 @@ def perform_apply(config_loader, is_destroy=False, terraform_template_dir=None):
     if config_loader.is_test():
         return True
 
+    print(" - Run terraform apply")
     terraform_apply_cmd = f'{terraform_cmd} apply -input=false -json'
     if config_loader.is_dev():
         subprocess.check_call(

--- a/cloud/shared/variable_definitions.json
+++ b/cloud/shared/variable_definitions.json
@@ -52,7 +52,7 @@
   "CIVIFORM_MODE": {
     "required": true,
     "secret": false,
-    "tfvar": false,
+    "tfvar": true,
     "type": "enum",
     "values": ["prod", "staging", "dev", "test"]
   },


### PR DESCRIPTION
### Description

Uses the AWS tagging mechanism to more clearly communicate that this resource is part of civiform, which app_prefix this resource is for, and also what function it is for.

Uses the default tags terraform setting for the app prefix group, civiform label, and environment.  Individual resources are tagged with a name to show their purpose

### Checklist

- [ ] Deployed to aws
