### PR TITLE
Show program applications link to global admins

### DIFF
--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -229,8 +229,9 @@ public class CiviFormProfile {
     return this.getAccount()
         .thenApply(
             account -> {
-              if (account.getAdministeredProgramNames().stream()
-                  .anyMatch(program -> program.equals(programName))) {
+              if (account.getGlobalAdmin()
+                  || account.getAdministeredProgramNames().stream()
+                      .anyMatch(program -> program.equals(programName))) {
                 return null;
               }
               throw new SecurityException(


### PR DESCRIPTION
### Description

CiviForm Global Admins can't see the Applications link on the Programs page. This will now check if you are a global admin or an admin of a specific program to show the link.

## Release notes:

Show Applications link on Programs page to CiviForm Global Admins

### Checklist

- [x] Created tests which fail without the change (if possible)



