### PR TITLE
Import individual AWS SDK libraries.

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -31,7 +31,8 @@ lazy val root = (project in file("."))
       "com.j2html" % "j2html" % "1.5.0",
 
       // Amazon AWS SDK
-      "software.amazon.awssdk" % "aws-sdk-java" % "2.17.234",
+      "software.amazon.awssdk" % "s3" % "2.17.234",
+      "software.amazon.awssdk" % "ses" % "2.17.234",
 
       // Microsoft Azure SDK
       "com.azure" % "azure-identity" % "1.5.3",


### PR DESCRIPTION
### Description

Rather than including all AWS SDK libs use only the one that we need (s3 and simple email) It reduces AWS deps:
367MB => 8MB
336 libs => 27 libs

### Issue(s)

Fixes #2921
