### PR TITLE
Added reminder to add labels to the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Describe the change as it should be communicated to partners in the release note
 
 ### Checklist
 
+- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >
 - [ ] Created tests which fail without the change (if possible)
 - [ ] Extended the README / documentation, if necessary
 


### PR DESCRIPTION
### Description

When creating a PR, added a note to the template to remind people to add a label for use during releases.
