### PR TITLE
Prevent archiving / restoring questions that aren't in a valid state.

### DIFF
--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -30,7 +30,7 @@ import services.question.types.QuestionDefinition;
  */
 @Entity
 @Table(name = "versions")
-public final class Version extends BaseModel {
+public class Version extends BaseModel {
 
   @Constraints.Required private LifecycleStage lifecycleStage;
 

--- a/server/app/models/Version.java
+++ b/server/app/models/Version.java
@@ -30,7 +30,7 @@ import services.question.types.QuestionDefinition;
  */
 @Entity
 @Table(name = "versions")
-public class Version extends BaseModel {
+public final class Version extends BaseModel {
 
   @Constraints.Required private LifecycleStage lifecycleStage;
 
@@ -38,9 +38,8 @@ public class Version extends BaseModel {
   private List<Question> questions;
 
   /**
-   * A tombstoned question or program is a question or program that will not be copied to the next
-   * version published. It is set on the current draft version. Questions / Programs are listed here
-   * by name rather than by ID.
+   * A tombstoned question is a question that will not be copied to the next version published. It
+   * is set on the current draft version. Questions are listed here by name rather than by ID.
    */
   @DbArray private List<String> tombstonedQuestionNames = new ArrayList<>();
 
@@ -49,9 +48,8 @@ public class Version extends BaseModel {
   private List<Program> programs;
 
   /**
-   * A tombstoned question or program is a question or program that will not be copied to the next
-   * version published. It is set on the current draft version. Questions / Programs are listed here
-   * by name rather than by ID.
+   * A tombstoned program is a program that will not be copied to the next version published. It is
+   * set on the current draft version. Programs are listed here by name rather than by ID.
    */
   @DbArray private List<String> tombstonedProgramNames = new ArrayList<>();
 

--- a/server/app/services/question/QuestionServiceImpl.java
+++ b/server/app/services/question/QuestionServiceImpl.java
@@ -118,8 +118,9 @@ public final class QuestionServiceImpl implements QuestionService {
     }
     ActiveAndDraftQuestions activeQuestions =
         readOnlyQuestionService().getActiveAndDraftQuestions();
-    if (activeQuestions.getDeletionStatus(question.get().getQuestionDefinition().getName())
-        != DeletionStatus.PENDING_DELETION) {
+    if (!activeQuestions
+        .getDeletionStatus(question.get().getQuestionDefinition().getName())
+        .equals(DeletionStatus.PENDING_DELETION)) {
       throw new InvalidUpdateException("Question is not restorable.");
     }
     Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
@@ -138,8 +139,9 @@ public final class QuestionServiceImpl implements QuestionService {
     }
     ActiveAndDraftQuestions activeQuestions =
         readOnlyQuestionService().getActiveAndDraftQuestions();
-    if (activeQuestions.getDeletionStatus(question.get().getQuestionDefinition().getName())
-        != DeletionStatus.DELETABLE) {
+    if (!activeQuestions
+        .getDeletionStatus(question.get().getQuestionDefinition().getName())
+        .equals(DeletionStatus.DELETABLE)) {
       throw new InvalidUpdateException("Question is not archivable.");
     }
     Version draftVersion = versionRepositoryProvider.get().getDraftVersion();

--- a/server/app/services/question/QuestionServiceImpl.java
+++ b/server/app/services/question/QuestionServiceImpl.java
@@ -17,6 +17,7 @@ import models.Version;
 import repository.QuestionRepository;
 import repository.VersionRepository;
 import services.CiviFormError;
+import services.DeletionStatus;
 import services.ErrorAnd;
 import services.export.ExporterService;
 import services.question.exceptions.InvalidUpdateException;
@@ -63,10 +64,13 @@ public final class QuestionServiceImpl implements QuestionService {
 
   @Override
   public CompletionStage<ReadOnlyQuestionService> getReadOnlyQuestionService() {
-    return CompletableFuture.completedStage(
-        new ReadOnlyCurrentQuestionServiceImpl(
-            versionRepositoryProvider.get().getActiveVersion(),
-            versionRepositoryProvider.get().getDraftVersion()));
+    return CompletableFuture.completedStage(readOnlyQuestionService());
+  }
+
+  private ReadOnlyQuestionService readOnlyQuestionService() {
+    return new ReadOnlyCurrentQuestionServiceImpl(
+        versionRepositoryProvider.get().getActiveVersion(),
+        versionRepositoryProvider.get().getDraftVersion());
   }
 
   @Override
@@ -112,6 +116,12 @@ public final class QuestionServiceImpl implements QuestionService {
     if (question.isEmpty()) {
       throw new InvalidUpdateException("Did not find question.");
     }
+    ActiveAndDraftQuestions activeQuestions =
+        readOnlyQuestionService().getActiveAndDraftQuestions();
+    if (activeQuestions.getDeletionStatus(question.get().getQuestionDefinition().getName())
+        != DeletionStatus.PENDING_DELETION) {
+      throw new InvalidUpdateException("Question is not restorable.");
+    }
     Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
     if (!draftVersion.removeTombstoneForQuestion(question.get())) {
       throw new InvalidUpdateException("Not tombstoned.");
@@ -125,6 +135,12 @@ public final class QuestionServiceImpl implements QuestionService {
         questionRepository.lookupQuestion(id).toCompletableFuture().join();
     if (question.isEmpty()) {
       throw new InvalidUpdateException("Did not find question.");
+    }
+    ActiveAndDraftQuestions activeQuestions =
+        readOnlyQuestionService().getActiveAndDraftQuestions();
+    if (activeQuestions.getDeletionStatus(question.get().getQuestionDefinition().getName())
+        != DeletionStatus.DELETABLE) {
+      throw new InvalidUpdateException("Question is not archivable.");
     }
     Version draftVersion = versionRepositoryProvider.get().getDraftVersion();
     if (!draftVersion.addTombstoneForQuestion(question.get())) {


### PR DESCRIPTION
### Description

Presently, the `/archive` and `/restore` handlers don't do any validation beyond the question ID existing. This means that a question that is still referenced by a program can be archived.

This could definitely occur for a stale tab scenario where an admin has the archive option, then references the question from a separate program (rendering it unarchivable).

Additionally, we should always rely on validation before we mutate state rather than relying on links being generated at the appropriate time.

Currently, this returns a 400 error. As part of #2788, I may adjust the controller to redirect to the main question page with an error message.

## Release notes:

Fix issue where UI could allow accidental archival of questions that were still referenced.

### Checklist

- [X] Created tests which fail without the change (if possible)

### Issue(s)

#2788