### PR TITLE
Remove --ipc param when running browser tests.

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -6,7 +6,7 @@ source bin/lib.sh
 docker::set_project_name_browser_tests
 bin/pull-image
 
-docker run --ipc=host --rm -it \
+docker run --rm -it \
   -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
   -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
   -v "$(pwd)/browser-test/tmp:/usr/src/civiform-browser-tests/tmp" \


### PR DESCRIPTION
### Description

Having `--ipc=host` has issues for engineers using linux. Reading docs, ipc is related to memory sharing and shouldn't be needed for browser tests. Tried on macos and linux - tests work fine with the param removed.