### PR TITLE
Use tsconfig.json for TS transformation when running browser tests

### DIFF
--- a/bin/run-browser-tests
+++ b/bin/run-browser-tests
@@ -7,9 +7,7 @@ docker::set_project_name_browser_tests
 bin/pull-image
 
 docker run --rm -it \
-  -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
-  -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
-  -v "$(pwd)/browser-test/tmp:/usr/src/civiform-browser-tests/tmp" \
+  -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform/civiform-browser-test:latest \

--- a/bin/run-browser-tests-ci
+++ b/bin/run-browser-tests-ci
@@ -8,9 +8,7 @@ source bin/lib.sh
 docker::set_project_name_browser_tests
 
 docker run \
-  -v "$(pwd)/browser-test/src:/usr/src/civiform-browser-tests/src" \
-  -v "$(pwd)/browser-test/bin:/usr/src/civiform-browser-tests/bin" \
-  -v "$(pwd)/browser-test/tmp:/usr/src/civiform-browser-tests/tmp" \
+  -v "$(pwd)/browser-test:/usr/src/civiform-browser-tests" \
   -e RECORD_VIDEO="${RECORD_VIDEO}" \
   --network "${DOCKER_NETWORK_NAME}" \
   civiform-browser-test:latest \

--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -25,6 +25,8 @@ for arg; do
   set -- "$@" "$arg"
 done
 
+yarn install
+
 if (($debug == 1)); then
   DEBUG="pw:api" BASE_URL="${SERVER_URL}" yarn test "$@"
 else

--- a/browser-test/jest.config.js
+++ b/browser-test/jest.config.js
@@ -5,4 +5,9 @@ module.exports = {
     '^.+\\.(ts)$': 'ts-jest',
   },
   globalSetup: './src/delete_database.ts',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'src/tsconfig.json',
+    },
+  },
 }

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -2,9 +2,6 @@ FROM mcr.microsoft.com/playwright:focal
 
 ENV PROJECT_DIR /usr/src/civiform-browser-tests
 
-COPY package.json ${PROJECT_DIR}/
-RUN cd ${PROJECT_DIR} && yarn install
-
 WORKDIR $PROJECT_DIR
 
 ENV TINI_VERSION v0.19.0

--- a/browser-test/src/tsconfig.json
+++ b/browser-test/src/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "strict": true,
+    // Fix errors and set to true.
+    // TODO(https://github.com/seattle-uat/civiform/issues/2955)
+    "strict": false,
     "module": "commonjs",
     "noEmit": true
   },


### PR DESCRIPTION
### Description

With this change browser tests will use configuration files (`package.json`, `jest.config.js`) from local directory rather than using the ones provided in the image. That makes sure that changes to configs immediately take effect. 

Additionally this change sets up `ts-jest` to use `tsconfig.json` provided in the tests. Until now `tsconfig.json` hasn't been used at all.

Related to #2955
