### PR TITLE
Disable authorization_response_iss_parameter_supported for form_post token/id_token methods

### DIFF
--- a/server/app/auth/oidc/OidcProvider.java
+++ b/server/app/auth/oidc/OidcProvider.java
@@ -192,7 +192,6 @@ public abstract class OidcProvider implements Provider<OidcClient> {
     config.setWithState(false);
 
     config.setScope(scope);
-    // logger.debug("Provider metadata: " + config.getProviderMetadata().toString());
     OidcClient client = new OidcClient(config);
 
     if (providerName.isPresent()) {

--- a/server/app/auth/oidc/OidcProvider.java
+++ b/server/app/auth/oidc/OidcProvider.java
@@ -192,7 +192,7 @@ public abstract class OidcProvider implements Provider<OidcClient> {
     config.setWithState(false);
 
     config.setScope(scope);
-
+    // logger.debug("Provider metadata: " + config.getProviderMetadata().toString());
     OidcClient client = new OidcClient(config);
 
     if (providerName.isPresent()) {
@@ -207,6 +207,17 @@ public abstract class OidcProvider implements Provider<OidcClient> {
     } catch (Exception e) {
       logger.error("Error while initilizing OIDC provider", e);
       throw e;
+    }
+
+    var providerMetadata = client.getConfiguration().getProviderMetadata();
+    logger.debug("Provider metadata: " + providerMetadata.toString());
+    if (providerMetadata.supportsAuthorizationResponseIssuerParam()
+        && responseMode.equals("form_post")
+        && responseType.contains("token")
+        && !responseType.contains("code")) {
+      // The issuer param verification doesn't work for form_post token/id_token response types.
+      providerMetadata.setSupportsAuthorizationResponseIssuerParam(false);
+      logger.debug("Disabled authorization_response_iss_parameter_supported");
     }
     return client;
   }


### PR DESCRIPTION
### Description

Pac4j doesn't properly verify the issuer when `authorization_response_iss_parameter_supported` is set in the metadata for `token` or `id_token` response types with the `form_post` method (it does work for `code` response type).  This manually disables it in those cases.

## Release notes:

When using `token`/`id_token` response types, and the OIDC provider has `authorization_response_iss_parameter_supported` enabled, disable the issuer checking, since it's not supported by pac4j.

