### PR TITLE
Disable applicant auth by default in tests

### DIFF
--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -17,3 +17,5 @@ azure.blob.container = "super cool blob container name"
 azure.blob.account = "my awesome azure account name"
 
 application_status_tracking_enabled = true
+
+auth.applicant_idp="disabled"

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -30,15 +30,15 @@ public class CfTestHelpers {
   }
 
   public static ImmutableMap<String, Object> oidcConfig(String host, int port) {
-    return ImmutableMap.of(
-        "idcs.client_id",
-        "foo",
-        "idcs.secret",
-        "bar",
-        "idcs.discovery_uri",
-        String.format("http://%s:%d/.well-known/openid-configuration", host, port),
-        "base_url",
-        String.format("http://localhost:%d", Helpers.testServerPort()));
+    return new ImmutableMap.Builder<String, String>()
+        .put("auth.applicant_idp", "idcs")
+        .put("idcs.client_id", "foo")
+        .put("idcs.secret", "bar")
+        .put(
+            "idcs.discovery_uri",
+            String.format("http://%s:%d/.well-known/openid-configuration", host, port))
+        .put("base_url", String.format("http://localhost:%d", Helpers.testServerPort()))
+        .build();
   }
 
   public static Provider<UserRepository> userRepositoryProvider(UserRepository userRepository) {

--- a/server/test/support/CfTestHelpers.java
+++ b/server/test/support/CfTestHelpers.java
@@ -30,7 +30,7 @@ public class CfTestHelpers {
   }
 
   public static ImmutableMap<String, Object> oidcConfig(String host, int port) {
-    return new ImmutableMap.Builder<String, String>()
+    return new ImmutableMap.Builder<String, Object>()
         .put("auth.applicant_idp", "idcs")
         .put("idcs.client_id", "foo")
         .put("idcs.secret", "bar")


### PR DESCRIPTION
### Description

It's hard to write tests when the applicant icsc client name & secret are always required.  This disables it by default.
