### PR TITLE
Fix question count to reflect the number of rows in the table

### DIFF
--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -92,18 +92,4 @@ public final class ActiveAndDraftQuestions {
   public Optional<QuestionDefinition> getDraftQuestionDefinition(String name) {
     return versionedByName.get(name).second();
   }
-
-  public ImmutableSet<String> getActiveQuestionNames() {
-    return versionedByName.entrySet().stream()
-        .filter(e -> e.getValue().first().isPresent())
-        .map(e -> e.getKey())
-        .collect(ImmutableSet.toImmutableSet());
-  }
-
-  public ImmutableSet<String> getDraftQuestionNames() {
-    return versionedByName.entrySet().stream()
-        .filter(e -> e.getValue().second().isPresent())
-        .map(e -> e.getKey())
-        .collect(ImmutableSet.toImmutableSet());
-  }
 }

--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -18,14 +18,12 @@ import services.question.types.QuestionDefinition;
  * should be measured in milliseconds - seconds at the maximum - within one request serving path -
  * because it does not have any mechanism for a refresh.
  */
-public class ActiveAndDraftQuestions {
+public final class ActiveAndDraftQuestions {
 
   private final ImmutableMap<
           String, Pair<Optional<QuestionDefinition>, Optional<QuestionDefinition>>>
       versionedByName;
   private final ImmutableMap<String, DeletionStatus> deletionStatusByName;
-  private final int activeSize;
-  private final int draftSize;
 
   public ActiveAndDraftQuestions(Version active, Version draft) {
     ImmutableMap.Builder<String, QuestionDefinition> activeToName = ImmutableMap.builder();
@@ -39,8 +37,6 @@ public class ActiveAndDraftQuestions {
         .forEach(qd -> activeToName.put(qd.getName(), qd));
     ImmutableMap<String, QuestionDefinition> activeNames = activeToName.build();
     ImmutableMap<String, QuestionDefinition> draftNames = draftToName.build();
-    activeSize = activeNames.size();
-    draftSize = draftNames.size();
     ImmutableMap.Builder<String, Pair<Optional<QuestionDefinition>, Optional<QuestionDefinition>>>
         versionedByNameBuilder = ImmutableMap.builder();
     for (String name : Sets.union(activeNames.keySet(), draftNames.keySet())) {
@@ -97,11 +93,17 @@ public class ActiveAndDraftQuestions {
     return versionedByName.get(name).second();
   }
 
-  public int getActiveSize() {
-    return activeSize;
+  public ImmutableSet<String> getActiveQuestionNames() {
+    return versionedByName.entrySet().stream()
+        .filter(e -> e.getValue().first().isPresent())
+        .map(e -> e.getKey())
+        .collect(ImmutableSet.toImmutableSet());
   }
 
-  public int getDraftSize() {
-    return draftSize;
+  public ImmutableSet<String> getDraftQuestionNames() {
+    return versionedByName.entrySet().stream()
+        .filter(e -> e.getValue().second().isPresent())
+        .map(e -> e.getKey())
+        .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -3,6 +3,7 @@ package views.admin.questions;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.*;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
@@ -116,9 +117,14 @@ public final class QuestionsListView extends BaseHtmlView {
   }
 
   private DivTag renderSummary(ActiveAndDraftQuestions activeAndDraftQuestions) {
+    // The total question count should be equivalent to the number of rows in the displayed table,
+    // where we have a single entry for a question that is active and has a draft.
     return div(String.format(
             "Total Questions: %d",
-            activeAndDraftQuestions.getActiveSize() + activeAndDraftQuestions.getDraftSize()))
+            Sets.union(
+                    activeAndDraftQuestions.getActiveQuestionNames(),
+                    activeAndDraftQuestions.getDraftQuestionNames())
+                .size()))
         .withClasses(Styles.FLOAT_RIGHT, Styles.TEXT_BASE, Styles.PX_4, Styles.MY_2);
   }
 

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -3,7 +3,6 @@ package views.admin.questions;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.*;
 
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
@@ -120,11 +119,7 @@ public final class QuestionsListView extends BaseHtmlView {
     // The total question count should be equivalent to the number of rows in the displayed table,
     // where we have a single entry for a question that is active and has a draft.
     return div(String.format(
-            "Total Questions: %d",
-            Sets.union(
-                    activeAndDraftQuestions.getActiveQuestionNames(),
-                    activeAndDraftQuestions.getDraftQuestionNames())
-                .size()))
+            "Total Questions: %d", activeAndDraftQuestions.getQuestionNames().size()))
         .withClasses(Styles.FLOAT_RIGHT, Styles.TEXT_BASE, Styles.PX_4, Styles.MY_2);
   }
 

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -31,6 +31,7 @@ import services.question.types.DropdownQuestionDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.NameQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 import views.html.helper.CSRF;
 
@@ -225,9 +226,14 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void index_returnsQuestions() {
+  public void index_returnsQuestions() throws Exception {
     testQuestionBank.applicantAddress();
-    testQuestionBank.applicantName();
+    Question nameQuestion = testQuestionBank.applicantName();
+    // Create a draft version of an already published question and ensure that it isn't
+    // double-counted in the rendered total number of questions.
+    QuestionDefinition updatedQuestion =
+        new QuestionDefinitionBuilder(nameQuestion.getQuestionDefinition()).clearId().build();
+    testQuestionBank.maybeSave(updatedQuestion, LifecycleStage.DRAFT);
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
     controller
         .index(request)


### PR DESCRIPTION
### Description

Presently, the "Total Questions" area displays `active version questions + draft version questions`. The number of rows displayed has a single entry for each unique question identifier.

Consider the starting scenario where 12 questions exist:
  * `Total questions: 12`
  * 12 entries in the table

Now assume an edit is made to a single question:
  * `Total questions: 13`
  * 12 entries in the table

There are still logically 12 questions in this case. This PR fixes that and adds a regression test.

## Release notes:

Fixes "Total questions" count the questions view to not include edits to existing questions.

### Checklist

- [X] Created tests which fail without the change (if possible)

### Issue(s)

#2788