### PR TITLE
Fix typo

### DIFF
--- a/cloud/azure/bin/ses-to-keyvault
+++ b/cloud/azure/bin/ses-to-keyvault
@@ -33,7 +33,7 @@ fi
 echo "Getting an AWS access key"
 CREATED_KEY_RESULT="$(aws::create_access_key "${USERNAME}")"
 ACCESS_KEY_ID="$(aws::parse_access_key_id "${CREATED_KEY_RESULT}")"
-SECRET_ACCESS_KEY="$(aws::parse_access_secret_key "${CREATED_KEY_RESULTt}")"
+SECRET_ACCESS_KEY="$(aws::parse_access_secret_key "${CREATED_KEY_RESULT}")"
 
 echo "Adding the secret access key to the azure key vault"
 key_vault::add_secret "${VAULT_NAME}" "${AWS_SECRET_ACCESS_TOKEN_NAME}" "${SECRET_ACCESS_KEY}"


### PR DESCRIPTION
### Description

The extra 't' tacked on to `CREATED_KEY_RESULT` will result in an empty string being added to the key vault instead of the actual secret access key.

cc @shubha-rajan 

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

None; drive-by.
