### PR TITLE
Better logging for stored file migration

### DIFF
--- a/server/app/tasks/StoredFileAclMigrationTask.java
+++ b/server/app/tasks/StoredFileAclMigrationTask.java
@@ -64,6 +64,10 @@ public class StoredFileAclMigrationTask implements Runnable {
           } catch (ProgramNotFoundException | RuntimeException e) {
             counter.incrementErrorCount();
             LOGGER.error(String.format("StoredFileMigrationError: %s", e.toString()));
+
+            if (counter.getErrorCount() > 10) {
+              throw new RuntimeException(e);
+            }
           }
         });
 

--- a/server/app/tasks/StoredFileAclMigrationTask.java
+++ b/server/app/tasks/StoredFileAclMigrationTask.java
@@ -64,7 +64,6 @@ public class StoredFileAclMigrationTask implements Runnable {
           } catch (ProgramNotFoundException | RuntimeException e) {
             counter.incrementErrorCount();
             LOGGER.error(String.format("StoredFileMigrationError: %s", e.toString()));
-            throw e;
           }
         });
 

--- a/server/app/tasks/StoredFileAclMigrationTask.java
+++ b/server/app/tasks/StoredFileAclMigrationTask.java
@@ -63,7 +63,8 @@ public class StoredFileAclMigrationTask implements Runnable {
             addAclsToApplicationFiles(counter, programDefinitions, application);
           } catch (ProgramNotFoundException | RuntimeException e) {
             counter.incrementErrorCount();
-            LOGGER.error("StoredFileMigrationError: %s", e.toString());
+            LOGGER.error(String.format("StoredFileMigrationError: %s", e.toString()));
+            throw e;
           }
         });
 


### PR DESCRIPTION
The slf4j does not do string formatting, despite it's method signature suggesting it does. This PR fixes formatting errors encountered during the stored file migration and stops the migration if an error is encountered.