### PR TITLE
Remove negative margin from site title

### DIFF
--- a/server/app/views/LoginForm.java
+++ b/server/app/views/LoginForm.java
@@ -106,7 +106,7 @@ public class LoginForm extends BaseHtmlView {
 
     content.with(
         div()
-            .withClasses(Styles.FLEX, Styles.TEXT_4XL, Styles.GAP_1, Styles._MT_6, Styles.PX_8)
+            .withClasses(Styles.FLEX, Styles.TEXT_4XL, Styles.GAP_1, Styles.PX_8)
             .with(p(civicEntityShortName).withClasses(Styles.FONT_BOLD))
             .with(p("CiviForm")));
 


### PR DESCRIPTION
### Description

Negative margin causes overlap of text with the logo if the logo doesn't have extra whitespace. Generally we shouldn't expect logos to have whitespace. 

Before:
![image](https://user-images.githubusercontent.com/252053/180863479-5594d886-6e73-4961-8bf7-c61f0a246833.png)

After:
![image](https://user-images.githubusercontent.com/252053/180863554-5b374240-58c5-4a15-b33a-54184fda9862.png)


## Release notes:

Fixes overlapping of title and logo on login form. 

### Checklist

- [x] Added the correct label: < feature | bug | dependencies | infrastructure | ignore-for-release >

