### PR TITLE
Fix File Download Not Downloading

### DIFF
--- a/server/app/controllers/FileController.java
+++ b/server/app/controllers/FileController.java
@@ -103,8 +103,10 @@ public class FileController extends CiviFormController {
    * identified by {@code maybeProgramId} if it is present.
    */
   private Result adminShowInternal(Request request, Optional<Long> maybeProgramId, String fileKey) {
+    String decodedFileKey = URLDecoder.decode(fileKey, StandardCharsets.UTF_8);
+
     Optional<StoredFile> maybeFile =
-        storedFileRepository.lookupFile(fileKey).toCompletableFuture().join();
+        storedFileRepository.lookupFile(decodedFileKey).toCompletableFuture().join();
 
     if (maybeFile.isEmpty()) {
       return notFound();
@@ -122,7 +124,6 @@ public class FileController extends CiviFormController {
           .orElse(unauthorized());
     }
 
-    String decodedFileKey = URLDecoder.decode(fileKey, StandardCharsets.UTF_8);
     return redirect(storageClient.getPresignedUrlString(decodedFileKey));
   }
 

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -15,7 +15,6 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import support.ProgramBuilder;
 
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -15,6 +15,10 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import support.ProgramBuilder;
 
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 public class FileControllerTest extends WithMockedProfiles {
 
   private FileController controller;
@@ -168,13 +172,19 @@ public class FileControllerTest extends WithMockedProfiles {
     createProgramAdminWithMockedProfile(program);
     String fileKey = fakeFileKey(1L, program.id);
     createStoredFileWithProgramAccess(fileKey, program);
+    String encodedFileKey = encodefakeFileKey(fileKey);
 
-    Result result = controller.acledAdminShow(fakeRequest().build(), fileKey);
+    Result result = controller.acledAdminShow(fakeRequest().build(), encodedFileKey);
+
     assertThat(result.status()).isEqualTo(SEE_OTHER);
   }
 
   private String fakeFileKey(long applicantId, long programId) {
     return String.format("applicant-%d/program-%d/block-0", applicantId, programId);
+  }
+
+  private String encodefakeFileKey(String fileKey) {
+    return URLEncoder.encode(fileKey, StandardCharsets.UTF_8);
   }
 
   private void createStoredFileWithProgramAccess(String fileKey, Program program) {

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -6,6 +6,8 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.fakeRequest;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import models.Applicant;
 import models.Program;
 import models.StoredFile;
@@ -14,9 +16,6 @@ import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import support.ProgramBuilder;
-
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 public class FileControllerTest extends WithMockedProfiles {
 


### PR DESCRIPTION
### Description

Program admins clicking on a file to download would see a blank screen. In the browser console you'd see

`The resource from “https://civiform.seattle.gov/admin/programs/625/fi...” was not rendered due to an unknown, incorrect or missing MIME type (X-Content-Type-Options: nosniff).`

This console output appears to be a misnomer. I was able to repro locally. The FileController.acledAdminShow method fileKey parameter is URL Encoded. It isn't getting decoded before trying to look it up. This is causing it to not find the StoredFile object in the database. I'm decoding the string earlier in the method and passing the decoded value to be used to lookup the StoredFile object.

Examples
fileKey = "applicant-15%2Fprogram-13%2Fblock-1%2FTest.png"
decodedFileKey = "applicant-15/program-13/block-1/Test.png"

## Release notes:

Match ACL against decoded fileKey value to be able to download files.

### Checklist

- [x] Created tests which fail without the change (if possible)
