### PR TITLE
Use the underlying exception when completable futures error

### DIFF
--- a/server/app/auth/ProfileMergeConflictException.java
+++ b/server/app/auth/ProfileMergeConflictException.java
@@ -1,22 +1,14 @@
 package auth;
 
-import org.pac4j.core.exception.http.HttpAction;
-import org.pac4j.core.exception.http.WithContentAction;
+import org.pac4j.core.exception.TechnicalException;
 
-public class ProfileMergeConflictException extends HttpAction implements WithContentAction {
-  private final String message;
+public class ProfileMergeConflictException extends TechnicalException {
 
   /**
    * When this exception is thrown in a controller, the resulting response will be a 400 and the
-   * provided message will be displayed to the user (unformatted, for now).
+   * provided content will be displayed to the user (unformatted, for now).
    */
-  ProfileMergeConflictException(String message) {
-    super(400);
-    this.message = message;
-  }
-
-  @Override
-  public String getContent() {
-    return String.format("Failed to merge your existing profile with the new one: \"%s\"", message);
+  ProfileMergeConflictException(String content) {
+    super(content);
   }
 }

--- a/server/app/controllers/ErrorHandler.java
+++ b/server/app/controllers/ErrorHandler.java
@@ -7,6 +7,7 @@ import controllers.admin.NotChangeableException;
 import controllers.api.BadApiRequestException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -66,6 +67,11 @@ public class ErrorHandler extends DefaultHttpErrorHandler {
 
     if (match.isPresent()) {
       return CompletableFuture.completedFuture(Results.unauthorized());
+    }
+
+    // Unwrap CompletionException
+    if (exception instanceof CompletionException) {
+      return super.onServerError(request, exception.getCause());
     }
 
     return super.onServerError(request, exception);

--- a/server/app/controllers/LoginController.java
+++ b/server/app/controllers/LoginController.java
@@ -5,6 +5,7 @@ import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import auth.AdminAuthClient;
 import auth.ApplicantAuthClient;
 import auth.AuthIdentityProviderName;
+import auth.CiviFormHttpActionAdapter;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
@@ -19,7 +20,6 @@ import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.play.PlayWebContext;
-import org.pac4j.play.http.PlayHttpActionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.mvc.Controller;
@@ -47,12 +47,13 @@ public class LoginController extends Controller {
   public LoginController(
       @AdminAuthClient @Nullable IndirectClient adminClient,
       @ApplicantAuthClient @Nullable IndirectClient applicantClient,
+      CiviFormHttpActionAdapter civiFormHttpActionAdapter,
       SessionStore sessionStore,
       Config config) {
     this.adminClient = adminClient;
     this.applicantClient = applicantClient;
     this.sessionStore = Preconditions.checkNotNull(sessionStore);
-    this.httpActionAdapter = PlayHttpActionAdapter.INSTANCE;
+    this.httpActionAdapter = civiFormHttpActionAdapter;
     this.config = config;
   }
 


### PR DESCRIPTION
### Description
This unwraps completion exceptions and uses the custom civiform exception handler for logins.
Also updates the ProfileMergeConflictException to store the error message in the exception, rather than using the non-functioning redirect action from pac4j.

Previously, errors were getting wrapped and rendered useless.  This enables the underlying exception message to be displayed.