### PR TITLE
Use the JRE for the final prod image build

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -30,7 +30,7 @@ RUN cd "${PROJECT_LOC}" && \
 
 # This is a common trick to shrink container sizes. We discard everything added
 # during the build phase and use only the inflated artifacts created by sbt dist.
-FROM eclipse-temurin:11-jdk-alpine AS stage2
+FROM eclipse-temurin:11.0.15_10-jre-alpine AS stage2
 COPY --from=stage1 /civiform-server-0.0.1 /civiform-server-0.0.1
 
 # Upgrade packages for stage2 to include latest versions.


### PR DESCRIPTION
### Description

Switch to using the smaller JRE alpine image for the final prod docker image base.

## Release notes:
Use eclipse-temurin:11.0.15_10-jre-alpine for the production image

### Checklist

- [ ] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

