### PR TITLE
Redirect to draft question when trying to edit published.

### DIFF
--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -272,7 +272,8 @@ describe('normal question lifecycle', () => {
 
     // Update the question to create new draft version.
     await adminQuestions.gotoQuestionNewVersionPage('name-q')
-    // Save edit url as later we'll use it to imitate user having multiple tabs open.
+    // The ID in the URL after clicking new version corresponds to the active question form (e.g. ID=15).
+    // After a draft is created, the ID will reflect the newly created draft version (e.g. ID=16).
     const editUrl = page.url()
     const newQuestionText = await adminQuestions.updateQuestionText(
       'second version',

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -258,7 +258,6 @@ describe('normal question lifecycle', () => {
 
   it('redirects to draft question when trying to edit original question', async () => {
     const {page} = await startSession()
-    page.setDefaultTimeout(4000)
     await loginAsAdmin(page)
 
     const adminQuestions = new AdminQuestions(page)

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -255,4 +255,36 @@ describe('normal question lifecycle', () => {
       ),
     ).toBeTruthy()
   })
+
+  it('redirects to draft question when trying to edit original question', async () => {
+    const {page} = await startSession()
+    page.setDefaultTimeout(4000)
+    await loginAsAdmin(page)
+
+    const adminQuestions = new AdminQuestions(page)
+    const adminPrograms = new AdminPrograms(page)
+
+    await adminQuestions.gotoAdminQuestionsPage()
+    await adminQuestions.addNameQuestion({questionName: 'name-q'})
+
+    const programName = 'test program'
+    await adminPrograms.addProgram(programName)
+    await adminPrograms.publishProgram(programName)
+
+    // Update the question to create new draft version.
+    await adminQuestions.gotoQuestionNewVersionPage('name-q')
+    // Save edit url as later we'll use it to imitate user having multiple tabs open.
+    const editUrl = page.url()
+    const newQuestionText = await adminQuestions.updateQuestionText(
+      'second version',
+    )
+    await adminQuestions.clickSubmitButtonAndNavigate('Update')
+
+    // Try edit the original published question and make sure that we see the draft version.
+    await page.goto(editUrl)
+    await waitForPageJsLoad(page)
+    expect(await page.inputValue('label:has-text("Question text")')).toContain(
+      newQuestionText,
+    )
+  })
 })

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -163,10 +163,13 @@ export class AdminQuestions {
     expect(tableInnerText).not.toContain(questionName)
   }
 
-  private async gotoQuestionEditOrNewVersionPage(
-    questionName: string,
-    buttonText: string,
-  ) {
+  private async gotoQuestionEditOrNewVersionPage({
+    questionName,
+    buttonText,
+  }: {
+    questionName: string
+    buttonText: string
+  }) {
     await this.gotoAdminQuestionsPage()
     await this.page.click(
       this.selectWithinQuestionTableRow(questionName, `:text("${buttonText}")`),
@@ -176,11 +179,17 @@ export class AdminQuestions {
   }
 
   async gotoQuestionEditPage(questionName: string) {
-    await this.gotoQuestionEditOrNewVersionPage(questionName, 'Edit')
+    await this.gotoQuestionEditOrNewVersionPage({
+      questionName,
+      buttonText: 'Edit',
+    })
   }
 
   async gotoQuestionNewVersionPage(questionName: string) {
-    await this.gotoQuestionEditOrNewVersionPage(questionName, 'New Version')
+    await this.gotoQuestionEditOrNewVersionPage({
+      questionName,
+      buttonText: 'New Version',
+    })
   }
 
   async undeleteQuestion(questionName: string) {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -163,13 +163,24 @@ export class AdminQuestions {
     expect(tableInnerText).not.toContain(questionName)
   }
 
-  async gotoQuestionEditPage(questionName: string) {
+  private async gotoQuestionEditOrNewVersionPage(
+    questionName: string,
+    buttonText: string,
+  ) {
     await this.gotoAdminQuestionsPage()
     await this.page.click(
-      this.selectWithinQuestionTableRow(questionName, ':text("Edit")'),
+      this.selectWithinQuestionTableRow(questionName, `:text("${buttonText}")`),
     )
     await waitForPageJsLoad(this.page)
     await this.expectQuestionEditPage(questionName)
+  }
+
+  async gotoQuestionEditPage(questionName: string) {
+    await this.gotoQuestionEditOrNewVersionPage(questionName, 'Edit')
+  }
+
+  async gotoQuestionNewVersionPage(questionName: string) {
+    await this.gotoQuestionEditOrNewVersionPage(questionName, 'New Version')
   }
 
   async undeleteQuestion(questionName: string) {
@@ -258,12 +269,7 @@ export class AdminQuestions {
   }
 
   async createNewVersion(questionName: string) {
-    await this.gotoAdminQuestionsPage()
-    await this.page.click(
-      this.selectWithinQuestionTableRow(questionName, ':text("New Version")'),
-    )
-    await waitForPageJsLoad(this.page)
-    await this.expectQuestionEditPage(questionName)
+    await this.gotoQuestionNewVersionPage(questionName)
     const newQuestionText = await this.updateQuestionText(' new version')
 
     await this.clickSubmitButtonAndNavigate('Update')

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -224,6 +224,17 @@ public class AdminQuestionController extends CiviFormController {
                 return badRequest(e.toString());
               }
 
+              // Handle case someone tries to edit a live question that already has a draft version.
+              // In this case we should redirect to the draft version.
+              // https://github.com/seattle-uat/civiform/issues/2497
+              Optional<QuestionDefinition> possibleDraft =
+                  readOnlyService
+                      .getActiveAndDraftQuestions()
+                      .getDraftQuestionDefinition(questionDefinition.getName());
+              if (possibleDraft.isPresent() && possibleDraft.get().getId() != id) {
+                return redirect(routes.AdminQuestionController.edit(possibleDraft.get().getId()));
+              }
+
               Optional<QuestionDefinition> maybeEnumerationQuestion =
                   maybeGetEnumerationQuestion(readOnlyService, questionDefinition);
               try {

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -190,20 +190,20 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
   @Test
   public void edit_returnsRedirectWhenEditingQuestionWithExistingDraft() {
-    Question originalNameQuestion = testQuestionBank.applicantName();
-    Question draftNameQuestion =
+    Question publishedQuestion = testQuestionBank.applicantName();
+    Question draftQuestion =
         testQuestionBank.maybeSave(
-            this.createNameQuestionDuplicate(originalNameQuestion), LifecycleStage.DRAFT);
+            this.createNameQuestionDuplicate(publishedQuestion), LifecycleStage.DRAFT);
 
-    // sanity check that thew new question has different id.
-    assertThat(originalNameQuestion.id).isNotEqualTo(draftNameQuestion.id);
+    // sanity check that the new question has different id.
+    assertThat(publishedQuestion.id).isNotEqualTo(draftQuestion.id);
 
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
-    Result result = controller.edit(request, originalNameQuestion.id).toCompletableFuture().join();
+    Result result = controller.edit(request, publishedQuestion.id).toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
-        .hasValue(routes.AdminQuestionController.edit(draftNameQuestion.id).url());
+        .hasValue(routes.AdminQuestionController.edit(draftQuestion.id).url());
   }
 
   @Test

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -189,6 +189,24 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void edit_returnsRedirectWhenEditingQuestionWithExistingDraft() {
+    Question originalNameQuestion = testQuestionBank.applicantName();
+    Question draftNameQuestion =
+        testQuestionBank.maybeSave(
+            this.createNameQuestionDuplicate(originalNameQuestion), LifecycleStage.DRAFT);
+
+    // sanity check that thew new question has different id.
+    assertThat(originalNameQuestion.id).isNotEqualTo(draftNameQuestion.id);
+
+    Request request = addCSRFToken(Helpers.fakeRequest()).build();
+    Result result = controller.edit(request, originalNameQuestion.id).toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminQuestionController.edit(draftNameQuestion.id).url());
+  }
+
+  @Test
   public void edit_returnsPopulatedForm() {
     Question question = testQuestionBank.applicantName();
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
@@ -329,12 +347,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     // We can only update draft questions, so save this in the DRAFT version.
     Question originalNameQuestion =
         testQuestionBank.maybeSave(
-            new NameQuestionDefinition(
-                "applicant name",
-                Optional.empty(),
-                "name of applicant",
-                LocalizedStrings.of(Locale.US, "what is your name?"),
-                LocalizedStrings.of(Locale.US, "help text")),
+            this.createNameQuestionDuplicate(testQuestionBank.applicantName()),
             LifecycleStage.DRAFT);
     assertThat(originalNameQuestion.getQuestionTags()).isEmpty();
 
@@ -504,5 +517,15 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     Result result = controller.update(requestBuilder.build(), question.id, "invalid_type");
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
+  }
+
+  private NameQuestionDefinition createNameQuestionDuplicate(Question question) {
+    QuestionDefinition def = question.getQuestionDefinition();
+    return new NameQuestionDefinition(
+        def.getName(),
+        Optional.empty(),
+        def.getDescription(),
+        def.getQuestionText(),
+        def.getQuestionHelpText());
   }
 }


### PR DESCRIPTION
### Description

It's possible for global admins to edit question in parallel: in one tab create a new version of an existing question and then, in the second tab, try to edit the original question. Currently if that happens the admin sees the original question data even though a new draft version exists. This PR handles this case and redirects admin to the draft version.

## Release notes:

Redirect to the draft version if exists when trying to edit a published question.

### Checklist

- [x] Created tests which fail without the change (if possible)

### Issue(s)

Fixes #2497