### PR TITLE
Improve application index and preview look on mobile

### DIFF
--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -166,7 +166,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
     }
 
     ContainerTag actionAndTimestampDiv =
-        div().withClasses(Styles.PR_2, Styles.FLEX, Styles.FLEX_COL);
+        div().withClasses(Styles.PR_2, Styles.FLEX, Styles.FLEX_COL, Styles.TEXT_RIGHT);
     // Show timestamp if answered elsewhere.
     if (data.isPreviousResponse()) {
       LocalDate date =

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -1,11 +1,7 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.a;
-import static j2html.TagCreator.br;
-import static j2html.TagCreator.div;
-import static j2html.TagCreator.form;
-import static j2html.TagCreator.h1;
+import static j2html.TagCreator.*;
 import static j2html.attributes.Attr.HREF;
 
 import com.google.auto.value.AutoValue;
@@ -139,43 +135,43 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       long applicantId,
       boolean inReview,
       boolean isFirstUnanswered) {
-    ContainerTag questionPrompt =
-        div(data.questionText()).withClasses(Styles.FLEX_AUTO, Styles.FONT_SEMIBOLD);
-    ContainerTag questionContent =
-        div(questionPrompt).withClasses(Styles.FLEX, Styles.FLEX_ROW, Styles.PR_2);
+    ContainerTag questionPrompt = div(data.questionText()).withClasses(Styles.FONT_SEMIBOLD);
+    ContainerTag questionContent = div(questionPrompt).withClasses(Styles.PR_2);
 
+    // Add existing answer.
+    if (data.isAnswered()) {
+      final ContainerTag answerContent;
+      if (data.fileKey().isPresent()) {
+        String encodedFileKey = URLEncoder.encode(data.fileKey().get(), StandardCharsets.UTF_8);
+        String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
+        answerContent = a().withHref(fileLink);
+      } else {
+        answerContent = div();
+      }
+      answerContent.withClasses(Styles.FONT_LIGHT, Styles.TEXT_SM);
+      // Add answer text, converting newlines to <br/> tags.
+      String[] texts = data.answerText().split("\n");
+      texts = Arrays.stream(texts).filter(text -> text.length() > 0).toArray(String[]::new);
+      for (int i = 0; i < texts.length; i++) {
+        if (i > 0) {
+          answerContent.with(br());
+        }
+        answerContent.withText(texts[i]);
+      }
+      questionContent.with(answerContent);
+    }
+
+    ContainerTag actionAndTimestampDiv =
+        div().withClasses(Styles.PR_2, Styles.FLEX, Styles.FLEX_COL);
     // Show timestamp if answered elsewhere.
     if (data.isPreviousResponse()) {
       LocalDate date =
           Instant.ofEpochMilli(data.timestamp()).atZone(ZoneId.systemDefault()).toLocalDate();
       ContainerTag timestampContent =
           div("Previously answered on " + date)
-              .withClasses(Styles.FLEX_AUTO, Styles.TEXT_RIGHT, Styles.FONT_LIGHT, Styles.TEXT_XS);
-      questionContent.with(timestampContent);
+              .withClasses(Styles.FONT_LIGHT, Styles.TEXT_XS, Styles.FLEX_GROW);
+      actionAndTimestampDiv.with(timestampContent);
     }
-
-    final ContainerTag answerContent;
-    if (data.fileKey().isPresent()) {
-      String encodedFileKey = URLEncoder.encode(data.fileKey().get(), StandardCharsets.UTF_8);
-      String fileLink = controllers.routes.FileController.show(applicantId, encodedFileKey).url();
-      answerContent = a().withHref(fileLink).withClasses(Styles.W_2_3);
-    } else {
-      answerContent = div();
-    }
-    answerContent.withClasses(
-        Styles.FLEX_AUTO, Styles.TEXT_LEFT, Styles.FONT_LIGHT, Styles.TEXT_SM);
-    // Add answer text, converting newlines to <br/> tags.
-    String[] texts = data.answerText().split("\n");
-    texts = Arrays.stream(texts).filter(text -> text.length() > 0).toArray(String[]::new);
-    for (int i = 0; i < texts.length; i++) {
-      if (i > 0) {
-        answerContent.with(br());
-      }
-      answerContent.withText(texts[i]);
-    }
-
-    ContainerTag answerDiv =
-        div(answerContent).withClasses(Styles.FLEX, Styles.FLEX_ROW, Styles.PR_2);
 
     // Maybe link to block containing specific question.
     if (data.isAnswered() || isFirstUnanswered) {
@@ -200,10 +196,8 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
               .setHref(editLink)
               .setText(editText)
               .setStyles(
-                  Styles.ABSOLUTE,
                   Styles.BOTTOM_0,
                   Styles.RIGHT_0,
-                  Styles.PR_2,
                   Styles.TEXT_BLUE_600,
                   StyleUtils.hover(Styles.TEXT_BLUE_700))
               .asAnchorText()
@@ -213,16 +207,17 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
       ContainerTag editContent =
           div(editAction)
               .withClasses(
-                  Styles.FLEX_AUTO,
-                  Styles.TEXT_RIGHT,
                   Styles.FONT_MEDIUM,
-                  Styles.RELATIVE,
-                  Styles.BREAK_NORMAL);
+                  Styles.BREAK_NORMAL,
+                  Styles.FLEX,
+                  Styles.FLEX_GROW,
+                  Styles.JUSTIFY_END,
+                  Styles.ITEMS_CENTER);
 
-      answerDiv.with(editContent);
+      actionAndTimestampDiv.with(editContent);
     }
 
-    return div(questionContent, answerDiv)
+    return div(questionContent, actionAndTimestampDiv)
         .withClasses(
             ReferenceClasses.APPLICANT_SUMMARY_ROW,
             marginIndentClass(data.repeatedEntity().map(RepeatedEntity::depth).orElse(0)),
@@ -231,7 +226,9 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
             Styles.P_2,
             Styles.PT_4,
             Styles.BORDER_B,
-            Styles.BORDER_GRAY_300)
+            Styles.BORDER_GRAY_300,
+            Styles.FLEX,
+            Styles.JUSTIFY_BETWEEN)
         .attr("style", "word-break:break-word");
   }
 

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -1,7 +1,11 @@
 package views.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.*;
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.br;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.form;
+import static j2html.TagCreator.h1;
 import static j2html.attributes.Attr.HREF;
 
 import com.google.auto.value.AutoValue;

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -151,7 +151,7 @@ public class ProgramIndexView extends BaseHtmlView {
             .withClasses(Styles.MX_AUTO, Styles.MY_4, StyleUtils.responsiveSmall(Styles.M_10))
             .with(
                 h2().withText(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName()))
-                    .withClasses(Styles.MB_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD));
+                    .withClasses(Styles.MB_4, Styles.PX_4, Styles.TEXT_XL, Styles.FONT_SEMIBOLD));
 
     // The different program card containers should have the same styling, by using the program
     // count of the larger set of programs

--- a/server/app/views/style/ApplicantStyles.java
+++ b/server/app/views/style/ApplicantStyles.java
@@ -37,7 +37,7 @@ public final class ApplicantStyles {
       StyleUtils.joinStyles(BaseStyles.TEXT_SEATTLE_BLUE, Styles.TEXT_LG, Styles.FONT_BOLD);
 
   public static final String PROGRAM_CARDS_SUBTITLE =
-      StyleUtils.joinStyles(Styles.MY_4, Styles.TEXT_LG);
+      StyleUtils.joinStyles(Styles.MY_4, Styles.TEXT_LG, Styles.PX_4);
   public static final String PROGRAM_CARDS_CONTAINER_BASE =
       StyleUtils.joinStyles(
           Styles.GRID,


### PR DESCRIPTION
### Description

#### Applications index page
Add padding so that text doesn't start immediately at the border. 
Before: 
![image](https://user-images.githubusercontent.com/252053/178389044-03a01852-e421-4004-b7df-d4f8b11103af.png)
After:
![image](https://user-images.githubusercontent.com/252053/178389261-44c003cb-50b3-4c03-89a6-6050ce7a4de7.png)

### Application preview page
Reworked question DOM layout. Each question now consists of 2 columns. The left column contains question text with optional answer underneath. The right column contains optional answer timestamp with optional action link (edit/continue) vertically centered. That layout works better on mobile and avoids overlapping of text (see on screenshots). Most screens didn't change, only the second before/after pair is affected.

Before:
![image](https://user-images.githubusercontent.com/252053/178389695-f5b37130-0805-4d56-8a0f-6db1884fb69f.png)
After: 
![image](https://user-images.githubusercontent.com/252053/178389718-b84ccb89-fcd4-4553-bb01-74aec9de4dc6.png)


Before:
![image](https://user-images.githubusercontent.com/252053/178390330-172194b0-9b37-4c76-8c9a-f591be029858.png)


After:
![image](https://user-images.githubusercontent.com/252053/178391087-73d309b3-e8d2-4755-9cbb-28a08123ac8a.png)


Before:
![image](https://user-images.githubusercontent.com/252053/178390413-509fecc9-1354-4fac-9789-476064f81fb1.png)


After:
![image](https://user-images.githubusercontent.com/252053/178390463-b9ee4bd0-3662-4d02-b1ad-5e168fb8ea71.png)


Before:
![image](https://user-images.githubusercontent.com/252053/178390507-a70fa215-53eb-4314-99ef-90cbf500bea3.png)

After:
![image](https://user-images.githubusercontent.com/252053/178391194-7c3ec21b-ec8d-4c70-9356-1d448f5576a9.png)

