### PR TITLE
Revert "Add a flag to allow global admins to be program admins (#2928)" 

### DIFF
--- a/server/app/annotations/FeatureFlags.java
+++ b/server/app/annotations/FeatureFlags.java
@@ -14,9 +14,4 @@ public class FeatureFlags {
   @Target({METHOD, PARAMETER})
   @Retention(RUNTIME)
   public @interface ApplicationStatusTrackingEnabled {}
-
-  @Qualifier
-  @Target({METHOD, PARAMETER})
-  @Retention(RUNTIME)
-  public @interface AllowGlobalAdminsBeProgramAdmins {}
 }

--- a/server/app/modules/FeatureFlagsModule.java
+++ b/server/app/modules/FeatureFlagsModule.java
@@ -2,7 +2,6 @@ package modules;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import annotations.FeatureFlags.AllowGlobalAdminsBeProgramAdmins;
 import annotations.FeatureFlags.ApplicationStatusTrackingEnabled;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -18,11 +17,5 @@ public class FeatureFlagsModule extends AbstractModule {
   @ApplicationStatusTrackingEnabled
   public boolean provideStatusTrackingEnabled(Config config) {
     return checkNotNull(config).getBoolean("application_status_tracking_enabled");
-  }
-
-  @Provides
-  @AllowGlobalAdminsBeProgramAdmins
-  public boolean provideAllowGlobalAdminsBeProgramAdmins(Config config) {
-    return checkNotNull(config).getBoolean("allow_global_admins_be_program_admins");
   }
 }

--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -57,7 +57,7 @@ public class RoleService {
     ProgramDefinition program = programService.getProgramDefinition(programId);
     // Filter out CiviForm admins from the list of emails - a CiviForm admin cannot be a program
     // admin.
-    ImmutableSet<String> sysAdminEmails =
+    ImmutableSet<String> globalAdminEmails =
         getGlobalAdmins().stream()
             .map(Account::getEmailAddress)
             .filter(address -> !Strings.isNullOrEmpty(address))
@@ -66,7 +66,7 @@ public class RoleService {
     String errorMessageString = "";
 
     for (String email : accountEmails) {
-      if (sysAdminEmails.contains(email)) {
+      if (globalAdminEmails.contains(email)) {
         invalidEmailBuilder.add(email);
       } else {
         Optional<CiviFormError> maybeError = userRepository.addAdministeredProgram(email, program);

--- a/server/app/services/role/RoleService.java
+++ b/server/app/services/role/RoleService.java
@@ -2,7 +2,6 @@ package services.role;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
-import annotations.FeatureFlags.AllowGlobalAdminsBeProgramAdmins;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -20,16 +19,11 @@ public class RoleService {
 
   private final ProgramService programService;
   private final UserRepository userRepository;
-  private final boolean allowGlobalAdmins;
 
   @Inject
-  public RoleService(
-      ProgramService programRepository,
-      UserRepository userRepository,
-      @AllowGlobalAdminsBeProgramAdmins boolean allowGlobalAdmins) {
+  public RoleService(ProgramService programRepository, UserRepository userRepository) {
     this.programService = programRepository;
     this.userRepository = userRepository;
-    this.allowGlobalAdmins = allowGlobalAdmins;
   }
 
   /**
@@ -46,8 +40,7 @@ public class RoleService {
    * auth.Roles#ROLE_PROGRAM_ADMIN} for the given program. If an account is currently a {@link
    * auth.Roles#ROLE_CIVIFORM_ADMIN}, they will not be promoted, since CiviForm admins cannot be
    * program admins. Instead, we return a {@link CiviFormError} listing the admin accounts that
-   * could not be promoted to program admins. If {@link ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS} is
-   * set to True Global admins can be promoted to Program admins.
+   * could not be promoted to program admins.
    *
    * @param programId the ID of the {@link models.Program} these accounts administer
    * @param accountEmails a {@link ImmutableSet} of account emails to make program admins
@@ -62,18 +55,18 @@ public class RoleService {
     }
 
     ProgramDefinition program = programService.getProgramDefinition(programId);
-    ImmutableSet<String> globalAdminEmails =
-        allowGlobalAdmins
-            ? ImmutableSet.of()
-            : getGlobalAdmins().stream()
-                .map(Account::getEmailAddress)
-                .filter(address -> !Strings.isNullOrEmpty(address))
-                .collect(toImmutableSet());
+    // Filter out CiviForm admins from the list of emails - a CiviForm admin cannot be a program
+    // admin.
+    ImmutableSet<String> sysAdminEmails =
+        getGlobalAdmins().stream()
+            .map(Account::getEmailAddress)
+            .filter(address -> !Strings.isNullOrEmpty(address))
+            .collect(toImmutableSet());
     ImmutableSet.Builder<String> invalidEmailBuilder = ImmutableSet.builder();
     String errorMessageString = "";
 
     for (String email : accountEmails) {
-      if (globalAdminEmails.contains(email)) {
+      if (sysAdminEmails.contains(email)) {
         invalidEmailBuilder.add(email);
       } else {
         Optional<CiviFormError> maybeError = userRepository.addAdministeredProgram(email, program);

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -590,12 +590,6 @@ api_applications_list_max_page_size = ${?CIVIFORM_API_APPLICATIONS_LIST_MAX_PAGE
 ## Feature flag toggles.
 # Launched features.
 
-# When set to true Global Admins can also be Program Admins.
-# It will enable Global Admin assign themselves as Program Admins, and get access to 
-# all Applications for that program.
-allow_global_admins_be_program_admins = false
-allow_global_admins_be_program_admins = ${?ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS}
-
 # Preview features.
 
 # In development features.

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -14,7 +14,6 @@ import repository.UserRepository;
 import services.CiviFormError;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
-import services.program.ProgramService;
 import support.ProgramBuilder;
 
 public class RoleServiceTest extends ResetPostgres {
@@ -150,61 +149,6 @@ public class RoleServiceTest extends ResetPostgres {
                             + " Admin. %2$s does not have an admin account and cannot be added as"
                             + " a Program Admin. ",
                         email1, email2))));
-  }
-
-  @Test
-  public void makeProgramAdmins_blockGlobalAdmin() throws ProgramNotFoundException {
-    String globalAdminEmail = "global@admin";
-    Account globalAdmin = new Account();
-    globalAdmin.setEmailAddress(globalAdminEmail);
-    globalAdmin.setGlobalAdmin(true);
-    globalAdmin.save();
-
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
-
-    RoleService serviceWithGlobalAdminDisabled =
-        new RoleService(
-            instanceOf(ProgramService.class),
-            instanceOf(UserRepository.class),
-            /* allowGlobalAdmins= */ false);
-
-    assertThat(
-            serviceWithGlobalAdminDisabled.makeProgramAdmins(
-                program.id, ImmutableSet.of(globalAdminEmail)))
-        .isEqualTo(
-            Optional.of(
-                CiviFormError.of(
-                    String.format(
-                        "The following are already CiviForm admins and could not be added as"
-                            + " program admins: %s",
-                        globalAdminEmail))));
-  }
-
-  @Test
-  public void makeProgramAdmins_allowGlobalAdmin() throws ProgramNotFoundException {
-    String globalAdminEmail = "global@admin";
-    Account globalAdmin = new Account();
-    globalAdmin.setEmailAddress(globalAdminEmail);
-    globalAdmin.setGlobalAdmin(true);
-    globalAdmin.save();
-
-    String programName = "test program";
-    Program program = ProgramBuilder.newDraftProgram(programName).build();
-
-    RoleService serviceWithGlobalAdminEnabled =
-        new RoleService(
-            instanceOf(ProgramService.class),
-            instanceOf(UserRepository.class),
-            /* allowGlobalAdmins= */ true);
-    assertThat(
-            serviceWithGlobalAdminEnabled.makeProgramAdmins(
-                program.id, ImmutableSet.of(globalAdminEmail)))
-        .isEmpty();
-
-    globalAdmin = userRepository.lookupAccountByEmail(globalAdminEmail).get();
-
-    assertThat(globalAdmin.getAdministeredProgramNames()).containsOnly(programName);
   }
 
   @Test

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -199,8 +199,7 @@ public class RoleServiceTest extends ResetPostgres {
     String programName = "test program";
     Program program = ProgramBuilder.newDraftProgram(programName).build();
 
-    assertThat(
-            service.makeProgramAdmins(program.id, ImmutableSet.of(globalAdminEmail)))
+    assertThat(service.makeProgramAdmins(program.id, ImmutableSet.of(globalAdminEmail)))
         .isEqualTo(
             Optional.of(
                 CiviFormError.of(
@@ -208,5 +207,5 @@ public class RoleServiceTest extends ResetPostgres {
                         "The following are already CiviForm admins and could not be added as"
                             + " program admins: %s",
                         globalAdminEmail))));
-  }
+      }
 }

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -187,4 +187,26 @@ public class RoleServiceTest extends ResetPostgres {
     assertThatThrownBy(() -> service.removeProgramAdmins(1234L, ImmutableSet.of("test")))
         .isInstanceOf(ProgramNotFoundException.class);
   }
+
+  @Test
+  public void makeProgramAdmins_blockGlobalAdmin() throws ProgramNotFoundException {
+    String globalAdminEmail = "global@admin";
+    Account globalAdmin = new Account();
+    globalAdmin.setEmailAddress(globalAdminEmail);
+    globalAdmin.setGlobalAdmin(true);
+    globalAdmin.save();
+
+    String programName = "test program";
+    Program program = ProgramBuilder.newDraftProgram(programName).build();
+
+    assertThat(
+            service.makeProgramAdmins(program.id, ImmutableSet.of(globalAdminEmail)))
+        .isEqualTo(
+            Optional.of(
+                CiviFormError.of(
+                    String.format(
+                        "The following are already CiviForm admins and could not be added as"
+                            + " program admins: %s",
+                        globalAdminEmail))));
+  }
 }

--- a/server/test/services/role/RoleServiceTest.java
+++ b/server/test/services/role/RoleServiceTest.java
@@ -207,5 +207,5 @@ public class RoleServiceTest extends ResetPostgres {
                         "The following are already CiviForm admins and could not be added as"
                             + " program admins: %s",
                         globalAdminEmail))));
-      }
+  }
 }


### PR DESCRIPTION
I've kept the test that was missing to validate expected behavior.

## Release notes:

Removing config value: ALLOW_GLOBAL_ADMINS_BE_PROGRAM_ADMINS. After consideration, this is not a use case that we need to support.