### PR TITLE
File migration fix

### DIFF
--- a/server/app/auth/StoredFileAcls.java
+++ b/server/app/auth/StoredFileAcls.java
@@ -1,11 +1,10 @@
 package auth;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
+import javax.annotation.Nullable;
 import models.Account;
 import services.program.ProgramDefinition;
 
@@ -25,8 +24,20 @@ public class StoredFileAcls {
   }
 
   @JsonCreator
-  public StoredFileAcls(@JsonProperty("programReadAcls") HashSet<String> programReadAcls) {
-    this.programReadAcls = checkNotNull(programReadAcls);
+  public StoredFileAcls(
+      @Nullable @JsonProperty("programReadAcls") HashSet<String> programReadAcls) {
+    // If the file was created before the migration to using StoredFileAcls,
+    // programReadAcls will be null on initial load. In this case we initialize
+    // the internal state of the ACLs to an empty collection so the migration
+    // task can populate them.
+    // It is safest to leave this code in, even after the migration, in the
+    // event that somehow a StoredFile is created without serializing an
+    // instance StoredFileAcls.
+    if (programReadAcls == null) {
+      this.programReadAcls = new HashSet<>();
+    } else {
+      this.programReadAcls = programReadAcls;
+    }
   }
 
   public ImmutableSet<String> getProgramReadAcls() {

--- a/server/app/tasks/StoredFileAclMigrationTask.java
+++ b/server/app/tasks/StoredFileAclMigrationTask.java
@@ -64,6 +64,10 @@ public class StoredFileAclMigrationTask implements Runnable {
           } catch (ProgramNotFoundException | RuntimeException e) {
             counter.incrementErrorCount();
             LOGGER.error(String.format("StoredFileMigrationError: %s", e.toString()));
+
+            if (counter.getErrorCount() > 10) {
+              throw new RuntimeException(e);
+            }
           }
         });
 

--- a/server/app/tasks/StoredFileAclMigrationTask.java
+++ b/server/app/tasks/StoredFileAclMigrationTask.java
@@ -64,7 +64,6 @@ public class StoredFileAclMigrationTask implements Runnable {
           } catch (ProgramNotFoundException | RuntimeException e) {
             counter.incrementErrorCount();
             LOGGER.error(String.format("StoredFileMigrationError: %s", e.toString()));
-            throw e;
           }
         });
 

--- a/server/app/tasks/StoredFileAclMigrationTask.java
+++ b/server/app/tasks/StoredFileAclMigrationTask.java
@@ -63,7 +63,8 @@ public class StoredFileAclMigrationTask implements Runnable {
             addAclsToApplicationFiles(counter, programDefinitions, application);
           } catch (ProgramNotFoundException | RuntimeException e) {
             counter.incrementErrorCount();
-            LOGGER.error("StoredFileMigrationError: %s", e.toString());
+            LOGGER.error(String.format("StoredFileMigrationError: %s", e.toString()));
+            throw e;
           }
         });
 


### PR DESCRIPTION
If a file was created before the migration to using StoredFileAcls, programReadAcls will be null on initial load. This caused a NullPointerException when loading the record in the migration task. This PR sets the internal state of the ACLs to an empty collection so the migration task can populate them.
