### PR TITLE
Remove dependency on junit 5.

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -39,9 +39,6 @@ lazy val root = (project in file("."))
 
       // Database and database testing libraries
       "org.postgresql" % "postgresql" % "42.4.0",
-      "org.junit.jupiter" % "junit-jupiter-engine" % "5.8.2" % Test,
-      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % Test,
-      "org.junit.jupiter" % "junit-jupiter-params" % "5.8.2" % Test,
       "com.h2database" % "h2" % "2.1.214" % Test,
 
       // Parameterized testing

--- a/server/test/auth/ApiAuthenticatorTest.java
+++ b/server/test/auth/ApiAuthenticatorTest.java
@@ -1,7 +1,7 @@
 package auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.test.Helpers.fakeRequest;
 
 import com.google.inject.Guice;
@@ -160,14 +160,12 @@ public class ApiAuthenticatorTest {
 
   private void assertBadCredentialsException(
       Http.Request request, UsernamePasswordCredentials credentials, String expectedMessage) {
-    var exception =
-        assertThrows(
-            BadCredentialsException.class,
+    assertThatThrownBy(
             () ->
                 apiAuthenticator.validate(
-                    credentials, new PlayWebContext(request), MOCK_SESSION_STORE));
-
-    assertThat(exception).hasMessage(expectedMessage);
+                    credentials, new PlayWebContext(request), MOCK_SESSION_STORE))
+        .isInstanceOf(BadCredentialsException.class)
+        .hasMessage(expectedMessage);
   }
 
   private static Http.Request buildFakeRequest(String rawCredentials) {

--- a/server/test/auth/oidc/OidcProviderTest.java
+++ b/server/test/auth/oidc/OidcProviderTest.java
@@ -1,7 +1,7 @@
 package auth.oidc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import auth.ProfileFactory;
 import auth.oidc.applicant.IdcsProfileAdapter;
@@ -105,16 +105,10 @@ public class OidcProviderTest extends ResetPostgres {
   public void Test_get(String name, String wantResponseType, ImmutableMap<String, String> c) {
     Config config = ConfigFactory.parseMap(c);
 
-    OidcProvider oidcProvider;
-    try {
-      oidcProvider =
-          new IdcsProvider(
-              config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
+    OidcProvider oidcProvider =
+        new IdcsProvider(
+            config, profileFactory, CfTestHelpers.userRepositoryProvider(userRepository));
 
-    } catch (RuntimeException e) {
-      fail(e);
-      return;
-    }
     OidcClient client = oidcProvider.get();
 
     assertThat(client.getCallbackUrl()).isEqualTo(c.get("base_url") + "/callback");
@@ -189,18 +183,15 @@ public class OidcProviderTest extends ResetPostgres {
   @Parameters(method = "provideConfigsForInvalidConfig")
   public void get_invalidConfig(String name, ImmutableMap<String, String> c) {
     Config bad_secret_config = ConfigFactory.parseMap(c);
-    OidcProvider badOidcProvider;
-    try {
-      badOidcProvider =
-          new IdcsProvider(
-              bad_secret_config,
-              profileFactory,
-              CfTestHelpers.userRepositoryProvider(userRepository));
-      badOidcProvider.get();
-      fail("Initilizing without correct config should cause runtimeException");
-    } catch (RuntimeException e) {
-      // pass
-      return;
-    }
+    assertThatThrownBy(
+            () -> {
+              OidcProvider badOidcProvider =
+                  new IdcsProvider(
+                      bad_secret_config,
+                      profileFactory,
+                      CfTestHelpers.userRepositoryProvider(userRepository));
+              badOidcProvider.get();
+            })
+        .isInstanceOf(RuntimeException.class);
   }
 }

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
@@ -41,10 +41,11 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
 
   @Test
   public void edit_withNonExistantProgram_notFound() {
-    assertThrows(
-        NotChangeableException.class,
-        () ->
-            controller.edit(fakeRequest().build(), /* programId= */ 1, /* blockDefinitionId= */ 1));
+    assertThatThrownBy(
+            () ->
+                controller.edit(
+                    fakeRequest().build(), /* programId= */ 1, /* blockDefinitionId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
@@ -60,9 +61,9 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   @Test
   public void edit_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThrows(
-        NotChangeableException.class,
-        () -> controller.edit(fakeRequest().build(), programId, /* blockDefinitionId= */ 1));
+    assertThatThrownBy(
+            () -> controller.edit(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
@@ -272,17 +273,16 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   @Test
   public void update_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThrows(
-        NotChangeableException.class,
-        () -> controller.update(fakeRequest().build(), programId, /* blockDefinitionId= */ 1));
+    assertThatThrownBy(
+            () -> controller.update(fakeRequest().build(), programId, /* blockDefinitionId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
   public void destroy_activeProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThrows(
-        NotChangeableException.class,
-        () -> controller.destroy(programId, /* blockDefinitionId= */ 1));
+    assertThatThrownBy(() -> controller.destroy(programId, /* blockDefinitionId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
@@ -65,31 +65,30 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   @Test
   public void create_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThrows(
-        NotChangeableException.class,
-        () -> controller.create(fakeRequest().build(), programId, /* blockId= */ 1));
+    assertThatThrownBy(() -> controller.create(fakeRequest().build(), programId, /* blockId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
   public void destroy_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThrows(
-        NotChangeableException.class,
-        () ->
-            controller.destroy(
-                programId, /* blockDefinitionId= */ 1, /* questionDefinitionId= */ 1));
+    assertThatThrownBy(
+            () ->
+                controller.destroy(
+                    programId, /* blockDefinitionId= */ 1, /* questionDefinitionId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 
   @Test
   public void setOptional_withActiveProgram_throws() {
     Long programId = resourceCreator.insertActiveProgram("active program").id;
-    assertThrows(
-        NotChangeableException.class,
-        () ->
-            controller.setOptional(
-                fakeRequest().build(),
-                programId,
-                /* blockDefinitionId= */ 1,
-                /* questionDefinitionId= */ 1));
+    assertThatThrownBy(
+            () ->
+                controller.setOptional(
+                    fakeRequest().build(),
+                    programId,
+                    /* blockDefinitionId= */ 1,
+                    /* questionDefinitionId= */ 1))
+        .isInstanceOf(NotChangeableException.class);
   }
 }

--- a/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramStatusesControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
@@ -34,9 +34,8 @@ public class AdminProgramStatusesControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void index_missingProgram() throws ProgramNotFoundException {
-    assertThrows(
-        ProgramNotFoundException.class,
-        () -> controller.index(fakeRequest().build(), Long.MAX_VALUE));
+  public void index_missingProgram() {
+    assertThatThrownBy(() -> controller.index(fakeRequest().build(), Long.MAX_VALUE))
+        .isInstanceOf(ProgramNotFoundException.class);
   }
 }

--- a/server/test/repository/ApiKeyRepositoryTest.java
+++ b/server/test/repository/ApiKeyRepositoryTest.java
@@ -1,7 +1,7 @@
 package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import auth.ApiKeyGrants;
 import io.ebean.DataIntegrityException;
@@ -59,11 +59,10 @@ public class ApiKeyRepositoryTest extends ResetPostgres {
     ApiKeyGrants grants = new ApiKeyGrants();
     ApiKey apiKey = new ApiKey(grants);
 
-    CompletionException exception =
-        assertThrows(
-            CompletionException.class, () -> repo.insert(apiKey).toCompletableFuture().join());
-
-    assertThat(exception.getCause()).isInstanceOf(DataIntegrityException.class);
-    assertThat(exception.getCause().getMessage()).contains("violates not-null constraint");
+    assertThatThrownBy(() -> repo.insert(apiKey).toCompletableFuture().join())
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .isInstanceOf(DataIntegrityException.class)
+        .hasMessageContaining("violates not-null constraint");
   }
 }

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -1,7 +1,7 @@
 package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -111,15 +111,15 @@ public class ApplicationRepositoryTest extends ResetPostgres {
     Application appDraft2 = Application.create(applicant, program, LifecycleStage.DRAFT);
     appDraft2.save();
 
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class,
+    assertThatThrownBy(
             () ->
                 repo.submitApplication(applicant, program, Optional.empty())
                     .toCompletableFuture()
-                    .join());
+                    .join())
+        .isInstanceOf(RuntimeException.class)
+        .cause()
+        .hasMessageContaining("Found more than one DRAFT application");
 
-    assertThat(exception.getCause().getMessage()).contains("Found more than one DRAFT application");
     assertThat(
             repo.getApplication(appDraft1.id)
                 .toCompletableFuture()

--- a/server/test/services/apikey/ApiKeyServiceTest.java
+++ b/server/test/services/apikey/ApiKeyServiceTest.java
@@ -1,7 +1,7 @@
 package services.apikey;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static play.test.Helpers.fakeRequest;
 
 import auth.ApiKeyGrants.Permission;
@@ -107,19 +107,18 @@ public class ApiKeyServiceTest extends ResetPostgres {
             .getApiKey();
     apiKeyService.retireApiKey(apiKey.id, adminProfile);
 
-    NotChangeableException exception =
-        assertThrows(
-            NotChangeableException.class,
-            () -> apiKeyService.retireApiKey(apiKey.id, adminProfile));
-    assertThat(exception).hasMessage(String.format("ApiKey %s is already retired", apiKey));
+    assertThatThrownBy(() -> apiKeyService.retireApiKey(apiKey.id, adminProfile))
+        .isInstanceOf(NotChangeableException.class)
+        .hasMessage(String.format("ApiKey %s is already retired", apiKey));
   }
 
   @Test
   public void retireApiKey_keyDoesNotExist_throws() {
-    RuntimeException exception =
-        assertThrows(RuntimeException.class, () -> apiKeyService.retireApiKey(111l, adminProfile));
-    assertThat(exception.getCause()).isInstanceOf(ApiKeyNotFoundException.class);
-    assertThat(exception.getCause()).hasMessage("ApiKey not found for database ID: 111");
+    assertThatThrownBy(() -> apiKeyService.retireApiKey(111l, adminProfile))
+        .isInstanceOf(RuntimeException.class)
+        .cause()
+        .isInstanceOf(ApiKeyNotFoundException.class)
+        .hasMessage("ApiKey not found for database ID: 111");
   }
 
   @Test
@@ -260,10 +259,11 @@ public class ApiKeyServiceTest extends ResetPostgres {
                 "subnet", "0.1.1.1",
                 "grant-program-read[test-program]", "true"));
 
-    RuntimeException exception =
-        assertThrows(RuntimeException.class, () -> apiKeyService.createApiKey(form, adminProfile));
-
-    assertThat(exception).hasCause(new ProgramNotFoundException("test-program"));
+    assertThatThrownBy(() -> apiKeyService.createApiKey(form, adminProfile))
+        .isInstanceOf(RuntimeException.class)
+        .cause()
+        .isInstanceOf(ProgramNotFoundException.class)
+        .hasMessageContaining("test-program");
   }
 
   @Test
@@ -280,8 +280,8 @@ public class ApiKeyServiceTest extends ResetPostgres {
                 "subnet", "0.0.0.1/32",
                 "grant-program-read[test-program]", "true"));
 
-    assertThrows(
-        RuntimeException.class, () -> apiKeyService.createApiKey(form, missingAuthorityIdProfile));
+    assertThatThrownBy(() -> apiKeyService.createApiKey(form, missingAuthorityIdProfile))
+        .isInstanceOf(RuntimeException.class);
   }
 
   private DynamicForm buildForm(ImmutableMap<String, String> formContents) {


### PR DESCRIPTION
### Description

We use Junit 4 to execute tests and AssertJ for performing assertions. Yes we include Junit 5 as test dependency. Some tests use `assertThrows` provided by it. AssertJ has similar method `assertThatThrownBy` and should be used instead for consistency. Plus it removes potential confusion that project is using Junit 5.
