### PR TITLE
Update the devex: recreate civiform container on ctrl-c 

### DIFF
--- a/bin/pull-image
+++ b/bin/pull-image
@@ -23,16 +23,16 @@ echo "Making sure we're up to date with the latest dev... " \
 
 function pull_all() {
   echo "Pull all docker images"
-  docker pull -q civiform/civiform-dev:latest
+  docker pull civiform/civiform-dev:latest
 
   # Explicitly pull dev dependencies. (in parallel)
-  docker pull -q docker.io/civiform/oidc-provider:latest &
-  docker pull -q mcr.microsoft.com/azure-storage/azurite &
-  docker pull -q localstack/localstack &
+  docker pull docker.io/civiform/oidc-provider:latest &
+  docker pull mcr.microsoft.com/azure-storage/azurite &
+  docker pull localstack/localstack &
 
-  docker pull -q docker.io/civiform/civiform-localstack:latest &
-  docker pull -q docker.io/civiform/formatter:latest &
-  docker pull -q docker.io/civiform/civiform-browser-test:latest &
+  docker pull docker.io/civiform/civiform-localstack:latest &
+  docker pull docker.io/civiform/formatter:latest &
+  docker pull docker.io/civiform/civiform-browser-test:latest &
 
   wait
 
@@ -47,47 +47,47 @@ fi
 
 while [ "${1:-}" != "" ]; do
   case "${1}" in
-    "--all")
-      pull_all
-      ;;
+  "--all")
+    pull_all
+    ;;
 
-    "--dev")
-      echo "Pull dev docker image"
-      docker pull -q docker.io/civiform/civiform-dev:latest
-      docker tag civiform/civiform-dev:latest civiform-dev
+  "--dev")
+    echo "Pull dev docker image"
+    docker pull docker.io/civiform/civiform-dev:latest
+    docker tag civiform/civiform-dev:latest civiform-dev
 
-      ;;
+    ;;
 
-    "--formatter")
-      echo "Pull formatter docker image"
-      docker pull -q docker.io/civiform/formatter:latest
-      ;;
+  "--formatter")
+    echo "Pull formatter docker image"
+    docker pull docker.io/civiform/formatter:latest
+    ;;
 
-    "--localstack")
-      echo "Pull localstack docker image"
-      docker pull -q docker.io/civiform/civiform-localstack:latest
-      docker tag civiform/civiform-localstack:latest civiform-localstack
-      ;;
+  "--localstack")
+    echo "Pull localstack docker image"
+    docker pull docker.io/civiform/civiform-localstack:latest
+    docker tag civiform/civiform-localstack:latest civiform-localstack
+    ;;
 
-    "--azurite")
-      echo "Pull azurite docker image"
-      docker pull -q mcr.microsoft.com/azure-storage/azurite
-      ;;
+  "--azurite")
+    echo "Pull azurite docker image"
+    docker pull mcr.microsoft.com/azure-storage/azurite
+    ;;
 
-    "--oidc-provider")
-      echo "Pull oidc-provider docker image"
-      docker pull -q docker.io/civiform/oidc-provider:latest
-      ;;
+  "--oidc-provider")
+    echo "Pull oidc-provider docker image"
+    docker pull docker.io/civiform/oidc-provider:latest
+    ;;
 
-    "--browser-tests")
-      echo "Pull browser-tests docker image"
-      docker pull -q docker.io/civiform/civiform-browser-test:latest
-      ;;
+  "--browser-tests")
+    echo "Pull browser-tests docker image"
+    docker pull docker.io/civiform/civiform-browser-test:latest
+    ;;
 
-    *)
-      out::error "Unexpected flag value ${1}"
-      exit 1
-      ;;
+  *)
+    out::error "Unexpected flag value ${1}"
+    exit 1
+    ;;
   esac
 
   shift

--- a/bin/pull-image
+++ b/bin/pull-image
@@ -47,47 +47,47 @@ fi
 
 while [ "${1:-}" != "" ]; do
   case "${1}" in
-  "--all")
-    pull_all
-    ;;
+    "--all")
+      pull_all
+      ;;
 
-  "--dev")
-    echo "Pull dev docker image"
-    docker pull docker.io/civiform/civiform-dev:latest
-    docker tag civiform/civiform-dev:latest civiform-dev
+    "--dev")
+      echo "Pull dev docker image"
+      docker pull docker.io/civiform/civiform-dev:latest
+      docker tag civiform/civiform-dev:latest civiform-dev
 
-    ;;
+      ;;
 
-  "--formatter")
-    echo "Pull formatter docker image"
-    docker pull docker.io/civiform/formatter:latest
-    ;;
+    "--formatter")
+      echo "Pull formatter docker image"
+      docker pull docker.io/civiform/formatter:latest
+      ;;
 
-  "--localstack")
-    echo "Pull localstack docker image"
-    docker pull docker.io/civiform/civiform-localstack:latest
-    docker tag civiform/civiform-localstack:latest civiform-localstack
-    ;;
+    "--localstack")
+      echo "Pull localstack docker image"
+      docker pull docker.io/civiform/civiform-localstack:latest
+      docker tag civiform/civiform-localstack:latest civiform-localstack
+      ;;
 
-  "--azurite")
-    echo "Pull azurite docker image"
-    docker pull mcr.microsoft.com/azure-storage/azurite
-    ;;
+    "--azurite")
+      echo "Pull azurite docker image"
+      docker pull mcr.microsoft.com/azure-storage/azurite
+      ;;
 
-  "--oidc-provider")
-    echo "Pull oidc-provider docker image"
-    docker pull docker.io/civiform/oidc-provider:latest
-    ;;
+    "--oidc-provider")
+      echo "Pull oidc-provider docker image"
+      docker pull docker.io/civiform/oidc-provider:latest
+      ;;
 
-  "--browser-tests")
-    echo "Pull browser-tests docker image"
-    docker pull docker.io/civiform/civiform-browser-test:latest
-    ;;
+    "--browser-tests")
+      echo "Pull browser-tests docker image"
+      docker pull docker.io/civiform/civiform-browser-test:latest
+      ;;
 
-  *)
-    out::error "Unexpected flag value ${1}"
-    exit 1
-    ;;
+    *)
+      out::error "Unexpected flag value ${1}"
+      exit 1
+      ;;
   esac
 
   shift

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -22,15 +22,15 @@ emulators::set_localstack_emulator_vars
 function set_args() {
   while [ "${1:-}" != "" ]; do
     case "$1" in
-      "--azure")
-        emulators::ensure_only_one_cloud_provider_flag azure
-        emulators::set_azurite_emulator_vars
-        ;;
+    "--azure")
+      emulators::ensure_only_one_cloud_provider_flag azure
+      emulators::set_azurite_emulator_vars
+      ;;
 
-      "--aws")
-        emulators::ensure_only_one_cloud_provider_flag aws
-        # Already defaulted to AWS.
-        ;;
+    "--aws")
+      emulators::ensure_only_one_cloud_provider_flag aws
+      # Already defaulted to AWS.
+      ;;
     esac
 
     shift
@@ -49,9 +49,14 @@ docker::compose_dev --profile "${cloud_provider}" \
 # Wait until the emulator is running.
 "bin/${emulator}/wait"
 
-# Attach to the civiform container.
+# Start the civiform container and dependancies.
 docker::compose_dev up \
   --wait \
   -d
 
-bin/attach-dev
+# Attach to the civiform container.
+
+docker::compose_dev up civiform \
+  --no-recreate \
+  --no-deps \
+  --no-log-prefix

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -22,15 +22,15 @@ emulators::set_localstack_emulator_vars
 function set_args() {
   while [ "${1:-}" != "" ]; do
     case "$1" in
-    "--azure")
-      emulators::ensure_only_one_cloud_provider_flag azure
-      emulators::set_azurite_emulator_vars
-      ;;
+      "--azure")
+        emulators::ensure_only_one_cloud_provider_flag azure
+        emulators::set_azurite_emulator_vars
+        ;;
 
-    "--aws")
-      emulators::ensure_only_one_cloud_provider_flag aws
-      # Already defaulted to AWS.
-      ;;
+      "--aws")
+        emulators::ensure_only_one_cloud_provider_flag aws
+        # Already defaulted to AWS.
+        ;;
     esac
 
     shift

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,8 @@ version: '3.4'
 # Shared yaml extensions (https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields)
 # Volume mapping shared between containers.
 x-sbt-volumes:
-  volumes: &sbt-volumes
+  volumes:
+    &sbt-volumes
     - ./server:/usr/src/server
     # Un-shadow the build directories under server.
     - target:/usr/src/server/target
@@ -23,15 +24,16 @@ services:
     volumes: *sbt-volumes
     stdin_open: true # docker run -i
     tty: true # docker run -t
+    restart: always
     ports:
       - 9000:9000
       - 8457:8457
-    command: -jvm-debug "*:8457" ~run -Dconfig.file=conf/application.dev.conf
+    command: -jvm-debug "*:8457" ~run -Dsbt.offline -Dconfig.file=conf/application.dev.conf
 
   civiform-shell:
     image: civiform-dev
     entrypoint: /bin/bash
-    profiles: ['shell']
+    profiles: [ 'shell' ]
     volumes: *sbt-volumes
     stdin_open: true # docker run -i
     tty: true # docker run -t
@@ -58,7 +60,7 @@ services:
       - db-data:/var/lib/postgresql/data
 
   pgadmin:
-    profiles: ['pgadmin']
+    profiles: [ 'pgadmin' ]
     image: dpage/pgadmin4
     restart: always
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,8 +5,7 @@ version: '3.4'
 # Shared yaml extensions (https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields)
 # Volume mapping shared between containers.
 x-sbt-volumes:
-  volumes:
-    &sbt-volumes
+  volumes: &sbt-volumes
     - ./server:/usr/src/server
     # Un-shadow the build directories under server.
     - target:/usr/src/server/target
@@ -33,7 +32,7 @@ services:
   civiform-shell:
     image: civiform-dev
     entrypoint: /bin/bash
-    profiles: [ 'shell' ]
+    profiles: ['shell']
     volumes: *sbt-volumes
     stdin_open: true # docker run -i
     tty: true # docker run -t
@@ -60,7 +59,7 @@ services:
       - db-data:/var/lib/postgresql/data
 
   pgadmin:
-    profiles: [ 'pgadmin' ]
+    profiles: ['pgadmin']
     image: dpage/pgadmin4
     restart: always
     depends_on:


### PR DESCRIPTION
### Description

- Recreates the civiform container each time you ctrl-c out of it (but the other emulators stay running to improve restart time).
- Also tell the dev container to avoid re-downloading dependancies on first start (rely on the ones built-in to the container).
- Shows output when pulling images from docker hub

