### PR TITLE
Add all missing browser test coverage for remaining question types

### DIFF
--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -153,7 +153,7 @@ describe('Checkbox question for applicant flow', () => {
       await loginAsGuest(pageObject)
       await selectApplicantLanguage(pageObject, 'English')
 
-      // Only answer first question. Leave second question blank.
+      // Only answer required question.
       await applicantQuestions.applyProgram(programName)
       await applicantQuestions.answerCheckboxQuestion(['red'])
       await applicantQuestions.clickNext()

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -74,6 +74,10 @@ describe('Checkbox question for applicant flow', () => {
       // Check checkbox error and required error are present.
       expect(await pageObject.isHidden(checkBoxError)).toEqual(false)
       const checkboxId = '.cf-question-checkbox'
+<<<<<<< HEAD
+=======
+      // Contains this substring. Is this brittle? Would have to update text every time. Or can I add an ID just for testing?
+>>>>>>> f46b6f4a (Add checkbox browser test)
       expect(await pageObject.innerText(checkboxId)).toContain(
         'This question is required.',
       )
@@ -149,7 +153,11 @@ describe('Checkbox question for applicant flow', () => {
       await applicantQuestions.submitFromReviewPage(programName)
     })
 
+<<<<<<< HEAD
     it('with unanswered optional question submits successfully', async () => {
+=======
+    it('unanswered optional question submits successfully', async () => {
+>>>>>>> f46b6f4a (Add checkbox browser test)
       await loginAsGuest(pageObject)
       await selectApplicantLanguage(pageObject, 'English')
 

--- a/browser-test/src/checkbox.test.ts
+++ b/browser-test/src/checkbox.test.ts
@@ -36,8 +36,8 @@ describe('Checkbox question for applicant flow', () => {
       await adminQuestions.addCheckboxQuestion({
         questionName: 'checkbox-color-q',
         options: ['red', 'green', 'orange', 'blue'],
-        minNumChoices: 1,
-        maxNumChoices: 2,
+        minNum: 1,
+        maxNum: 2,
       })
       await adminPrograms.addAndPublishProgramWithQuestions(
         ['checkbox-color-q'],
@@ -74,10 +74,6 @@ describe('Checkbox question for applicant flow', () => {
       // Check checkbox error and required error are present.
       expect(await pageObject.isHidden(checkBoxError)).toEqual(false)
       const checkboxId = '.cf-question-checkbox'
-<<<<<<< HEAD
-=======
-      // Contains this substring. Is this brittle? Would have to update text every time. Or can I add an ID just for testing?
->>>>>>> f46b6f4a (Add checkbox browser test)
       expect(await pageObject.innerText(checkboxId)).toContain(
         'This question is required.',
       )
@@ -118,14 +114,14 @@ describe('Checkbox question for applicant flow', () => {
       await adminQuestions.addCheckboxQuestion({
         questionName: 'checkbox-fave-color-q',
         options: ['red', 'green', 'orange', 'blue'],
-        minNumChoices: 1,
-        maxNumChoices: 2,
+        minNum: 1,
+        maxNum: 2,
       })
       await adminQuestions.addCheckboxQuestion({
         questionName: 'checkbox-vacation-q',
         options: ['beach', 'mountains', 'city', 'cruise'],
-        minNumChoices: 1,
-        maxNumChoices: 2,
+        minNum: 1,
+        maxNum: 2,
       })
 
       await adminPrograms.addProgram(programName)
@@ -146,24 +142,20 @@ describe('Checkbox question for applicant flow', () => {
       await selectApplicantLanguage(pageObject, 'English')
 
       await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerCheckboxQuestion(['blue'], 0)
-      await applicantQuestions.answerCheckboxQuestion(['beach'], 1)
+      await applicantQuestions.answerCheckboxQuestion(['blue'])
+      await applicantQuestions.answerCheckboxQuestion(['beach'])
       await applicantQuestions.clickNext()
 
       await applicantQuestions.submitFromReviewPage(programName)
     })
 
-<<<<<<< HEAD
     it('with unanswered optional question submits successfully', async () => {
-=======
-    it('unanswered optional question submits successfully', async () => {
->>>>>>> f46b6f4a (Add checkbox browser test)
       await loginAsGuest(pageObject)
       await selectApplicantLanguage(pageObject, 'English')
 
       // Only answer first question. Leave second question blank.
       await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.answerCheckboxQuestion(['red'], 0)
+      await applicantQuestions.answerCheckboxQuestion(['red'])
       await applicantQuestions.clickNext()
 
       await applicantQuestions.submitFromReviewPage(programName)
@@ -183,7 +175,7 @@ describe('Checkbox question for applicant flow', () => {
         ['red', 'green', 'orange'],
         0,
       )
-      await applicantQuestions.answerCheckboxQuestion(['beach'], 1)
+      await applicantQuestions.answerCheckboxQuestion(['beach'])
       await applicantQuestions.clickNext()
 
       expect(await pageObject.isHidden(checkboxError)).toEqual(false)
@@ -198,7 +190,7 @@ describe('Checkbox question for applicant flow', () => {
       // No validation errors on first page load.
       expect(await pageObject.isHidden(checkboxError)).toEqual(true)
 
-      await applicantQuestions.answerCheckboxQuestion(['red'], 0)
+      await applicantQuestions.answerCheckboxQuestion(['red'])
       // Max of 2 answers allowed.
       await applicantQuestions.answerCheckboxQuestion(
         ['beach', 'mountains', 'city'],

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -10,8 +10,6 @@ import {
   resetSession,
 } from './support'
 
-// Date validation is done by browser itself, so we do not test it here.
-
 describe('Date question for applicant flow', () => {
   let pageObject
 

--- a/browser-test/src/date.test.ts
+++ b/browser-test/src/date.test.ts
@@ -33,9 +33,9 @@ describe('Date question for applicant flow', () => {
       const adminPrograms = new AdminPrograms(pageObject)
       applicantQuestions = new ApplicantQuestions(pageObject)
 
-      await adminQuestions.addDateQuestion({questionName: 'date-q'})
+      await adminQuestions.addDateQuestion({questionName: 'general-date-q'})
       await adminPrograms.addAndPublishProgramWithQuestions(
-        ['date-q'],
+        ['general-date-q'],
         programName,
       )
 

--- a/browser-test/src/dropdown.test.ts
+++ b/browser-test/src/dropdown.test.ts
@@ -1,0 +1,130 @@
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  selectApplicantLanguage,
+  startSession,
+  resetSession,
+} from './support'
+
+describe('Dropdown question for applicant flow', () => {
+  let pageObject
+
+  beforeAll(async () => {
+    const {page} = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single dropdown question', () => {
+    let applicantQuestions
+    const programName = 'test program for single dropdown'
+
+    beforeAll(async () => {
+      // As admin, create program with single dropdown question.
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addDropdownQuestion({
+        questionName: 'dropdown-color-q',
+        options: ['red', 'green', 'orange', 'blue'],
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['dropdown-color-q'],
+        programName,
+      )
+
+      await logout(pageObject)
+    })
+
+    it('with selected option submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerDropdownQuestion('green')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with no selection does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      // Click next without selecting anything.
+      await applicantQuestions.clickNext()
+
+      const dropdownId = '.cf-question-dropdown'
+      expect(await pageObject.innerText(dropdownId)).toContain(
+        'This question is required.',
+      )
+    })
+  })
+
+  describe('multiple dropdown questions', () => {
+    let applicantQuestions
+    const programName = 'test program for multiple dropdowns'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addDropdownQuestion({
+        questionName: 'dropdown-fave-vacation-q',
+        options: ['beach', 'mountains', 'city', 'cruise'],
+      })
+      await adminQuestions.addDropdownQuestion({
+        questionName: 'dropdown-fave-color-q',
+        options: ['red', 'green', 'orange', 'blue'],
+      })
+
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+        programName,
+        'Optional question block',
+        ['dropdown-fave-color-q'],
+        'dropdown-fave-vacation-q', // optional
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with selected options submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerDropdownQuestion('beach', 0)
+      await applicantQuestions.answerDropdownQuestion('blue', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with unanswered optional question submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      // Only answer second question. First is optional.
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerDropdownQuestion('red', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+  })
+})

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -33,9 +33,9 @@ describe('Email question for applicant flow', () => {
       const adminPrograms = new AdminPrograms(pageObject)
       applicantQuestions = new ApplicantQuestions(pageObject)
 
-      await adminQuestions.addEmailQuestion({questionName: 'email-q'})
+      await adminQuestions.addEmailQuestion({questionName: 'general-email-q'})
       await adminPrograms.addAndPublishProgramWithQuestions(
-        ['email-q'],
+        ['general-email-q'],
         programName,
       )
 

--- a/browser-test/src/email.test.ts
+++ b/browser-test/src/email.test.ts
@@ -1,0 +1,121 @@
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  selectApplicantLanguage,
+  startSession,
+  resetSession,
+} from './support'
+
+describe('Email question for applicant flow', () => {
+  let pageObject
+
+  beforeAll(async () => {
+    const {page} = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single email question', () => {
+    let applicantQuestions
+    const programName = 'test program for single email'
+
+    beforeAll(async () => {
+      // As admin, create program with single email question.
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addEmailQuestion({questionName: 'email-q'})
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['email-q'],
+        programName,
+      )
+
+      await logout(pageObject)
+    })
+
+    it('with email input submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerEmailQuestion('my_email@civiform.gov')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with no email input does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      // Click next without inputting anything.
+      await applicantQuestions.clickNext()
+
+      const emailId = '.cf-question-email'
+      expect(await pageObject.innerText(emailId)).toContain(
+        'This question is required.',
+      )
+    })
+  })
+
+  describe('multiple email questions', () => {
+    let applicantQuestions
+    const programName = 'test program for multiple emails'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addEmailQuestion({questionName: 'my-email-q'})
+      await adminQuestions.addEmailQuestion({questionName: 'your-email-q'})
+
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+        programName,
+        'Optional question block',
+        ['my-email-q'],
+        'your-email-q', // optional
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with email inputs submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerEmailQuestion('your_email@civiform.gov', 0)
+      await applicantQuestions.answerEmailQuestion('my_email@civiform.gov', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with unanswered optional question submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      // Only answer second question. First is optional.
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerEmailQuestion('my_email@civiform.gov', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+  })
+})

--- a/browser-test/src/id.test.ts
+++ b/browser-test/src/id.test.ts
@@ -1,0 +1,202 @@
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  selectApplicantLanguage,
+  startSession,
+  resetSession,
+} from './support'
+
+describe('Id question for applicant flow', () => {
+  let pageObject
+
+  beforeAll(async () => {
+    const {page} = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single id question', () => {
+    let applicantQuestions
+    const programName = 'test program for single id'
+
+    beforeAll(async () => {
+      // As admin, create program with single id question.
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addIdQuestion({
+        questionName: 'id-q',
+        minNum: 5,
+        maxNum: 5,
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['id-q'],
+        programName,
+      )
+
+      await logout(pageObject)
+    })
+
+    it('with id submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('12345')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with empty id does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      // Click next without inputting anything
+      await applicantQuestions.clickNext()
+
+      const identificationId = '.cf-question-id'
+      expect(await pageObject.innerText(identificationId)).toContain(
+        'This question is required.',
+      )
+    })
+
+    it('with too short id does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('123')
+      await applicantQuestions.clickNext()
+
+      const identificationId = '.cf-question-id'
+      expect(await pageObject.innerText(identificationId)).toContain(
+        'Must contain at least 5 characters.',
+      )
+    })
+
+    it('with too long id does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('123456')
+      await applicantQuestions.clickNext()
+
+      const identificationId = '.cf-question-id'
+      expect(await pageObject.innerText(identificationId)).toContain(
+        'Must contain at most 5 characters.',
+      )
+    })
+
+    it('with non-numeric characters does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('abcde')
+      await applicantQuestions.clickNext()
+
+      const identificationId = '.cf-question-id'
+      expect(await pageObject.innerText(identificationId)).toContain(
+        'Must contain only numbers.',
+      )
+    })
+  })
+
+  describe('multiple id questions', () => {
+    let applicantQuestions
+    const programName = 'test program for multiple ids'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addIdQuestion({
+        questionName: 'my-id-q',
+      })
+      await adminQuestions.addIdQuestion({
+        questionName: 'your-id-q',
+      })
+
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+        programName,
+        'Optional question block',
+        ['my-id-q'],
+        'your-id-q', // optional
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with both id inputs submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('12345', 0)
+      await applicantQuestions.answerIdQuestion('67890', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with unanswered optional question submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      // Only answer second question. First is optional.
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('67890', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with first invalid does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('abcde', 0)
+      await applicantQuestions.answerIdQuestion('67890', 1)
+      await applicantQuestions.clickNext()
+
+      const identificationId = '.cf-question-id'
+      expect(await pageObject.innerText(identificationId)).toContain(
+        'Must contain only numbers.',
+      )
+    })
+
+    it('with second invalid does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerIdQuestion('67890', 0)
+      await applicantQuestions.answerIdQuestion('abcde', 1)
+      await applicantQuestions.clickNext()
+
+      const identificationId = `.cf-question-id >> nth=1`
+      expect(await pageObject.innerText(identificationId)).toContain(
+        'Must contain only numbers.',
+      )
+    })
+  })
+})

--- a/browser-test/src/radio_button.test.ts
+++ b/browser-test/src/radio_button.test.ts
@@ -1,0 +1,132 @@
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  selectApplicantLanguage,
+  startSession,
+  resetSession,
+} from './support'
+
+describe('Radio button question for applicant flow', () => {
+  let pageObject
+
+  beforeAll(async () => {
+    const {page} = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single radio button question', () => {
+    let applicantQuestions
+    const programName = 'test program for single radio button'
+
+    beforeAll(async () => {
+      // As admin, create program with radio button question.
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addRadioButtonQuestion({
+        questionName: 'ice-cream-radio-q',
+        options: ['matcha', 'strawberry', 'vanilla'],
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['ice-cream-radio-q'],
+        programName,
+      )
+
+      await logout(pageObject)
+    })
+
+    it('with selection submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerRadioButtonQuestion('matcha')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with empty selection does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      // Click next without inputting anything
+      await applicantQuestions.clickNext()
+
+      const radioButtonId = '.cf-question-radio'
+      expect(await pageObject.innerText(radioButtonId)).toContain(
+        'This question is required.',
+      )
+    })
+  })
+
+  describe('multiple radio button questions', () => {
+    let applicantQuestions
+    const programName = 'test program for multiple radio button qs'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addRadioButtonQuestion({
+        questionName: 'fave-ice-cream-q',
+        options: ['matcha', 'strawberry', 'vanilla'],
+      })
+
+      await adminQuestions.addCheckboxQuestion({
+        questionName: 'fave-vacation-q',
+        options: ['beach', 'mountains', 'city', 'cruise'],
+      })
+
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+        programName,
+        'Optional question block',
+        ['fave-ice-cream-q'],
+        'fave-vacation-q', // optional
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with both selections submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerRadioButtonQuestion('matcha')
+      await applicantQuestions.answerRadioButtonQuestion('mountains')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with unanswered optional question submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      // Only answer second question. First is optional.
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerRadioButtonQuestion('matcha')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+  })
+})

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -30,9 +30,9 @@ describe('Static text question for applicant flow', () => {
       questionText: staticText,
     })
     // Must add an answerable question for text to show.
-    await adminQuestions.addEmailQuestion({questionName: 'email-q'})
+    await adminQuestions.addEmailQuestion({questionName: 'partner-email-q'})
     await adminPrograms.addAndPublishProgramWithQuestions(
-      ['static-text-q', 'email-q'],
+      ['static-text-q', 'partner-email-q'],
       programName,
     )
 

--- a/browser-test/src/static_text.test.ts
+++ b/browser-test/src/static_text.test.ts
@@ -1,0 +1,55 @@
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  selectApplicantLanguage,
+  startSession,
+  resetSession,
+} from './support'
+
+describe('Static text question for applicant flow', () => {
+  const staticText = 'Hello, I am some static text!'
+  const programName = 'test program for static text'
+  let pageObject
+  let applicantQuestions
+
+  beforeAll(async () => {
+    const {page} = await startSession()
+    pageObject = page
+    // As admin, create program with static text question.
+    await loginAsAdmin(pageObject)
+    const adminQuestions = new AdminQuestions(pageObject)
+    const adminPrograms = new AdminPrograms(pageObject)
+    applicantQuestions = new ApplicantQuestions(pageObject)
+
+    await adminQuestions.addStaticQuestion({
+      questionName: 'static-text-q',
+      questionText: staticText,
+    })
+    // Must add an answerable question for text to show.
+    await adminQuestions.addEmailQuestion({questionName: 'email-q'})
+    await adminPrograms.addAndPublishProgramWithQuestions(
+      ['static-text-q', 'email-q'],
+      programName,
+    )
+
+    await logout(pageObject)
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  it('displays static text', async () => {
+    await loginAsGuest(pageObject)
+    await selectApplicantLanguage(pageObject, 'English')
+
+    await applicantQuestions.applyProgram(programName)
+
+    const staticId = '.cf-question-static'
+    expect(await pageObject.innerText(staticId)).toContain(staticText)
+  })
+})

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -3,8 +3,8 @@ import {waitForPageJsLoad} from './wait'
 
 type QuestionParams = {
   questionName: string
-  minNumChoices?: number | null
-  maxNumChoices?: number | null
+  minNum?: number | null
+  maxNum?: number | null
   options?: Array<string>
   description?: string
   questionText?: string
@@ -413,8 +413,8 @@ export class AdminQuestions {
   async addCheckboxQuestion({
     questionName,
     options,
-    minNumChoices = null,
-    maxNumChoices = null,
+    minNum = null,
+    maxNum = null,
     description = 'checkbox description',
     questionText = 'checkbox question text',
     helpText = 'checkbox question help text',
@@ -436,16 +436,16 @@ export class AdminQuestions {
       exportOption,
     })
 
-    if (minNumChoices != null) {
+    if (minNum != null) {
       await this.page.fill(
         'label:has-text("Minimum number of choices required")',
-        String(minNumChoices),
+        String(minNum),
       )
     }
-    if (maxNumChoices != null) {
+    if (maxNum != null) {
       await this.page.fill(
         'label:has-text("Maximum number of choices allowed")',
-        String(maxNumChoices),
+        String(maxNum),
       )
     }
 
@@ -738,6 +738,8 @@ export class AdminQuestions {
     description = 'text description',
     questionText = 'text question text',
     helpText = 'text question help text',
+    minNum = null,
+    maxNum = null,
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
     exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
@@ -756,6 +758,13 @@ export class AdminQuestions {
       exportOption,
     })
 
+    if (minNum != null) {
+      await this.page.fill('label:has-text("Minimum length")', String(minNum))
+    }
+    if (maxNum != null) {
+      await this.page.fill('label:has-text("Maximum length")', String(maxNum))
+    }
+
     await this.clickSubmitButtonAndNavigate('Create')
 
     await this.expectAdminQuestionsPageWithCreateSuccessToast()
@@ -768,6 +777,8 @@ export class AdminQuestions {
     description = 'id description',
     questionText = 'id question text',
     helpText = 'id question help text',
+    minNum = null,
+    maxNum = null,
     enumeratorName = AdminQuestions.DOES_NOT_REPEAT_OPTION,
     exportOption = AdminQuestions.NO_EXPORT_OPTION,
   }: QuestionParams) {
@@ -785,6 +796,13 @@ export class AdminQuestions {
       enumeratorName,
       exportOption,
     })
+
+    if (minNum != null) {
+      await this.page.fill('label:has-text("Minimum length")', String(minNum))
+    }
+    if (maxNum != null) {
+      await this.page.fill('label:has-text("Maximum length")', String(maxNum))
+    }
 
     await this.clickSubmitButtonAndNavigate('Create')
 

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -91,18 +91,21 @@ export class ApplicantQuestions {
     })
   }
 
-  async answerIdQuestion(id: string) {
-    await this.page.fill('input[type="text"]', id)
+  async answerIdQuestion(id: string, index = 0) {
+    await this.page.fill(`input[type="text"] >> nth=${index}`, id)
   }
 
   async answerRadioButtonQuestion(checked: string) {
     await this.page.check(`text=${checked}`)
   }
 
-  async answerDropdownQuestion(selected: string) {
-    await this.page.selectOption('.cf-dropdown-question select', {
-      label: selected,
-    })
+  async answerDropdownQuestion(selected: string, index = 0) {
+    await this.page.selectOption(
+      `.cf-dropdown-question select >> nth=${index}`,
+      {
+        label: selected,
+      },
+    )
   }
 
   async answerNumberQuestion(number: string) {
@@ -114,8 +117,8 @@ export class ApplicantQuestions {
     await this.validateInputValue(number)
   }
 
-  async answerDateQuestion(date: string) {
-    await this.page.fill('input[type="date"]', date)
+  async answerDateQuestion(date: string, index = 0) {
+    await this.page.fill(`input[type="date"] >> nth=${index}`, date)
   }
 
   async checkDateQuestionValue(date: string) {
@@ -123,12 +126,12 @@ export class ApplicantQuestions {
     await this.validateInputValue(date)
   }
 
-  async answerTextQuestion(text: string) {
-    await this.page.fill('input[type="text"]', text)
+  async answerTextQuestion(text: string, index = 0) {
+    await this.page.fill(`input[type="text"] >> nth=${index}`, text)
   }
 
-  async answerEmailQuestion(email: string) {
-    await this.page.fill('input[type="email"]', email)
+  async answerEmailQuestion(email: string, index = 0) {
+    await this.page.fill(`input[type="email"] >> nth=${index}`, email)
   }
 
   async checkEmailQuestionValue(email: string) {

--- a/browser-test/src/text.test.ts
+++ b/browser-test/src/text.test.ts
@@ -1,0 +1,200 @@
+import {
+  AdminPrograms,
+  AdminQuestions,
+  ApplicantQuestions,
+  loginAsAdmin,
+  loginAsGuest,
+  logout,
+  selectApplicantLanguage,
+  startSession,
+  resetSession,
+} from './support'
+
+describe('Text question for applicant flow', () => {
+  let pageObject
+
+  beforeAll(async () => {
+    const {page} = await startSession()
+    pageObject = page
+  })
+
+  afterEach(async () => {
+    await resetSession(pageObject)
+  })
+
+  describe('single text question', () => {
+    let applicantQuestions
+    const programName = 'test program for single text q'
+
+    beforeAll(async () => {
+      // As admin, create program with a free form text question.
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addTextQuestion({
+        questionName: 'text-q',
+        minNum: 5,
+        maxNum: 20,
+      })
+      await adminPrograms.addAndPublishProgramWithQuestions(
+        ['text-q'],
+        programName,
+      )
+
+      await logout(pageObject)
+    })
+
+    it('with text submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('I love CiviForm!')
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with empty text does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+
+      // Click next without inputting anything
+      await applicantQuestions.clickNext()
+
+      const textId = '.cf-question-text'
+      expect(await pageObject.innerText(textId)).toContain(
+        'This question is required.',
+      )
+    })
+
+    it('with too short text does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('hi')
+      await applicantQuestions.clickNext()
+
+      const textId = '.cf-question-text'
+      expect(await pageObject.innerText(textId)).toContain(
+        'Must contain at least 5 characters.',
+      )
+    })
+
+    it('with too long text does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion(
+        'A long string that exceeds the character limit',
+      )
+      await applicantQuestions.clickNext()
+
+      const textId = '.cf-question-text'
+      expect(await pageObject.innerText(textId)).toContain(
+        'Must contain at most 20 characters.',
+      )
+    })
+  })
+
+  describe('multiple text questions', () => {
+    let applicantQuestions
+    const programName = 'test program for multiple text qs'
+
+    beforeAll(async () => {
+      await loginAsAdmin(pageObject)
+      const adminQuestions = new AdminQuestions(pageObject)
+      const adminPrograms = new AdminPrograms(pageObject)
+      applicantQuestions = new ApplicantQuestions(pageObject)
+
+      await adminQuestions.addTextQuestion({
+        questionName: 'first-text-q',
+        minNum: 5,
+        maxNum: 20,
+      })
+      await adminQuestions.addTextQuestion({
+        questionName: 'second-text-q',
+        minNum: 5,
+        maxNum: 20,
+      })
+
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.editProgramBlockWithOptional(
+        programName,
+        'Optional question block',
+        ['second-text-q'],
+        'first-text-q', // optional
+      )
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.publishAllPrograms()
+
+      await logout(pageObject)
+    })
+
+    it('with both selections submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
+      await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with unanswered optional question submits successfully', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      // Only answer second question. First is optional.
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
+      await applicantQuestions.clickNext()
+
+      await applicantQuestions.submitFromReviewPage(programName)
+    })
+
+    it('with first invalid does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion(
+        'A long string that exceeds the character limit',
+        0,
+      )
+      await applicantQuestions.answerTextQuestion('You love CiviForm!', 1)
+      await applicantQuestions.clickNext()
+
+      const textId = '.cf-question-text'
+      expect(await pageObject.innerText(textId)).toContain(
+        'Must contain at most 20 characters.',
+      )
+    })
+
+    it('with second invalid does not submit', async () => {
+      await loginAsGuest(pageObject)
+      await selectApplicantLanguage(pageObject, 'English')
+
+      await applicantQuestions.applyProgram(programName)
+      await applicantQuestions.answerTextQuestion('I love CiviForm!', 0)
+      await applicantQuestions.answerTextQuestion(
+        'A long string that exceeds the character limit',
+        1,
+      )
+      await applicantQuestions.clickNext()
+
+      const textId = `.cf-question-text >> nth=1`
+      expect(await pageObject.innerText(textId)).toContain(
+        'Must contain at most 20 characters.',
+      )
+    })
+  })
+})


### PR DESCRIPTION
### Description

Add focused browser tests for date, dropdown, email, id, radio button, static text, text questions.

Will send a followup PR to update the existing question type browser tests to align with this structure.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#1937 