### PR TITLE
Add a flag to allow global admins to be program admins

### DIFF
--- a/server/app/annotations/FeatureFlags.java
+++ b/server/app/annotations/FeatureFlags.java
@@ -14,4 +14,9 @@ public class FeatureFlags {
   @Target({METHOD, PARAMETER})
   @Retention(RUNTIME)
   public @interface ApplicationStatusTrackingEnabled {}
+
+  @Qualifier
+  @Target({METHOD, PARAMETER})
+  @Retention(RUNTIME)
+  public @interface AllowGlobalAdminsBeProgramAdmins {}
 }

--- a/server/app/modules/FeatureFlagsModule.java
+++ b/server/app/modules/FeatureFlagsModule.java
@@ -2,6 +2,7 @@ package modules;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import annotations.FeatureFlags.AllowGlobalAdminsBeProgramAdmins;
 import annotations.FeatureFlags.ApplicationStatusTrackingEnabled;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -17,5 +18,11 @@ public class FeatureFlagsModule extends AbstractModule {
   @ApplicationStatusTrackingEnabled
   public boolean provideStatusTrackingEnabled(Config config) {
     return checkNotNull(config).getBoolean("application_status_tracking_enabled");
+  }
+
+  @Provides
+  @AllowGlobalAdminsBeProgramAdmins
+  public boolean provideAllowGlobalAdminsBeProgramAdmins(Config config) {
+    return checkNotNull(config).getBoolean("allow_global_admins_be_program_admins");
   }
 }

--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -62,7 +62,7 @@ public class RoleService {
     }
 
     ProgramDefinition program = programService.getProgramDefinition(programId);
-    ImmutableSet<String> sysAdminEmails =
+    ImmutableSet<String> globalAdminEmails =
         allowGlobalAdmins
             ? ImmutableSet.of()
             : getGlobalAdmins().stream()
@@ -73,7 +73,7 @@ public class RoleService {
     String errorMessageString = "";
 
     for (String email : accountEmails) {
-      if (sysAdminEmails.contains(email)) {
+      if (globalAdminEmails.contains(email)) {
         invalidEmailBuilder.add(email);
       } else {
         Optional<CiviFormError> maybeError = userRepository.addAdministeredProgram(email, program);

--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -2,6 +2,7 @@ package services.role;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+import annotations.FeatureFlags.AllowGlobalAdminsBeProgramAdmins;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -19,11 +20,16 @@ public class RoleService {
 
   private final ProgramService programService;
   private final UserRepository userRepository;
+  private final boolean allowGlobalAdmins;
 
   @Inject
-  public RoleService(ProgramService programRepository, UserRepository userRepository) {
+  public RoleService(
+      ProgramService programRepository,
+      UserRepository userRepository,
+      @AllowGlobalAdminsBeProgramAdmins boolean allowGlobalAdmins) {
     this.programService = programRepository;
     this.userRepository = userRepository;
+    this.allowGlobalAdmins = allowGlobalAdmins;
   }
 
   /**
@@ -40,7 +46,8 @@ public class RoleService {
    * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. If an account is currently a {@link
    * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since CiviForm admins cannot be
    * program admins. Instead, we return a {@link CiviFormError} listing the admin accounts that
-   * could not be promoted to program admins.
+   * could not be promoted to program admins. If {@link ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS} is
+   * set to True Global admins can be promoted to Program admins.
    *
    * @param programId the ID of the {@link models.Program} these accounts administer
    * @param accountEmails a {@link ImmutableSet} of account emails to make program admins
@@ -55,13 +62,13 @@ public class RoleService {
     }
 
     ProgramDefinition program = programService.getProgramDefinition(programId);
-    // Filter out CiviForm admins from the list of emails - a CiviForm admin cannot be a program
-    // admin.
     ImmutableSet<String> sysAdminEmails =
-        getGlobalAdmins().stream()
-            .map(Account::getEmailAddress)
-            .filter(address -> !Strings.isNullOrEmpty(address))
-            .collect(toImmutableSet());
+        allowGlobalAdmins
+            ? ImmutableSet.of()
+            : getGlobalAdmins().stream()
+                .map(Account::getEmailAddress)
+                .filter(address -> !Strings.isNullOrEmpty(address))
+                .collect(toImmutableSet());
     ImmutableSet.Builder<String> invalidEmailBuilder = ImmutableSet.builder();
     String errorMessageString = "";
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -584,6 +584,10 @@ api_applications_list_max_page_size = ${?CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE
 
 ## Feature flag toggles.
 # Launched features.
+
+# When set to true Global Admins can also be Program Admins.
+# It will enable Global Admin assign themselves as Program Admins, and get access to 
+# all Applications for that program.
 allow_global_admins_be_program_admins = false
 allow_global_admins_be_program_admins = ${?ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS}
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -584,6 +584,8 @@ api_applications_list_max_page_size = ${?CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE
 
 ## Feature flag toggles.
 # Launched features.
+allow_global_admins_be_program_admins = false
+allow_global_admins_be_program_admins = ${?ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS}
 
 # Preview features.
 

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -164,7 +164,10 @@ public class RoleServiceTest extends ResetPostgres {
     Program program = ProgramBuilder.newDraftProgram(programName).build();
 
     RoleService serviceWithGlobalAdminDisabled =
-        new RoleService(instanceOf(ProgramService.class), instanceOf(UserRepository.class), false);
+        new RoleService(
+            instanceOf(ProgramService.class),
+            instanceOf(UserRepository.class),
+            /* allowGlobalAdmins= */ false);
 
     assertThat(
             serviceWithGlobalAdminDisabled.makeProgramAdmins(
@@ -190,7 +193,10 @@ public class RoleServiceTest extends ResetPostgres {
     Program program = ProgramBuilder.newDraftProgram(programName).build();
 
     RoleService serviceWithGlobalAdminEnabled =
-        new RoleService(instanceOf(ProgramService.class), instanceOf(UserRepository.class), true);
+        new RoleService(
+            instanceOf(ProgramService.class),
+            instanceOf(UserRepository.class),
+            /* allowGlobalAdmins= */ true);
     assertThat(
             serviceWithGlobalAdminEnabled.makeProgramAdmins(
                 program.id, ImmutableSet.of(globalAdminEmail)))


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes:

New config value is introduced: ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS. When set to true it allows Civiform Global Admin to also be a Program Admin. 

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

### Issue(s)

Fixes #2916
